### PR TITLE
ci(workflow): add notify-discord job

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -1,0 +1,22 @@
+name: notify-release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Notify Discord
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: ${{ secrets.OKP4_DISCORD_WEBHOOK }}
+          method: 'POST'
+          customHeaders: '{"Content-Type": "application/json"}'
+          data: |-
+            {
+              "avatar_url": "https://avatars.githubusercontent.com/u/98603954?v=4",
+              "username": "Bot Anik",
+              "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 Documentation: https://ontology.okp4.space"
+            }


### PR DESCRIPTION
# Add notification job to the OKP4 discord (on release)

- [x] I've read the last version of [CODE_OF_CONDUCT.md](https://github.com/okp4/.github/blob/main/CODE-OF-CONDUCT.md) and [CONTRIBUTING.md](https://github.com/okp4/.github/blob/main/CONTRIBUTING.md)

## Description

Self explanatory. Add a notification job on the [OKP4 discord serveur](https://discord.gg/okp4) when this project is released. 

---

## Additional Details (Optional)

Similar to what is already done on other projects ([okp4/ui](https://github.com/okp4/ui), [okp4/okp4d](https://github.com/okp4/okp4d)).
