### PR TITLE
Feat/thesaurus topic

### DIFF
--- a/src/okp4.ttl
+++ b/src/okp4.ttl
@@ -190,3 +190,63 @@ okp4core:wasCreatedBy
   a skos:Concept ;
   skos:prefLabel "Data Integration"@en ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> .
+
+# -- thesaurus - topic
+<https://ontology.okp4.space/thesaurus/topic>
+  a skos:ConceptScheme ;
+  dcterms:title "The OKP4 Topic Thesaurus"@en ;
+  dcterms:description """
+  This thesaurus defines a controlled vocabulary expressing the different common topics, allowing resources
+  to be organised and classified according to their nature or purpose.
+  """@en ;
+  rdfs:label "Topic Thesaurus"@en .
+
+<https://ontology.okp4.space/thesaurus/topic/AgricultureEnvironmentAndForestry>
+  a skos:Concept ;
+  skos:prefLabel "Agriculture, environment and forestry"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/BiologyGeologyAndChemistry>
+  a skos:Concept ;
+  skos:prefLabel "Biology, geology and chemistry"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/IndustryMobilityAndEngineering>
+  a skos:Concept ;
+  skos:prefLabel "Industry, mobility and engineering"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/LogisticsRetailSupplyChainECommerce>
+  a skos:Concept ;
+  skos:prefLabel "Logistics, retail, supply chain and eCommerce"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/DeFiAndCrypto>
+  a skos:Concept ;
+  skos:prefLabel "DeFi and Crypto"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/Healthcare>
+  a skos:Concept ;
+  skos:prefLabel "Healthcare"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/BusinessAndPurchase>
+  a skos:Concept ;
+  skos:prefLabel "Business and purchase"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/MarketingAndCustomerBehavior>
+  a skos:Concept ;
+  skos:prefLabel "Marketing and Customer Behavior"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/Energy>
+  a skos:Concept ;
+  skos:prefLabel "Energy"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .
+
+<https://ontology.okp4.space/thesaurus/topic/Other>
+  a skos:Concept ;
+  skos:prefLabel "Other"@en ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> .


### PR DESCRIPTION
# Add the thesaurus "Topic"

## Description

Add to the ontology the "Topic" controlled vocabulary which specify the different topics for the resources of the dataverse - as currently specified at OKP4.

- Agriculture, environment and forestry
- Biology, geology, and chemistry
- Industry, mobility, and engineering
- Logistics, retail, supply chain, and eCommerce
- DeFi and Crypto
- Healthcare
- Business and purchase
- Marketing and Customer Behavior
- Energy
- Other

## Additional Details

- The thesaurus is implemented using the [SKOS](https://www.w3.org/2009/08/skos-reference/skos.html) meta-model, as it is, IMHO, a simple, standard and powerful enough way to build thesauri, glossaries and even to some extent taxonomies. The same will apply to all future thesauri. 
- Obviously, the thesaurus can be amended and enriched as required.