### PR TITLE
chore: move target url to okp4.space

### DIFF
--- a/.github/gh-home/index.html
+++ b/.github/gh-home/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <title>OKP4 ontology</title>
-      <meta http-equiv = "refresh" content = "1; url = https://ontology.okp4.network/versions/{{release_version}}/index-en.html" />
+      <meta http-equiv = "refresh" content = "1; url = https://ontology.okp4.space/versions/{{release_version}}/index-en.html" />
    </head>
    <body> </body>
 </html>

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,4 +44,4 @@ jobs:
           keep_files: true
           commit-message: |
             chore: release ontology github pages ${{ steps.get_version.outputs.version }}
-          cname: ontology.okp4.network
+          cname: ontology.okp4.space

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge)](https://conventionalcommits.org)
 ![W3C](https://img.shields.io/badge/W3C-1572B6?style=for-the-badge&logo=w3c&logoColor=white) [![cc-by-sa-4.0][cc-by-sa-image]][cc-by-sa]
 
-## The [OKP4](https://okp4.network) ontology
+## The [OKP4](https://okp4.space) ontology
 
 ### A formal model for the OKP4 blockchain
 
-This ontology describes and defines the different forms of vocabularies used in the [OKP4](https://okp4.network) protocol in a standard and well designed format. The aim is to model a semantic network of all the _entities_  (Data Spaces, data, services, processing workflows) by semantically characterizing what they are and the relationships they maintain between them. Thus, the ontology provides a complete living understanding and knowledge of the datasets within a Data Space, their transformation (by the services), as well as the governance rules that apply (data sharing, consents, policy rules).
+This ontology describes and defines the different forms of vocabularies used in the [OKP4](https://okp4.space) protocol in a standard and well designed format. The aim is to model a semantic network of all the _entities_  (Data Spaces, data, services, processing workflows) by semantically characterizing what they are and the relationships they maintain between them. Thus, the ontology provides a complete living understanding and knowledge of the datasets within a Data Space, their transformation (by the services), as well as the governance rules that apply (data sharing, consents, policy rules).
 
 ### Ontology at the heart of the blockchain
 
@@ -24,7 +24,7 @@ The knowledge representation language chosen for OKP4 is [RDF Schema](http://www
 
 ## Documentation
 
-Last released version of OKP4 ontology documentation is available here: <https://ontology.okp4.network>.
+Last released version of OKP4 ontology documentation is available here: <https://ontology.okp4.space>.
 
 ## Ontology construction process
 


### PR DESCRIPTION
# Move target url to okp4.space

- [x] I've read the last version of [CODE_OF_CONDUCT.md](https://github.com/okp4/.github/blob/main/CODE-OF-CONDUCT.md) and [CONTRIBUTING.md](https://github.com/okp4/.github/blob/main/CONTRIBUTING.md)

## Description

This PR to match the URL redirection  `ontology.okp4.space` as ontology is not a core part of the protocol.

---