### PR TITLE
Feat/thesaurus service category

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,7 +54,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup ruby environment
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.6"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,6 +57,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "2.6"
+          bundler-cache: true
 
       - run: |
           gem install rdf-turtle

--- a/src/okp4.ttl
+++ b/src/okp4.ttl
@@ -3,6 +3,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
@@ -39,7 +40,7 @@ dcterms:description
 dcterms:title
   a owl:AnnotationProperty .
 
-# -- classes
+# -- core classes
 
 okp4core:Resource
   a owl:Class ;
@@ -108,7 +109,7 @@ okp4core:Dataset
   """@en .
 
 
-# -- properties
+# -- core properties
 
 okp4core:belongsTo
   a owl:ObjectProperty ;
@@ -129,3 +130,63 @@ okp4core:wasCreatedBy
 
   This information is stored initially and will never be changed thereafter.
   """@en .
+
+# -- thesaurus - service category
+<https://ontology.okp4.space/thesaurus/service-category>
+  a skos:ConceptScheme ;
+  dcterms:title "The OKP4 Service Category Thesaurus"@en ;
+  dcterms:description """
+  This thesaurus defines a controlled vocabulary expressing the different categories/classes of services, allowing them to be organised
+  and classified according to their nature or purpose.
+  """@en ;
+  rdfs:label "Service Category Thesaurus"@en .
+
+<https://ontology.okp4.space/thesaurus/service-category/ClassificationModel>
+  a skos:Concept ;
+  skos:prefLabel "Classification Model"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/ClusteringModel>
+  a skos:Concept ;
+  skos:prefLabel "Clustering Model"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/NaturalLanguageProcessing>
+  a skos:Concept ;
+  skos:prefLabel "Natural Language Processing"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/RegressionModel>
+  a skos:Concept ;
+  skos:prefLabel "Regression Model"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/DeepLearning>
+  a skos:Concept ;
+  skos:prefLabel "Deep Learning"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/DataTransformation>
+  a skos:Concept ;
+  skos:prefLabel "Data Transformation"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/DataCleaning>
+  a skos:Concept ;
+  skos:prefLabel "Data Cleaning"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/ComputerVision>
+  a skos:Concept ;
+  skos:prefLabel "Computer Vision"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/StatisticsAndAnalytics>
+  a skos:Concept ;
+  skos:prefLabel "Statistics & Analytics"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+<https://ontology.okp4.space/thesaurus/service-category/DataIntegration>
+  a skos:Concept ;
+  skos:prefLabel "Data Integration"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .

--- a/src/okp4.ttl
+++ b/src/okp4.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://ontology.okp4.space/core/> .
+@prefix okp4core: <https://ontology.okp4.space/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@@ -41,44 +41,44 @@ dcterms:title
 
 # -- classes
 
-:Resource
+okp4core:Resource
   a owl:Class ;
   owl:unionOf (
-    :Dataset
+    okp4core:Dataset
   ) ;
   rdfs:subClassOf [ 
     a owl:Restriction ;
-    owl:onProperty :belongsTo ;
-    owl:allValuesFrom :DataSpace 
+    owl:onProperty okp4core:belongsTo ;
+    owl:allValuesFrom okp4core:DataSpace 
   ] ;
   rdfs:label "Resource"@en ;
   rdfs:comment """
   `Resource` denotes members of a `Data Space`, including datasets, services...
   """@en .
 
-:Data
+okp4core:Data
   a owl:Class ;
   rdfs:label "Data" ;
   rdfs:comment """
   `Data` denotes a quantity of information (processed or stored). 
   """@en .
 
-:Metadata
+okp4core:Metadata
   a owl:Class ;
   rdfs:label "Metadata"@en ;
-  rdfs:subClassOf :Data ;
+  rdfs:subClassOf okp4core:Data ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:onProperty :describes ;
-    owl:allValuesFrom :Data 
+    owl:onProperty okp4core:describes ;
+    owl:allValuesFrom okp4core:Data 
   ] ;
   rdfs:comment """
   `Metadata` denotes the information data about `Data` (i.e. data about the data).
    """@en .
 
-:DataSpace
+okp4core:DataSpace
   a owl:Class ;
-  rdfs:subClassOf :Data ;
+  rdfs:subClassOf okp4core:Data ;
   rdfs:label "Data Space"@en ;
   rdfs:comment """
   `Data Space` is a founding concept of this ontology and is described as an abstraction that comprises:
@@ -91,9 +91,9 @@ dcterms:title
 A Data Space is highly customizable to allow its members to create a space of sharing designed exactly as they need.
   """@en .
 
-:Dataset
+okp4core:Dataset
   a owl:Class ;
-  rdfs:subClassOf :Data ;
+  rdfs:subClassOf okp4core:Data ;
   rdfs:label "Dataset"@en ;
   rdfs:comment """
   `Dataset` denotes the collection of related sets of information, encoded in a defined structure, as published by the data provider.
@@ -110,17 +110,17 @@ A Data Space is highly customizable to allow its members to create a space of sh
 
 # -- properties
 
-:belongsTo
+okp4core:belongsTo
   a owl:ObjectProperty ;
   rdfs:label "belongs to"@en ;
   rdfs:comment "Denotes the state of membership of an entity towards another."@en .
 
-:describes
+okp4core:describes
   a owl:FunctionalProperty, owl:ObjectProperty ;
   rdfs:label "describes"@en ;
   rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
 
-:wasCreatedBy
+okp4core:wasCreatedBy
   a owl:AnnotationProperty ;
   rdfs:label "was created by"@en ;
   rdfs:range xsd:uri ;


### PR DESCRIPTION
# Add the thesaurus "Service Category"

## Description

Add to the ontology the "Service Category" controlled vocabulary which specifies the different categories of `services` - as currently specified at OKP4.

- Classification Model
- Clustering Model
- Natural Language Processing (NLP)
- Regression Model
- Deep Learning
- Data Transformation
- Data Cleaning 
- Computer Vision
- Statistics & Analytics 
- Data Integration

## Additional Details

- The thesaurus is implemented using the [SKOS](https://www.w3.org/2009/08/skos-reference/skos.html) meta-model, as it is, IMHO, a simple, standard and powerful enough way to build thesauri, glossaries and even to some extent taxonomies. The same will apply to all future thesauri. 
- Obviously, the thesaurus can be amended and enriched as required.