### PR TITLE
ci(release): properly configure conventional commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,8 @@ jobs:
             @semantic-release/exec
             @semantic-release/git
             @google/semantic-release-replace-plugin
+          extends: |
+            conventional-changelog-conventionalcommits
         env:
           GITHUB_TOKEN: ${{ secrets.OKP4_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.OKP4_BOT_GIT_AUTHOR_NAME }}

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -5,6 +5,7 @@ repositoryUrl: "git@github.com:okp4/ontology.git"
 
 plugins:
   - - "@semantic-release/commit-analyzer"
+    - preset: conventionalcommits
     - releaseRules:
         - type: build
           release: patch
@@ -18,7 +19,8 @@ plugins:
           release: patch
         - type: chore
           release: patch
-  - "@semantic-release/release-notes-generator"
+  - - "@semantic-release/release-notes-generator"
+    - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
       changelogTitle: "# OKP4 Ontology Changelog"


### PR DESCRIPTION
Use the `conventionalcommits` preset of semantic release.