### PR TITLE
Feat/metadata dataset description

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ clean: ## Clean all generated files
 
 ## Build:
 .PHONY: build
-build: $(ARTIFACT_TTL) ## Build the ontology
+build: $(CACHE)/owl-x86_64-linux-1.2.2 $(ARTIFACT_TTL) ## Build the ontology
 
 $(ARTIFACT_TTL): $(ARTIFACT_NT)
 	@echo "${COLOR_CYAN}📦 making${COLOR_RESET} the ontology ${COLOR_GREEN}$@${COLOR_RESET}"
@@ -57,9 +57,12 @@ $(ARTIFACT_NT): $(OBJ_FILES) | $(BIN)
 $(OBJ)/%.nt: $(SRC)/%.ttl | $(OBJ)
 	@echo "${COLOR_CYAN}🔁 converting${COLOR_RESET} ontology ${COLOR_GREEN}$<${COLOR_RESET} into ${COLOR_GREEN}$@${COLOR_RESET}"
 	@docker run --rm \
-  		-v `pwd`:/usr/src/ontology:rw \
-  		-w /usr/src/ontology \
-  		${DOCKER_IMAGE_RUBY_RDF} serialize -o $@ $<
+	  -v `pwd`:/usr/src/ontology:rw \
+	  -w /usr/src/ontology \
+	  ${DOCKER_IMAGE_UBUNTU} bash -c " \
+		${CACHE}/owl-x86_64-linux-1.2.2 write \
+		-o ntriple $< $@ \
+	  "
 
 $(BIN) $(OBJ) $(RES):
 	@mkdir -p -m 777 $@

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -90,6 +90,11 @@ okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "describes"@en ;
   rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
 
+okp4core:hasImage a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has image"@en ;
+  rdfs:comment "An image of the resource."@en ;
+  rdfs:range xsd:anyURI .
+
 okp4core:hasLicense a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has license"@en ;
   rdfs:comment "A legal document giving official permission to do something with the resource."@en ;

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -65,8 +65,8 @@ okp4core:Period a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:dateTime ;
-    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onDataRange xsd:dateTime ;
     owl:onProperty okp4core:hasEndDate ;
   ] .
 

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -76,6 +76,11 @@ okp4core:hasLicense a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has license"@en ;
   rdfs:comment "A legal document giving official permission to do something with the resource."@en ;
   rdfs:range okp4th:license .
+
+okp4core:hasSpatialCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has spatial coverage"@en ;
+  rdfs:comment "The spatial applicability of the resource."@en ;
+  rdfs:range okp4th:area .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -97,6 +97,13 @@ okp4core:hasCreator a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has publisher"@en ;
   rdfs:comment "An entity primarily responsible for making the resource."@en ;
   rdfs:range xsd:string .
+
+okp4core:hasDescription a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has description"@en ;
+  rdfs:comment """
+  A human-readable description of the resource.
+  """@en ;
+  rdfs:range xsd:string .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -81,6 +81,12 @@ okp4core:hasSpatialCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has spatial coverage"@en ;
   rdfs:comment "The spatial applicability of the resource."@en ;
   rdfs:range okp4th:area .
+
+okp4core:hasTemporalCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has temporal coverage"@en ;
+  rdfs:comment "The temporal applicability of the resource."@en ;
+  rdfs:range okp4core:Period .
+
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -61,13 +61,13 @@ okp4core:Period a owl:Class ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:allValuesFrom xsd:dateTime ;
-    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
-    owl:onProperty okp4core:hasEndDate ;
+    owl:onProperty okp4core:hasStartDate ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:allValuesFrom xsd:dateTime ;
-    owl:onProperty okp4core:hasStartDate ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onProperty okp4core:hasEndDate ;
   ] .
 
 okp4core:Resource a owl:Class ;
@@ -112,7 +112,6 @@ okp4core:hasTopic a owl:ObjectProperty, owl:FunctionalProperty ;
 
 okp4core:hasCreator a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has creator"@en ;
-  rdfs:label "has publisher"@en ;
   rdfs:comment "An entity primarily responsible for making the resource."@en ;
   rdfs:range xsd:string .
 
@@ -129,6 +128,11 @@ okp4core:hasEndDate a owl:DatatypeProperty, owl:FunctionalProperty ;
   The end date property represents the start date of an interval of time.
   """@en ;
   rdfs:range xsd:dateTime .
+
+okp4core:hasPublisher a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has publisher"@en ;
+  rdfs:comment "An entity primarily responsible for making the resource available."@en ;
+  rdfs:range xsd:string .
 
 okp4core:hasStartDate a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has start date"@en ;

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -91,6 +91,12 @@ okp4core:hasTopic a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has topic"@en ;
   rdfs:comment "A topic of the resource."@en ;
   rdfs:range okp4th:topic .
+
+okp4core:hasCreator a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has creator"@en ;
+  rdfs:label "has publisher"@en ;
+  rdfs:comment "An entity primarily responsible for making the resource."@en ;
+  rdfs:range xsd:string .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -143,6 +143,12 @@ okp4core:hasTag a owl:DatatypeProperty ;
   A keyword or term assigned to the resource.
   """@en ;
   rdfs:range xsd:string .
+
+okp4core:hasTitle a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has title"@en ;
+  rdfs:comment "A name given to the resource."@en ;
+  rdfs:range xsd:string .
+
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -4,6 +4,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix okp4core: <https://ontology.okp4.space/core/> .
+@prefix okp4th: <https://ontology.okp4.space/thesaurus/> .
 
 okp4core:Data a owl:Class ;
   rdfs:label "Data" ;
@@ -136,6 +137,12 @@ okp4core:hasStartDate a owl:DatatypeProperty, owl:FunctionalProperty ;
   """@en ;
   rdfs:range xsd:dateTime .
 
+okp4core:hasTag a owl:DatatypeProperty ;
+  rdfs:label "has tag"@en ;
+  rdfs:comment """
+  A keyword or term assigned to the resource.
+  """@en ;
+  rdfs:range xsd:string .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -1,0 +1,88 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix okp4core: <https://ontology.okp4.space/core/> .
+
+okp4core:Data a owl:Class ;
+  rdfs:label "Data" ;
+  rdfs:comment """
+  `Data` denotes a quantity of information (processed or stored). 
+  """@en .
+
+okp4core:DataSpace a owl:Class ;
+  rdfs:label "Data Space"@en ;
+  rdfs:comment """
+  `Data Space` is a founding concept of this ontology and is described as an abstraction that comprises:
+  
+  - Bundle of rights & rules that regulates interactions between data, algorithms, infrastructure and every resources shared by participants.
+  - Governance mechanisms to adapt these rules.
+
+  ![Data spaces](images/dataspace.png)
+
+A Data Space is highly customizable to allow its members to create a space of sharing designed exactly as they need.
+  """@en ;
+  rdfs:subClassOf okp4core:Data .
+
+okp4core:Dataset a owl:Class ;
+  rdfs:label "Dataset"@en ;
+  rdfs:comment """
+  `Dataset` denotes the collection of related sets of information, encoded in a defined structure, as published by the data provider.
+  This includes a wide variety of formats, for example: csv files, images, videos, databases, etc.
+
+  Datasets are accessible on the network by a [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) which defines the means
+  (the protocol, e.g. [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)) of access to the resource.
+
+  Datasets are described by a set of descriptions (aka metadata) providing information about one or more aspects of the dataset, like the
+  time and date of creation, the file size or the data quality, using specific data description vocabularies and thesaurus (e.g. `Exif`, `EBUCore`, ISO 19115),
+  allowing a great extensibility.
+  """@en ;
+  rdfs:subClassOf okp4core:Data .
+
+okp4core:Metadata a owl:Class ;
+  rdfs:label "Metadata"@en ;
+  rdfs:comment """
+  `Metadata` denotes the information data about `Data` (i.e. data about the data).
+   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:Data ;
+    owl:onProperty okp4core:describes ;
+  ] ;
+  rdfs:subClassOf okp4core:Data .
+
+okp4core:Resource a owl:Class ;
+  rdfs:label "Resource"@en ;
+  rdfs:comment """
+  `Resource` denotes members of a `Data Space`, including datasets, services...
+  """@en ;
+  owl:unionOf ( okp4core:Dataset ) ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:DataSpace ;
+    owl:onProperty okp4core:belongsTo ;
+  ] .
+
+okp4core:belongsTo a owl:ObjectProperty ;
+  rdfs:label "belongs to"@en ;
+  rdfs:comment "Denotes the state of membership of an entity towards another."@en .
+
+okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "describes"@en ;
+  rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
+
+dcterms:description a owl:AnnotationProperty .
+
+dcterms:title a owl:AnnotationProperty .
+
+okp4core:wasCreatedBy a owl:AnnotationProperty ;
+  rdfs:label "was created by"@en ;
+  rdfs:comment """
+  Information about who created the resource.
+
+  This information is stored initially and will never be changed thereafter.
+  """@en ;
+  rdfs:range xsd:uri .
+
+

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -45,6 +45,11 @@ okp4core:Dataset a owl:Class ;
   time and date of creation, the file size or the data quality, using specific data description vocabularies and thesaurus (e.g. `Exif`, `EBUCore`, ISO 19115),
   allowing a great extensibility.
   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
+  ] ;
   rdfs:subClassOf okp4core:Data .
 
 okp4core:Metadata a owl:Class ;

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -72,6 +72,10 @@ okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "describes"@en ;
   rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
 
+okp4core:hasLicense a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has license"@en ;
+  rdfs:comment "A legal document giving official permission to do something with the resource."@en ;
+  rdfs:range okp4th:license .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -52,6 +52,23 @@ okp4core:Metadata a owl:Class ;
   ] ;
   rdfs:subClassOf okp4core:Data .
 
+okp4core:Period a owl:Class ;
+  rdfs:label "Period"@en ;
+  rdfs:comment """
+  The Period class represents an interval of time, defined by a start and end time and date.
+  """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:dateTime ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onProperty okp4core:hasEndDate ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:dateTime ;
+    owl:onProperty okp4core:hasStartDate ;
+  ] .
+
 okp4core:Resource a owl:Class ;
   rdfs:label "Resource"@en ;
   rdfs:comment """
@@ -104,6 +121,21 @@ okp4core:hasDescription a owl:DatatypeProperty, owl:FunctionalProperty ;
   A human-readable description of the resource.
   """@en ;
   rdfs:range xsd:string .
+
+okp4core:hasEndDate a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has end date"@en ;
+  rdfs:comment """
+  The end date property represents the start date of an interval of time.
+  """@en ;
+  rdfs:range xsd:dateTime .
+
+okp4core:hasStartDate a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has start date"@en ;
+  rdfs:comment """
+  The start date property represents the start date of an interval of time.
+  """@en ;
+  rdfs:range xsd:dateTime .
+
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -6,6 +6,12 @@
 @prefix okp4core: <https://ontology.okp4.space/core/> .
 @prefix okp4th: <https://ontology.okp4.space/thesaurus/> .
 
+okp4core:DIDURI a owl:Class ;
+  rdfs:label "Decentralized Identifier URI"@en ;
+  rdfs:comment "A decentralized identifier URI is a URI that identifies a subject in a decentralized system and is managed independently of any centralized registry."@en ;
+  rdfs:seeAlso <https://www.w3.org/TR/did-core/> ;
+  rdfs:subClassOf xsd:anyURI .
+
 okp4core:Data a owl:Class ;
   rdfs:label "Data" ;
   rdfs:comment """
@@ -138,6 +144,11 @@ okp4core:hasPublisher a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has publisher"@en ;
   rdfs:comment "An entity primarily responsible for making the resource available."@en ;
   rdfs:range xsd:string .
+
+okp4core:hasRegistrar a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has registrar"@en ;
+  rdfs:comment "References the individual, company, or organization that is responsible for registering and managing a resource."@en ;
+  rdfs:range okp4core:DIDURI .
 
 okp4core:hasStartDate a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has start date"@en ;

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -87,6 +87,10 @@ okp4core:hasTemporalCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:comment "The temporal applicability of the resource."@en ;
   rdfs:range okp4core:Period .
 
+okp4core:hasTopic a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has topic"@en ;
+  rdfs:comment "A topic of the resource."@en ;
+  rdfs:range okp4th:topic .
 dcterms:description a owl:AnnotationProperty .
 
 dcterms:title a owl:AnnotationProperty .

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -1,0 +1,70 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix core: <https://ontology.okp4.space/core/> .
+@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
+@prefix meta: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+
+meta:GeneralMetadata a owl:Class ;
+  rdfs:label "General Metadata"@en ;
+  rdfs:comment """
+  Generalmetadata is a metadata that describes the basic characteristics of a dataset. It typically includes information such as the title, description, and tags of the dataset, as well as its topic and temporal and spatial coverages.
+
+  The purpose of this metadata is to provide a broad overview of the dataset, making it easier for users to understand what the dataset is about and how it can be used. It is often used in conjunction with more detailed metadata, which provides more specific information about the dataset.
+   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom core:Period ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onProperty core:hasTemporalCoverage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTag ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom [
+      a owl:Restriction ;
+      owl:hasValue license:dataLicenses ;
+      owl:onProperty skos:member ;
+    ] ;
+    owl:onProperty core:hasLicense ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom thesaurus:area ;
+    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onProperty core:hasSpatialCoverage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasCreator ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom thesaurus:topic ;
+    owl:onProperty core:hasTopic ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasPublisher ;
+  ] ;
+  rdfs:subClassOf core:Metadata .
+
+

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -16,9 +16,39 @@ meta:GeneralMetadata a owl:Class ;
    """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:onClass core:Period ;
+    owl:allValuesFrom thesaurus:topic ;
+    owl:onProperty core:hasTopic ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasPublisher ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:uri ;
+    owl:onProperty core:hasImage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onClass core:Period ;
     owl:onProperty core:hasTemporalCoverage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasCreator ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -36,34 +66,9 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:onClass thesaurus:area ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onClass thesaurus:area ;
     owl:onProperty core:hasSpatialCoverage ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasCreator ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasDescription ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasTitle ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom thesaurus:topic ;
-    owl:onProperty core:hasTopic ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasPublisher ;
   ] ;
   rdfs:subClassOf core:Metadata .
 

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -16,8 +16,8 @@ meta:GeneralMetadata a owl:Class ;
    """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom core:Period ;
-    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onClass core:Period ;
+    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
     owl:onProperty core:hasTemporalCoverage ;
   ] ;
   rdfs:subClassOf [
@@ -36,8 +36,8 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:area ;
-    owl:minCardinality "0"^^xsd:nonNegativeInteger ;
+    owl:onClass thesaurus:area ;
+    owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
     owl:onProperty core:hasSpatialCoverage ;
   ] ;
   rdfs:subClassOf [

--- a/src/ontology.ttl
+++ b/src/ontology.ttl
@@ -7,7 +7,7 @@
 @prefix vann: <http://purl.org/vocab/vann/> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 
-<https://ontology.okp4.space/core> a owl:Ontology ;
+<https://ontology.okp4.space> a owl:Ontology ;
   rdfs:label "OKP4 Ontology"@en ;
   dcterms:description """
   A vocabulary to describe knowledge graphs within data spaces.
@@ -30,85 +30,5 @@
   vann:preferredNamespacePrefix "okp4" ;
   vann:preferredNamespaceUri "https://ontology.okp4.space/core" ;
   vs:term_status "unstable"@en .
-
-okp4core:Data a owl:Class ;
-  rdfs:label "Data" ;
-  rdfs:comment """
-  `Data` denotes a quantity of information (processed or stored). 
-  """@en .
-
-okp4core:DataSpace a owl:Class ;
-  rdfs:label "Data Space"@en ;
-  rdfs:comment """
-  `Data Space` is a founding concept of this ontology and is described as an abstraction that comprises:
-  
-  - Bundle of rights & rules that regulates interactions between data, algorithms, infrastructure and every resources shared by participants.
-  - Governance mechanisms to adapt these rules.
-
-  ![Data spaces](images/dataspace.png)
-
-A Data Space is highly customizable to allow its members to create a space of sharing designed exactly as they need.
-  """@en ;
-  rdfs:subClassOf okp4core:Data .
-
-okp4core:Dataset a owl:Class ;
-  rdfs:label "Dataset"@en ;
-  rdfs:comment """
-  `Dataset` denotes the collection of related sets of information, encoded in a defined structure, as published by the data provider.
-  This includes a wide variety of formats, for example: csv files, images, videos, databases, etc.
-
-  Datasets are accessible on the network by a [URI](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) which defines the means
-  (the protocol, e.g. [HTTP](https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol)) of access to the resource.
-
-  Datasets are described by a set of descriptions (aka metadata) providing information about one or more aspects of the dataset, like the
-  time and date of creation, the file size or the data quality, using specific data description vocabularies and thesaurus (e.g. `Exif`, `EBUCore`, ISO 19115),
-  allowing a great extensibility.
-  """@en ;
-  rdfs:subClassOf okp4core:Data .
-
-okp4core:Metadata a owl:Class ;
-  rdfs:label "Metadata"@en ;
-  rdfs:comment """
-  `Metadata` denotes the information data about `Data` (i.e. data about the data).
-   """@en ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom okp4core:Data ;
-    owl:onProperty okp4core:describes ;
-  ] ;
-  rdfs:subClassOf okp4core:Data .
-
-okp4core:Resource a owl:Class ;
-  rdfs:label "Resource"@en ;
-  rdfs:comment """
-  `Resource` denotes members of a `Data Space`, including datasets, services...
-  """@en ;
-  owl:unionOf ( okp4core:Dataset ) ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom okp4core:DataSpace ;
-    owl:onProperty okp4core:belongsTo ;
-  ] .
-
-okp4core:belongsTo a owl:ObjectProperty ;
-  rdfs:label "belongs to"@en ;
-  rdfs:comment "Denotes the state of membership of an entity towards another."@en .
-
-okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
-  rdfs:label "describes"@en ;
-  rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
-
-dcterms:description a owl:AnnotationProperty .
-
-dcterms:title a owl:AnnotationProperty .
-
-okp4core:wasCreatedBy a owl:AnnotationProperty ;
-  rdfs:label "was created by"@en ;
-  rdfs:comment """
-  Information about who created the resource.
-
-  This information is stored initially and will never be changed thereafter.
-  """@en ;
-  rdfs:range xsd:uri .
 
 

--- a/src/vocab-area.ttl
+++ b/src/vocab-area.ttl
@@ -6,17 +6,17 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 area:hasAlpha2Code a owl:DatatypeProperty, owl:FunctionalProperty ;
-  rdfs:label "Has ISO 3166-1-alpha-2 code"@en ;
+  rdfs:label "has ISO 3166-1-alpha-2 code"@en ;
   rdfs:comment "Represents the ISO 3166-1 two-letter country codes that uniquely identifies a country."@en ;
   rdfs:range xsd:string .
 
 area:hasAlpha3Code a owl:DatatypeProperty, owl:FunctionalProperty ;
-  rdfs:label "Has ISO 3166-1-alpha-3 code"@en ;
+  rdfs:label "has ISO 3166-1-alpha-3 code"@en ;
   rdfs:comment "Represents the ISO 3166-1 three-letter country codes that uniquely identifies a country."@en ;
   rdfs:range xsd:string .
 
 area:hasAreaCode a owl:DatatypeProperty, owl:FunctionalProperty ;
-  rdfs:label "Has M.49 area code"@en ;
+  rdfs:label "has M.49 area code"@en ;
   rdfs:comment "Represents the M.49 area code that uniquely identifies an area."@en ;
   rdfs:range xsd:integer .
 

--- a/src/vocab-area.ttl
+++ b/src/vocab-area.ttl
@@ -1,0 +1,2475 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+area:hasAlpha2Code a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "Has ISO 3166-1-alpha-2 code"@en ;
+  rdfs:comment "Represents the ISO 3166-1 two-letter country codes that uniquely identifies a country."@en ;
+  rdfs:range xsd:string .
+
+area:hasAlpha3Code a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "Has ISO 3166-1-alpha-3 code"@en ;
+  rdfs:comment "Represents the ISO 3166-1 three-letter country codes that uniquely identifies a country."@en ;
+  rdfs:range xsd:string .
+
+area:hasAreaCode a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "Has M.49 area code"@en ;
+  rdfs:comment "Represents the M.49 area code that uniquely identifies an area."@en ;
+  rdfs:range xsd:integer .
+
+area:001 a skos:Concept ;
+  area:hasAreaCode 1 ;
+  skos:narrower area:002 ;
+  skos:narrower area:009 ;
+  skos:narrower area:010 ;
+  skos:narrower area:019 ;
+  skos:narrower area:142 ;
+  skos:narrower area:150 ;
+  skos:prefLabel "World"@en ;
+  skos:topConceptOf <https://ontology.okp4.space/thesaurus/area> .
+
+area:002 a skos:Concept ;
+  area:hasAreaCode 2 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:015 ;
+  skos:narrower area:202 ;
+  skos:prefLabel "Africa"@en .
+
+area:004 a skos:Concept ;
+  area:hasAlpha2Code "AF" ;
+  area:hasAlpha3Code "AFG" ;
+  area:hasAreaCode 4 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Afghanistan"@en .
+
+area:005 a skos:Concept ;
+  area:hasAreaCode 5 ;
+  skos:broader area:419 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:032 ;
+  skos:narrower area:068 ;
+  skos:narrower area:074 ;
+  skos:narrower area:076 ;
+  skos:narrower area:152 ;
+  skos:narrower area:170 ;
+  skos:narrower area:218 ;
+  skos:narrower area:238 ;
+  skos:narrower area:239 ;
+  skos:narrower area:254 ;
+  skos:narrower area:328 ;
+  skos:narrower area:600 ;
+  skos:narrower area:604 ;
+  skos:narrower area:740 ;
+  skos:narrower area:858 ;
+  skos:narrower area:862 ;
+  skos:prefLabel "South America"@en .
+
+area:008 a skos:Concept ;
+  area:hasAlpha2Code "AL" ;
+  area:hasAlpha3Code "ALB" ;
+  area:hasAreaCode 8 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Albania"@en .
+
+area:009 a skos:Concept ;
+  area:hasAreaCode 9 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:053 ;
+  skos:narrower area:054 ;
+  skos:narrower area:057 ;
+  skos:narrower area:061 ;
+  skos:prefLabel "Oceania"@en .
+
+area:010 a skos:Concept ;
+  area:hasAlpha2Code "AQ" ;
+  area:hasAlpha3Code "ATA" ;
+  area:hasAreaCode 10 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Antarctica"@en .
+
+area:011 a skos:Concept ;
+  area:hasAreaCode 11 ;
+  skos:broader area:202 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:132 ;
+  skos:narrower area:204 ;
+  skos:narrower area:270 ;
+  skos:narrower area:288 ;
+  skos:narrower area:324 ;
+  skos:narrower area:384 ;
+  skos:narrower area:430 ;
+  skos:narrower area:466 ;
+  skos:narrower area:478 ;
+  skos:narrower area:562 ;
+  skos:narrower area:566 ;
+  skos:narrower area:624 ;
+  skos:narrower area:654 ;
+  skos:narrower area:686 ;
+  skos:narrower area:694 ;
+  skos:narrower area:768 ;
+  skos:narrower area:854 ;
+  skos:prefLabel "Western Africa"@en .
+
+area:012 a skos:Concept ;
+  area:hasAlpha2Code "DZ" ;
+  area:hasAlpha3Code "DZA" ;
+  area:hasAreaCode 12 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Algeria"@en .
+
+area:013 a skos:Concept ;
+  area:hasAreaCode 13 ;
+  skos:broader area:419 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:084 ;
+  skos:narrower area:188 ;
+  skos:narrower area:222 ;
+  skos:narrower area:320 ;
+  skos:narrower area:340 ;
+  skos:narrower area:484 ;
+  skos:narrower area:558 ;
+  skos:narrower area:591 ;
+  skos:prefLabel "Central America"@en .
+
+area:014 a skos:Concept ;
+  area:hasAreaCode 14 ;
+  skos:broader area:202 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:086 ;
+  skos:narrower area:108 ;
+  skos:narrower area:174 ;
+  skos:narrower area:175 ;
+  skos:narrower area:231 ;
+  skos:narrower area:232 ;
+  skos:narrower area:260 ;
+  skos:narrower area:262 ;
+  skos:narrower area:404 ;
+  skos:narrower area:450 ;
+  skos:narrower area:454 ;
+  skos:narrower area:480 ;
+  skos:narrower area:508 ;
+  skos:narrower area:638 ;
+  skos:narrower area:646 ;
+  skos:narrower area:690 ;
+  skos:narrower area:706 ;
+  skos:narrower area:716 ;
+  skos:narrower area:728 ;
+  skos:narrower area:800 ;
+  skos:narrower area:834 ;
+  skos:narrower area:894 ;
+  skos:prefLabel "Eastern Africa"@en .
+
+area:015 a skos:Concept ;
+  area:hasAreaCode 15 ;
+  skos:broader area:002 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:012 ;
+  skos:narrower area:434 ;
+  skos:narrower area:504 ;
+  skos:narrower area:729 ;
+  skos:narrower area:732 ;
+  skos:narrower area:788 ;
+  skos:narrower area:818 ;
+  skos:prefLabel "Northern Africa"@en .
+
+area:016 a skos:Concept ;
+  area:hasAlpha2Code "AS" ;
+  area:hasAlpha3Code "ASM" ;
+  area:hasAreaCode 16 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "American Samoa"@en .
+
+area:017 a skos:Concept ;
+  area:hasAreaCode 17 ;
+  skos:broader area:202 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:024 ;
+  skos:narrower area:120 ;
+  skos:narrower area:140 ;
+  skos:narrower area:148 ;
+  skos:narrower area:178 ;
+  skos:narrower area:180 ;
+  skos:narrower area:226 ;
+  skos:narrower area:266 ;
+  skos:narrower area:678 ;
+  skos:prefLabel "Middle Africa"@en .
+
+area:018 a skos:Concept ;
+  area:hasAreaCode 18 ;
+  skos:broader area:202 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:072 ;
+  skos:narrower area:426 ;
+  skos:narrower area:516 ;
+  skos:narrower area:710 ;
+  skos:narrower area:748 ;
+  skos:prefLabel "Southern Africa"@en .
+
+area:019 a skos:Concept ;
+  area:hasAreaCode 19 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:021 ;
+  skos:narrower area:419 ;
+  skos:prefLabel "Americas"@en .
+
+area:020 a skos:Concept ;
+  area:hasAlpha2Code "AD" ;
+  area:hasAlpha3Code "AND" ;
+  area:hasAreaCode 20 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Andorra"@en .
+
+area:021 a skos:Concept ;
+  area:hasAreaCode 21 ;
+  skos:broader area:019 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:060 ;
+  skos:narrower area:124 ;
+  skos:narrower area:304 ;
+  skos:narrower area:666 ;
+  skos:narrower area:840 ;
+  skos:prefLabel "Northern America"@en .
+
+area:024 a skos:Concept ;
+  area:hasAlpha2Code "AO" ;
+  area:hasAlpha3Code "AGO" ;
+  area:hasAreaCode 24 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Angola"@en .
+
+area:028 a skos:Concept ;
+  area:hasAlpha2Code "AG" ;
+  area:hasAlpha3Code "ATG" ;
+  area:hasAreaCode 28 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Antigua and Barbuda"@en .
+
+area:029 a skos:Concept ;
+  area:hasAreaCode 29 ;
+  skos:broader area:419 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:028 ;
+  skos:narrower area:044 ;
+  skos:narrower area:052 ;
+  skos:narrower area:092 ;
+  skos:narrower area:136 ;
+  skos:narrower area:192 ;
+  skos:narrower area:212 ;
+  skos:narrower area:214 ;
+  skos:narrower area:308 ;
+  skos:narrower area:312 ;
+  skos:narrower area:332 ;
+  skos:narrower area:388 ;
+  skos:narrower area:474 ;
+  skos:narrower area:500 ;
+  skos:narrower area:531 ;
+  skos:narrower area:533 ;
+  skos:narrower area:534 ;
+  skos:narrower area:535 ;
+  skos:narrower area:630 ;
+  skos:narrower area:652 ;
+  skos:narrower area:659 ;
+  skos:narrower area:660 ;
+  skos:narrower area:662 ;
+  skos:narrower area:663 ;
+  skos:narrower area:670 ;
+  skos:narrower area:780 ;
+  skos:narrower area:796 ;
+  skos:narrower area:850 ;
+  skos:prefLabel "Caribbean"@en .
+
+area:030 a skos:Concept ;
+  area:hasAreaCode 30 ;
+  skos:broader area:142 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:156 ;
+  skos:narrower area:344 ;
+  skos:narrower area:392 ;
+  skos:narrower area:408 ;
+  skos:narrower area:410 ;
+  skos:narrower area:446 ;
+  skos:narrower area:496 ;
+  skos:prefLabel "Eastern Asia"@en .
+
+area:031 a skos:Concept ;
+  area:hasAlpha2Code "AZ" ;
+  area:hasAlpha3Code "AZE" ;
+  area:hasAreaCode 31 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Azerbaijan"@en .
+
+area:032 a skos:Concept ;
+  area:hasAlpha2Code "AR" ;
+  area:hasAlpha3Code "ARG" ;
+  area:hasAreaCode 32 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Argentina"@en .
+
+area:034 a skos:Concept ;
+  area:hasAreaCode 34 ;
+  skos:broader area:142 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:004 ;
+  skos:narrower area:050 ;
+  skos:narrower area:064 ;
+  skos:narrower area:144 ;
+  skos:narrower area:356 ;
+  skos:narrower area:364 ;
+  skos:narrower area:462 ;
+  skos:narrower area:524 ;
+  skos:narrower area:586 ;
+  skos:prefLabel "Southern Asia"@en .
+
+area:035 a skos:Concept ;
+  area:hasAreaCode 35 ;
+  skos:broader area:142 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:096 ;
+  skos:narrower area:104 ;
+  skos:narrower area:116 ;
+  skos:narrower area:360 ;
+  skos:narrower area:418 ;
+  skos:narrower area:458 ;
+  skos:narrower area:608 ;
+  skos:narrower area:626 ;
+  skos:narrower area:702 ;
+  skos:narrower area:704 ;
+  skos:narrower area:764 ;
+  skos:prefLabel "South-eastern Asia"@en .
+
+area:036 a skos:Concept ;
+  area:hasAlpha2Code "AU" ;
+  area:hasAlpha3Code "AUS" ;
+  area:hasAreaCode 36 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Australia"@en .
+
+area:039 a skos:Concept ;
+  area:hasAreaCode 39 ;
+  skos:broader area:150 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:008 ;
+  skos:narrower area:020 ;
+  skos:narrower area:070 ;
+  skos:narrower area:191 ;
+  skos:narrower area:292 ;
+  skos:narrower area:300 ;
+  skos:narrower area:336 ;
+  skos:narrower area:380 ;
+  skos:narrower area:470 ;
+  skos:narrower area:499 ;
+  skos:narrower area:620 ;
+  skos:narrower area:674 ;
+  skos:narrower area:688 ;
+  skos:narrower area:705 ;
+  skos:narrower area:724 ;
+  skos:narrower area:807 ;
+  skos:prefLabel "Southern Europe"@en .
+
+area:040 a skos:Concept ;
+  area:hasAlpha2Code "AT" ;
+  area:hasAlpha3Code "AUT" ;
+  area:hasAreaCode 40 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Austria"@en .
+
+area:044 a skos:Concept ;
+  area:hasAlpha2Code "BS" ;
+  area:hasAlpha3Code "BHS" ;
+  area:hasAreaCode 44 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bahamas"@en .
+
+area:048 a skos:Concept ;
+  area:hasAlpha2Code "BH" ;
+  area:hasAlpha3Code "BHR" ;
+  area:hasAreaCode 48 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bahrain"@en .
+
+area:050 a skos:Concept ;
+  area:hasAlpha2Code "BD" ;
+  area:hasAlpha3Code "BGD" ;
+  area:hasAreaCode 50 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bangladesh"@en .
+
+area:051 a skos:Concept ;
+  area:hasAlpha2Code "AM" ;
+  area:hasAlpha3Code "ARM" ;
+  area:hasAreaCode 51 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Armenia"@en .
+
+area:052 a skos:Concept ;
+  area:hasAlpha2Code "BB" ;
+  area:hasAlpha3Code "BRB" ;
+  area:hasAreaCode 52 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Barbados"@en .
+
+area:053 a skos:Concept ;
+  area:hasAreaCode 53 ;
+  skos:broader area:009 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:036 ;
+  skos:narrower area:162 ;
+  skos:narrower area:166 ;
+  skos:narrower area:334 ;
+  skos:narrower area:554 ;
+  skos:narrower area:574 ;
+  skos:prefLabel "Australia and New Zealand"@en .
+
+area:054 a skos:Concept ;
+  area:hasAreaCode 54 ;
+  skos:broader area:009 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:090 ;
+  skos:narrower area:242 ;
+  skos:narrower area:540 ;
+  skos:narrower area:548 ;
+  skos:narrower area:598 ;
+  skos:prefLabel "Melanesia"@en .
+
+area:056 a skos:Concept ;
+  area:hasAlpha2Code "BE" ;
+  area:hasAlpha3Code "BEL" ;
+  area:hasAreaCode 56 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Belgium"@en .
+
+area:057 a skos:Concept ;
+  area:hasAreaCode 57 ;
+  skos:broader area:009 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:296 ;
+  skos:narrower area:316 ;
+  skos:narrower area:520 ;
+  skos:narrower area:580 ;
+  skos:narrower area:581 ;
+  skos:narrower area:583 ;
+  skos:narrower area:584 ;
+  skos:narrower area:585 ;
+  skos:prefLabel "Micronesia"@en .
+
+area:060 a skos:Concept ;
+  area:hasAlpha2Code "BM" ;
+  area:hasAlpha3Code "BMU" ;
+  area:hasAreaCode 60 ;
+  skos:broader area:021 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bermuda"@en .
+
+area:061 a skos:Concept ;
+  area:hasAreaCode 61 ;
+  skos:broader area:009 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:016 ;
+  skos:narrower area:184 ;
+  skos:narrower area:258 ;
+  skos:narrower area:570 ;
+  skos:narrower area:612 ;
+  skos:narrower area:772 ;
+  skos:narrower area:776 ;
+  skos:narrower area:798 ;
+  skos:narrower area:876 ;
+  skos:narrower area:882 ;
+  skos:prefLabel "Polynesia"@en .
+
+area:064 a skos:Concept ;
+  area:hasAlpha2Code "BT" ;
+  area:hasAlpha3Code "BTN" ;
+  area:hasAreaCode 64 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bhutan"@en .
+
+area:068 a skos:Concept ;
+  area:hasAlpha2Code "BO" ;
+  area:hasAlpha3Code "BOL" ;
+  area:hasAreaCode 68 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bolivia (Plurinational State of)"@en .
+
+area:070 a skos:Concept ;
+  area:hasAlpha2Code "BA" ;
+  area:hasAlpha3Code "BIH" ;
+  area:hasAreaCode 70 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bosnia and Herzegovina"@en .
+
+area:072 a skos:Concept ;
+  area:hasAlpha2Code "BW" ;
+  area:hasAlpha3Code "BWA" ;
+  area:hasAreaCode 72 ;
+  skos:broader area:018 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Botswana"@en .
+
+area:074 a skos:Concept ;
+  area:hasAlpha2Code "BV" ;
+  area:hasAlpha3Code "BVT" ;
+  area:hasAreaCode 74 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bouvet Island"@en .
+
+area:076 a skos:Concept ;
+  area:hasAlpha2Code "BR" ;
+  area:hasAlpha3Code "BRA" ;
+  area:hasAreaCode 76 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Brazil"@en .
+
+area:084 a skos:Concept ;
+  area:hasAlpha2Code "BZ" ;
+  area:hasAlpha3Code "BLZ" ;
+  area:hasAreaCode 84 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Belize"@en .
+
+area:086 a skos:Concept ;
+  area:hasAlpha2Code "IO" ;
+  area:hasAlpha3Code "IOT" ;
+  area:hasAreaCode 86 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "British Indian Ocean Territory"@en .
+
+area:090 a skos:Concept ;
+  area:hasAlpha2Code "SB" ;
+  area:hasAlpha3Code "SLB" ;
+  area:hasAreaCode 90 ;
+  skos:broader area:054 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Solomon Islands"@en .
+
+area:092 a skos:Concept ;
+  area:hasAlpha2Code "VG" ;
+  area:hasAlpha3Code "VGB" ;
+  area:hasAreaCode 92 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "British Virgin Islands"@en .
+
+area:096 a skos:Concept ;
+  area:hasAlpha2Code "BN" ;
+  area:hasAlpha3Code "BRN" ;
+  area:hasAreaCode 96 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Brunei Darussalam"@en .
+
+area:100 a skos:Concept ;
+  area:hasAlpha2Code "BG" ;
+  area:hasAlpha3Code "BGR" ;
+  area:hasAreaCode 100 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bulgaria"@en .
+
+area:104 a skos:Concept ;
+  area:hasAlpha2Code "MM" ;
+  area:hasAlpha3Code "MMR" ;
+  area:hasAreaCode 104 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Myanmar"@en .
+
+area:108 a skos:Concept ;
+  area:hasAlpha2Code "BI" ;
+  area:hasAlpha3Code "BDI" ;
+  area:hasAreaCode 108 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Burundi"@en .
+
+area:112 a skos:Concept ;
+  area:hasAlpha2Code "BY" ;
+  area:hasAlpha3Code "BLR" ;
+  area:hasAreaCode 112 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Belarus"@en .
+
+area:116 a skos:Concept ;
+  area:hasAlpha2Code "KH" ;
+  area:hasAlpha3Code "KHM" ;
+  area:hasAreaCode 116 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cambodia"@en .
+
+area:120 a skos:Concept ;
+  area:hasAlpha2Code "CM" ;
+  area:hasAlpha3Code "CMR" ;
+  area:hasAreaCode 120 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cameroon"@en .
+
+area:124 a skos:Concept ;
+  area:hasAlpha2Code "CA" ;
+  area:hasAlpha3Code "CAN" ;
+  area:hasAreaCode 124 ;
+  skos:broader area:021 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Canada"@en .
+
+area:132 a skos:Concept ;
+  area:hasAlpha2Code "CV" ;
+  area:hasAlpha3Code "CPV" ;
+  area:hasAreaCode 132 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cabo Verde"@en .
+
+area:136 a skos:Concept ;
+  area:hasAlpha2Code "KY" ;
+  area:hasAlpha3Code "CYM" ;
+  area:hasAreaCode 136 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cayman Islands"@en .
+
+area:140 a skos:Concept ;
+  area:hasAlpha2Code "CF" ;
+  area:hasAlpha3Code "CAF" ;
+  area:hasAreaCode 140 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Central African Republic"@en .
+
+area:142 a skos:Concept ;
+  area:hasAreaCode 142 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:030 ;
+  skos:narrower area:034 ;
+  skos:narrower area:035 ;
+  skos:narrower area:143 ;
+  skos:narrower area:145 ;
+  skos:prefLabel "Asia"@en .
+
+area:143 a skos:Concept ;
+  area:hasAreaCode 143 ;
+  skos:broader area:142 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:398 ;
+  skos:narrower area:417 ;
+  skos:narrower area:762 ;
+  skos:narrower area:795 ;
+  skos:narrower area:860 ;
+  skos:prefLabel "Central Asia"@en .
+
+area:144 a skos:Concept ;
+  area:hasAlpha2Code "LK" ;
+  area:hasAlpha3Code "LKA" ;
+  area:hasAreaCode 144 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sri Lanka"@en .
+
+area:145 a skos:Concept ;
+  area:hasAreaCode 145 ;
+  skos:broader area:142 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:031 ;
+  skos:narrower area:048 ;
+  skos:narrower area:051 ;
+  skos:narrower area:196 ;
+  skos:narrower area:268 ;
+  skos:narrower area:275 ;
+  skos:narrower area:368 ;
+  skos:narrower area:376 ;
+  skos:narrower area:400 ;
+  skos:narrower area:414 ;
+  skos:narrower area:422 ;
+  skos:narrower area:512 ;
+  skos:narrower area:634 ;
+  skos:narrower area:682 ;
+  skos:narrower area:760 ;
+  skos:narrower area:784 ;
+  skos:narrower area:792 ;
+  skos:narrower area:887 ;
+  skos:prefLabel "Western Asia"@en .
+
+area:148 a skos:Concept ;
+  area:hasAlpha2Code "TD" ;
+  area:hasAlpha3Code "TCD" ;
+  area:hasAreaCode 148 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Chad"@en .
+
+area:150 a skos:Concept ;
+  area:hasAreaCode 150 ;
+  skos:broader area:001 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:039 ;
+  skos:narrower area:151 ;
+  skos:narrower area:154 ;
+  skos:narrower area:155 ;
+  skos:prefLabel "Europe"@en .
+
+area:151 a skos:Concept ;
+  area:hasAreaCode 151 ;
+  skos:broader area:150 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:100 ;
+  skos:narrower area:112 ;
+  skos:narrower area:203 ;
+  skos:narrower area:348 ;
+  skos:narrower area:498 ;
+  skos:narrower area:616 ;
+  skos:narrower area:642 ;
+  skos:narrower area:643 ;
+  skos:narrower area:703 ;
+  skos:narrower area:804 ;
+  skos:prefLabel "Eastern Europe"@en .
+
+area:152 a skos:Concept ;
+  area:hasAlpha2Code "CL" ;
+  area:hasAlpha3Code "CHL" ;
+  area:hasAreaCode 152 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Chile"@en .
+
+area:154 a skos:Concept ;
+  area:hasAreaCode 154 ;
+  skos:broader area:150 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:208 ;
+  skos:narrower area:233 ;
+  skos:narrower area:234 ;
+  skos:narrower area:246 ;
+  skos:narrower area:248 ;
+  skos:narrower area:352 ;
+  skos:narrower area:372 ;
+  skos:narrower area:428 ;
+  skos:narrower area:440 ;
+  skos:narrower area:578 ;
+  skos:narrower area:744 ;
+  skos:narrower area:752 ;
+  skos:narrower area:826 ;
+  skos:narrower area:830 ;
+  skos:narrower area:833 ;
+  skos:prefLabel "Northern Europe"@en .
+
+area:155 a skos:Concept ;
+  area:hasAreaCode 155 ;
+  skos:broader area:150 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:040 ;
+  skos:narrower area:056 ;
+  skos:narrower area:250 ;
+  skos:narrower area:276 ;
+  skos:narrower area:438 ;
+  skos:narrower area:442 ;
+  skos:narrower area:492 ;
+  skos:narrower area:528 ;
+  skos:narrower area:756 ;
+  skos:prefLabel "Western Europe"@en .
+
+area:156 a skos:Concept ;
+  area:hasAlpha2Code "CN" ;
+  area:hasAlpha3Code "CHN" ;
+  area:hasAreaCode 156 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "China"@en .
+
+area:162 a skos:Concept ;
+  area:hasAlpha2Code "CX" ;
+  area:hasAlpha3Code "CXR" ;
+  area:hasAreaCode 162 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Christmas Island"@en .
+
+area:166 a skos:Concept ;
+  area:hasAlpha2Code "CC" ;
+  area:hasAlpha3Code "CCK" ;
+  area:hasAreaCode 166 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cocos (Keeling) Islands"@en .
+
+area:170 a skos:Concept ;
+  area:hasAlpha2Code "CO" ;
+  area:hasAlpha3Code "COL" ;
+  area:hasAreaCode 170 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Colombia"@en .
+
+area:174 a skos:Concept ;
+  area:hasAlpha2Code "KM" ;
+  area:hasAlpha3Code "COM" ;
+  area:hasAreaCode 174 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Comoros"@en .
+
+area:175 a skos:Concept ;
+  area:hasAlpha2Code "YT" ;
+  area:hasAlpha3Code "MYT" ;
+  area:hasAreaCode 175 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mayotte"@en .
+
+area:178 a skos:Concept ;
+  area:hasAlpha2Code "CG" ;
+  area:hasAlpha3Code "COG" ;
+  area:hasAreaCode 178 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Congo"@en .
+
+area:180 a skos:Concept ;
+  area:hasAlpha2Code "CD" ;
+  area:hasAlpha3Code "COD" ;
+  area:hasAreaCode 180 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Democratic Republic of the Congo"@en .
+
+area:184 a skos:Concept ;
+  area:hasAlpha2Code "CK" ;
+  area:hasAlpha3Code "COK" ;
+  area:hasAreaCode 184 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cook Islands"@en .
+
+area:188 a skos:Concept ;
+  area:hasAlpha2Code "CR" ;
+  area:hasAlpha3Code "CRI" ;
+  area:hasAreaCode 188 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Costa Rica"@en .
+
+area:191 a skos:Concept ;
+  area:hasAlpha2Code "HR" ;
+  area:hasAlpha3Code "HRV" ;
+  area:hasAreaCode 191 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Croatia"@en .
+
+area:192 a skos:Concept ;
+  area:hasAlpha2Code "CU" ;
+  area:hasAlpha3Code "CUB" ;
+  area:hasAreaCode 192 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cuba"@en .
+
+area:196 a skos:Concept ;
+  area:hasAlpha2Code "CY" ;
+  area:hasAlpha3Code "CYP" ;
+  area:hasAreaCode 196 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Cyprus"@en .
+
+area:202 a skos:Concept ;
+  area:hasAreaCode 202 ;
+  skos:broader area:002 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:011 ;
+  skos:narrower area:014 ;
+  skos:narrower area:017 ;
+  skos:narrower area:018 ;
+  skos:prefLabel "Sub-Saharan Africa"@en .
+
+area:203 a skos:Concept ;
+  area:hasAlpha2Code "CZ" ;
+  area:hasAlpha3Code "CZE" ;
+  area:hasAreaCode 203 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Czechia"@en .
+
+area:204 a skos:Concept ;
+  area:hasAlpha2Code "BJ" ;
+  area:hasAlpha3Code "BEN" ;
+  area:hasAreaCode 204 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Benin"@en .
+
+area:208 a skos:Concept ;
+  area:hasAlpha2Code "DK" ;
+  area:hasAlpha3Code "DNK" ;
+  area:hasAreaCode 208 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Denmark"@en .
+
+area:212 a skos:Concept ;
+  area:hasAlpha2Code "DM" ;
+  area:hasAlpha3Code "DMA" ;
+  area:hasAreaCode 212 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Dominica"@en .
+
+area:214 a skos:Concept ;
+  area:hasAlpha2Code "DO" ;
+  area:hasAlpha3Code "DOM" ;
+  area:hasAreaCode 214 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Dominican Republic"@en .
+
+area:218 a skos:Concept ;
+  area:hasAlpha2Code "EC" ;
+  area:hasAlpha3Code "ECU" ;
+  area:hasAreaCode 218 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Ecuador"@en .
+
+area:222 a skos:Concept ;
+  area:hasAlpha2Code "SV" ;
+  area:hasAlpha3Code "SLV" ;
+  area:hasAreaCode 222 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "El Salvador"@en .
+
+area:226 a skos:Concept ;
+  area:hasAlpha2Code "GQ" ;
+  area:hasAlpha3Code "GNQ" ;
+  area:hasAreaCode 226 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Equatorial Guinea"@en .
+
+area:231 a skos:Concept ;
+  area:hasAlpha2Code "ET" ;
+  area:hasAlpha3Code "ETH" ;
+  area:hasAreaCode 231 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Ethiopia"@en .
+
+area:232 a skos:Concept ;
+  area:hasAlpha2Code "ER" ;
+  area:hasAlpha3Code "ERI" ;
+  area:hasAreaCode 232 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Eritrea"@en .
+
+area:233 a skos:Concept ;
+  area:hasAlpha2Code "EE" ;
+  area:hasAlpha3Code "EST" ;
+  area:hasAreaCode 233 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Estonia"@en .
+
+area:234 a skos:Concept ;
+  area:hasAlpha2Code "FO" ;
+  area:hasAlpha3Code "FRO" ;
+  area:hasAreaCode 234 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Faroe Islands"@en .
+
+area:238 a skos:Concept ;
+  area:hasAlpha2Code "FK" ;
+  area:hasAlpha3Code "FLK" ;
+  area:hasAreaCode 238 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Falkland Islands (Malvinas)"@en .
+
+area:239 a skos:Concept ;
+  area:hasAlpha2Code "GS" ;
+  area:hasAlpha3Code "SGS" ;
+  area:hasAreaCode 239 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "South Georgia and the South Sandwich Islands"@en .
+
+area:242 a skos:Concept ;
+  area:hasAlpha2Code "FJ" ;
+  area:hasAlpha3Code "FJI" ;
+  area:hasAreaCode 242 ;
+  skos:broader area:054 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Fiji"@en .
+
+area:246 a skos:Concept ;
+  area:hasAlpha2Code "FI" ;
+  area:hasAlpha3Code "FIN" ;
+  area:hasAreaCode 246 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Finland"@en .
+
+area:248 a skos:Concept ;
+  area:hasAlpha2Code "AX" ;
+  area:hasAlpha3Code "ALA" ;
+  area:hasAreaCode 248 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Åland Islands"@en .
+
+area:250 a skos:Concept ;
+  area:hasAlpha2Code "FR" ;
+  area:hasAlpha3Code "FRA" ;
+  area:hasAreaCode 250 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "France"@en .
+
+area:254 a skos:Concept ;
+  area:hasAlpha2Code "GF" ;
+  area:hasAlpha3Code "GUF" ;
+  area:hasAreaCode 254 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "French Guiana"@en .
+
+area:258 a skos:Concept ;
+  area:hasAlpha2Code "PF" ;
+  area:hasAlpha3Code "PYF" ;
+  area:hasAreaCode 258 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "French Polynesia"@en .
+
+area:260 a skos:Concept ;
+  area:hasAlpha2Code "TF" ;
+  area:hasAlpha3Code "ATF" ;
+  area:hasAreaCode 260 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "French Southern Territories"@en .
+
+area:262 a skos:Concept ;
+  area:hasAlpha2Code "DJ" ;
+  area:hasAlpha3Code "DJI" ;
+  area:hasAreaCode 262 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Djibouti"@en .
+
+area:266 a skos:Concept ;
+  area:hasAlpha2Code "GA" ;
+  area:hasAlpha3Code "GAB" ;
+  area:hasAreaCode 266 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Gabon"@en .
+
+area:268 a skos:Concept ;
+  area:hasAlpha2Code "GE" ;
+  area:hasAlpha3Code "GEO" ;
+  area:hasAreaCode 268 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Georgia"@en .
+
+area:270 a skos:Concept ;
+  area:hasAlpha2Code "GM" ;
+  area:hasAlpha3Code "GMB" ;
+  area:hasAreaCode 270 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Gambia"@en .
+
+area:275 a skos:Concept ;
+  area:hasAlpha2Code "PS" ;
+  area:hasAlpha3Code "PSE" ;
+  area:hasAreaCode 275 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "State of Palestine"@en .
+
+area:276 a skos:Concept ;
+  area:hasAlpha2Code "DE" ;
+  area:hasAlpha3Code "DEU" ;
+  area:hasAreaCode 276 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Germany"@en .
+
+area:288 a skos:Concept ;
+  area:hasAlpha2Code "GH" ;
+  area:hasAlpha3Code "GHA" ;
+  area:hasAreaCode 288 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Ghana"@en .
+
+area:292 a skos:Concept ;
+  area:hasAlpha2Code "GI" ;
+  area:hasAlpha3Code "GIB" ;
+  area:hasAreaCode 292 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Gibraltar"@en .
+
+area:296 a skos:Concept ;
+  area:hasAlpha2Code "KI" ;
+  area:hasAlpha3Code "KIR" ;
+  area:hasAreaCode 296 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Kiribati"@en .
+
+area:300 a skos:Concept ;
+  area:hasAlpha2Code "GR" ;
+  area:hasAlpha3Code "GRC" ;
+  area:hasAreaCode 300 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Greece"@en .
+
+area:304 a skos:Concept ;
+  area:hasAlpha2Code "GL" ;
+  area:hasAlpha3Code "GRL" ;
+  area:hasAreaCode 304 ;
+  skos:broader area:021 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Greenland"@en .
+
+area:308 a skos:Concept ;
+  area:hasAlpha2Code "GD" ;
+  area:hasAlpha3Code "GRD" ;
+  area:hasAreaCode 308 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Grenada"@en .
+
+area:312 a skos:Concept ;
+  area:hasAlpha2Code "GP" ;
+  area:hasAlpha3Code "GLP" ;
+  area:hasAreaCode 312 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guadeloupe"@en .
+
+area:316 a skos:Concept ;
+  area:hasAlpha2Code "GU" ;
+  area:hasAlpha3Code "GUM" ;
+  area:hasAreaCode 316 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guam"@en .
+
+area:320 a skos:Concept ;
+  area:hasAlpha2Code "GT" ;
+  area:hasAlpha3Code "GTM" ;
+  area:hasAreaCode 320 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guatemala"@en .
+
+area:324 a skos:Concept ;
+  area:hasAlpha2Code "GN" ;
+  area:hasAlpha3Code "GIN" ;
+  area:hasAreaCode 324 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guinea"@en .
+
+area:328 a skos:Concept ;
+  area:hasAlpha2Code "GY" ;
+  area:hasAlpha3Code "GUY" ;
+  area:hasAreaCode 328 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guyana"@en .
+
+area:332 a skos:Concept ;
+  area:hasAlpha2Code "HT" ;
+  area:hasAlpha3Code "HTI" ;
+  area:hasAreaCode 332 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Haiti"@en .
+
+area:334 a skos:Concept ;
+  area:hasAlpha2Code "HM" ;
+  area:hasAlpha3Code "HMD" ;
+  area:hasAreaCode 334 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Heard Island and McDonald Islands"@en .
+
+area:336 a skos:Concept ;
+  area:hasAlpha2Code "VA" ;
+  area:hasAlpha3Code "VAT" ;
+  area:hasAreaCode 336 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Holy See"@en .
+
+area:340 a skos:Concept ;
+  area:hasAlpha2Code "HN" ;
+  area:hasAlpha3Code "HND" ;
+  area:hasAreaCode 340 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Honduras"@en .
+
+area:344 a skos:Concept ;
+  area:hasAlpha2Code "HK" ;
+  area:hasAlpha3Code "HKG" ;
+  area:hasAreaCode 344 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "China, Hong Kong Special Administrative Region"@en .
+
+area:348 a skos:Concept ;
+  area:hasAlpha2Code "HU" ;
+  area:hasAlpha3Code "HUN" ;
+  area:hasAreaCode 348 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Hungary"@en .
+
+area:352 a skos:Concept ;
+  area:hasAlpha2Code "IS" ;
+  area:hasAlpha3Code "ISL" ;
+  area:hasAreaCode 352 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Iceland"@en .
+
+area:356 a skos:Concept ;
+  area:hasAlpha2Code "IN" ;
+  area:hasAlpha3Code "IND" ;
+  area:hasAreaCode 356 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "India"@en .
+
+area:360 a skos:Concept ;
+  area:hasAlpha2Code "ID" ;
+  area:hasAlpha3Code "IDN" ;
+  area:hasAreaCode 360 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Indonesia"@en .
+
+area:364 a skos:Concept ;
+  area:hasAlpha2Code "IR" ;
+  area:hasAlpha3Code "IRN" ;
+  area:hasAreaCode 364 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Iran (Islamic Republic of)"@en .
+
+area:368 a skos:Concept ;
+  area:hasAlpha2Code "IQ" ;
+  area:hasAlpha3Code "IRQ" ;
+  area:hasAreaCode 368 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Iraq"@en .
+
+area:372 a skos:Concept ;
+  area:hasAlpha2Code "IE" ;
+  area:hasAlpha3Code "IRL" ;
+  area:hasAreaCode 372 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Ireland"@en .
+
+area:376 a skos:Concept ;
+  area:hasAlpha2Code "IL" ;
+  area:hasAlpha3Code "ISR" ;
+  area:hasAreaCode 376 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Israel"@en .
+
+area:380 a skos:Concept ;
+  area:hasAlpha2Code "IT" ;
+  area:hasAlpha3Code "ITA" ;
+  area:hasAreaCode 380 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Italy"@en .
+
+area:384 a skos:Concept ;
+  area:hasAlpha2Code "CI" ;
+  area:hasAlpha3Code "CIV" ;
+  area:hasAreaCode 384 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Côte d’Ivoire"@en .
+
+area:388 a skos:Concept ;
+  area:hasAlpha2Code "JM" ;
+  area:hasAlpha3Code "JAM" ;
+  area:hasAreaCode 388 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Jamaica"@en .
+
+area:392 a skos:Concept ;
+  area:hasAlpha2Code "JP" ;
+  area:hasAlpha3Code "JPN" ;
+  area:hasAreaCode 392 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Japan"@en .
+
+area:398 a skos:Concept ;
+  area:hasAlpha2Code "KZ" ;
+  area:hasAlpha3Code "KAZ" ;
+  area:hasAreaCode 398 ;
+  skos:broader area:143 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Kazakhstan"@en .
+
+area:400 a skos:Concept ;
+  area:hasAlpha2Code "JO" ;
+  area:hasAlpha3Code "JOR" ;
+  area:hasAreaCode 400 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Jordan"@en .
+
+area:404 a skos:Concept ;
+  area:hasAlpha2Code "KE" ;
+  area:hasAlpha3Code "KEN" ;
+  area:hasAreaCode 404 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Kenya"@en .
+
+area:408 a skos:Concept ;
+  area:hasAlpha2Code "KP" ;
+  area:hasAlpha3Code "PRK" ;
+  area:hasAreaCode 408 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Democratic People's Republic of Korea"@en .
+
+area:410 a skos:Concept ;
+  area:hasAlpha2Code "KR" ;
+  area:hasAlpha3Code "KOR" ;
+  area:hasAreaCode 410 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Republic of Korea"@en .
+
+area:414 a skos:Concept ;
+  area:hasAlpha2Code "KW" ;
+  area:hasAlpha3Code "KWT" ;
+  area:hasAreaCode 414 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Kuwait"@en .
+
+area:417 a skos:Concept ;
+  area:hasAlpha2Code "KG" ;
+  area:hasAlpha3Code "KGZ" ;
+  area:hasAreaCode 417 ;
+  skos:broader area:143 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Kyrgyzstan"@en .
+
+area:418 a skos:Concept ;
+  area:hasAlpha2Code "LA" ;
+  area:hasAlpha3Code "LAO" ;
+  area:hasAreaCode 418 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Lao People's Democratic Republic"@en .
+
+area:419 a skos:Concept ;
+  area:hasAreaCode 419 ;
+  skos:broader area:019 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:005 ;
+  skos:narrower area:013 ;
+  skos:narrower area:029 ;
+  skos:prefLabel "Latin America and the Caribbean"@en .
+
+area:422 a skos:Concept ;
+  area:hasAlpha2Code "LB" ;
+  area:hasAlpha3Code "LBN" ;
+  area:hasAreaCode 422 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Lebanon"@en .
+
+area:426 a skos:Concept ;
+  area:hasAlpha2Code "LS" ;
+  area:hasAlpha3Code "LSO" ;
+  area:hasAreaCode 426 ;
+  skos:broader area:018 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Lesotho"@en .
+
+area:428 a skos:Concept ;
+  area:hasAlpha2Code "LV" ;
+  area:hasAlpha3Code "LVA" ;
+  area:hasAreaCode 428 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Latvia"@en .
+
+area:430 a skos:Concept ;
+  area:hasAlpha2Code "LR" ;
+  area:hasAlpha3Code "LBR" ;
+  area:hasAreaCode 430 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Liberia"@en .
+
+area:434 a skos:Concept ;
+  area:hasAlpha2Code "LY" ;
+  area:hasAlpha3Code "LBY" ;
+  area:hasAreaCode 434 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Libya"@en .
+
+area:438 a skos:Concept ;
+  area:hasAlpha2Code "LI" ;
+  area:hasAlpha3Code "LIE" ;
+  area:hasAreaCode 438 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Liechtenstein"@en .
+
+area:440 a skos:Concept ;
+  area:hasAlpha2Code "LT" ;
+  area:hasAlpha3Code "LTU" ;
+  area:hasAreaCode 440 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Lithuania"@en .
+
+area:442 a skos:Concept ;
+  area:hasAlpha2Code "LU" ;
+  area:hasAlpha3Code "LUX" ;
+  area:hasAreaCode 442 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Luxembourg"@en .
+
+area:446 a skos:Concept ;
+  area:hasAlpha2Code "MO" ;
+  area:hasAlpha3Code "MAC" ;
+  area:hasAreaCode 446 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "China, Macao Special Administrative Region"@en .
+
+area:450 a skos:Concept ;
+  area:hasAlpha2Code "MG" ;
+  area:hasAlpha3Code "MDG" ;
+  area:hasAreaCode 450 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Madagascar"@en .
+
+area:454 a skos:Concept ;
+  area:hasAlpha2Code "MW" ;
+  area:hasAlpha3Code "MWI" ;
+  area:hasAreaCode 454 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Malawi"@en .
+
+area:458 a skos:Concept ;
+  area:hasAlpha2Code "MY" ;
+  area:hasAlpha3Code "MYS" ;
+  area:hasAreaCode 458 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Malaysia"@en .
+
+area:462 a skos:Concept ;
+  area:hasAlpha2Code "MV" ;
+  area:hasAlpha3Code "MDV" ;
+  area:hasAreaCode 462 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Maldives"@en .
+
+area:466 a skos:Concept ;
+  area:hasAlpha2Code "ML" ;
+  area:hasAlpha3Code "MLI" ;
+  area:hasAreaCode 466 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mali"@en .
+
+area:470 a skos:Concept ;
+  area:hasAlpha2Code "MT" ;
+  area:hasAlpha3Code "MLT" ;
+  area:hasAreaCode 470 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Malta"@en .
+
+area:474 a skos:Concept ;
+  area:hasAlpha2Code "MQ" ;
+  area:hasAlpha3Code "MTQ" ;
+  area:hasAreaCode 474 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Martinique"@en .
+
+area:478 a skos:Concept ;
+  area:hasAlpha2Code "MR" ;
+  area:hasAlpha3Code "MRT" ;
+  area:hasAreaCode 478 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mauritania"@en .
+
+area:480 a skos:Concept ;
+  area:hasAlpha2Code "MU" ;
+  area:hasAlpha3Code "MUS" ;
+  area:hasAreaCode 480 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mauritius"@en .
+
+area:484 a skos:Concept ;
+  area:hasAlpha2Code "MX" ;
+  area:hasAlpha3Code "MEX" ;
+  area:hasAreaCode 484 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mexico"@en .
+
+area:492 a skos:Concept ;
+  area:hasAlpha2Code "MC" ;
+  area:hasAlpha3Code "MCO" ;
+  area:hasAreaCode 492 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Monaco"@en .
+
+area:496 a skos:Concept ;
+  area:hasAlpha2Code "MN" ;
+  area:hasAlpha3Code "MNG" ;
+  area:hasAreaCode 496 ;
+  skos:broader area:030 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mongolia"@en .
+
+area:498 a skos:Concept ;
+  area:hasAlpha2Code "MD" ;
+  area:hasAlpha3Code "MDA" ;
+  area:hasAreaCode 498 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Republic of Moldova"@en .
+
+area:499 a skos:Concept ;
+  area:hasAlpha3Code "MNE" ;
+  area:hasAreaCode 499 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Montenegro"@en .
+
+area:500 a skos:Concept ;
+  area:hasAlpha2Code "MS" ;
+  area:hasAlpha3Code "MSR" ;
+  area:hasAreaCode 500 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Montserrat"@en .
+
+area:504 a skos:Concept ;
+  area:hasAlpha2Code "MA" ;
+  area:hasAlpha3Code "MAR" ;
+  area:hasAreaCode 504 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Morocco"@en .
+
+area:508 a skos:Concept ;
+  area:hasAlpha2Code "MZ" ;
+  area:hasAlpha3Code "MOZ" ;
+  area:hasAreaCode 508 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Mozambique"@en .
+
+area:512 a skos:Concept ;
+  area:hasAlpha2Code "OM" ;
+  area:hasAlpha3Code "OMN" ;
+  area:hasAreaCode 512 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Oman"@en .
+
+area:516 a skos:Concept ;
+  area:hasAlpha2Code "NA" ;
+  area:hasAlpha3Code "NAM" ;
+  area:hasAreaCode 516 ;
+  skos:broader area:018 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Namibia"@en .
+
+area:520 a skos:Concept ;
+  area:hasAlpha2Code "NR" ;
+  area:hasAlpha3Code "NRU" ;
+  area:hasAreaCode 520 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Nauru"@en .
+
+area:524 a skos:Concept ;
+  area:hasAlpha2Code "NP" ;
+  area:hasAlpha3Code "NPL" ;
+  area:hasAreaCode 524 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Nepal"@en .
+
+area:528 a skos:Concept ;
+  area:hasAlpha2Code "NL" ;
+  area:hasAlpha3Code "NLD" ;
+  area:hasAreaCode 528 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Netherlands"@en .
+
+area:531 a skos:Concept ;
+  area:hasAlpha3Code "CUW" ;
+  area:hasAreaCode 531 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Curaçao"@en .
+
+area:533 a skos:Concept ;
+  area:hasAlpha2Code "AW" ;
+  area:hasAlpha3Code "ABW" ;
+  area:hasAreaCode 533 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Aruba"@en .
+
+area:534 a skos:Concept ;
+  area:hasAlpha3Code "SXM" ;
+  area:hasAreaCode 534 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sint Maarten (Dutch part)"@en .
+
+area:535 a skos:Concept ;
+  area:hasAlpha3Code "BES" ;
+  area:hasAreaCode 535 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Bonaire, Sint Eustatius and Saba"@en .
+
+area:540 a skos:Concept ;
+  area:hasAlpha2Code "NC" ;
+  area:hasAlpha3Code "NCL" ;
+  area:hasAreaCode 540 ;
+  skos:broader area:054 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "New Caledonia"@en .
+
+area:548 a skos:Concept ;
+  area:hasAlpha2Code "VU" ;
+  area:hasAlpha3Code "VUT" ;
+  area:hasAreaCode 548 ;
+  skos:broader area:054 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Vanuatu"@en .
+
+area:554 a skos:Concept ;
+  area:hasAlpha2Code "NZ" ;
+  area:hasAlpha3Code "NZL" ;
+  area:hasAreaCode 554 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "New Zealand"@en .
+
+area:558 a skos:Concept ;
+  area:hasAlpha2Code "NI" ;
+  area:hasAlpha3Code "NIC" ;
+  area:hasAreaCode 558 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Nicaragua"@en .
+
+area:562 a skos:Concept ;
+  area:hasAlpha2Code "NE" ;
+  area:hasAlpha3Code "NER" ;
+  area:hasAreaCode 562 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Niger"@en .
+
+area:566 a skos:Concept ;
+  area:hasAlpha2Code "NG" ;
+  area:hasAlpha3Code "NGA" ;
+  area:hasAreaCode 566 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Nigeria"@en .
+
+area:570 a skos:Concept ;
+  area:hasAlpha2Code "NU" ;
+  area:hasAlpha3Code "NIU" ;
+  area:hasAreaCode 570 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Niue"@en .
+
+area:574 a skos:Concept ;
+  area:hasAlpha2Code "NF" ;
+  area:hasAlpha3Code "NFK" ;
+  area:hasAreaCode 574 ;
+  skos:broader area:053 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Norfolk Island"@en .
+
+area:578 a skos:Concept ;
+  area:hasAlpha2Code "NO" ;
+  area:hasAlpha3Code "NOR" ;
+  area:hasAreaCode 578 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Norway"@en .
+
+area:580 a skos:Concept ;
+  area:hasAlpha2Code "MP" ;
+  area:hasAlpha3Code "MNP" ;
+  area:hasAreaCode 580 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Northern Mariana Islands"@en .
+
+area:581 a skos:Concept ;
+  area:hasAlpha2Code "UM" ;
+  area:hasAlpha3Code "UMI" ;
+  area:hasAreaCode 581 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United States Minor Outlying Islands"@en .
+
+area:583 a skos:Concept ;
+  area:hasAlpha2Code "FM" ;
+  area:hasAlpha3Code "FSM" ;
+  area:hasAreaCode 583 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Micronesia (Federated States of)"@en .
+
+area:584 a skos:Concept ;
+  area:hasAlpha2Code "MH" ;
+  area:hasAlpha3Code "MHL" ;
+  area:hasAreaCode 584 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Marshall Islands"@en .
+
+area:585 a skos:Concept ;
+  area:hasAlpha2Code "PW" ;
+  area:hasAlpha3Code "PLW" ;
+  area:hasAreaCode 585 ;
+  skos:broader area:057 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Palau"@en .
+
+area:586 a skos:Concept ;
+  area:hasAlpha2Code "PK" ;
+  area:hasAlpha3Code "PAK" ;
+  area:hasAreaCode 586 ;
+  skos:broader area:034 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Pakistan"@en .
+
+area:591 a skos:Concept ;
+  area:hasAlpha2Code "PA" ;
+  area:hasAlpha3Code "PAN" ;
+  area:hasAreaCode 591 ;
+  skos:broader area:013 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Panama"@en .
+
+area:598 a skos:Concept ;
+  area:hasAlpha2Code "PG" ;
+  area:hasAlpha3Code "PNG" ;
+  area:hasAreaCode 598 ;
+  skos:broader area:054 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Papua New Guinea"@en .
+
+area:600 a skos:Concept ;
+  area:hasAlpha2Code "PY" ;
+  area:hasAlpha3Code "PRY" ;
+  area:hasAreaCode 600 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Paraguay"@en .
+
+area:604 a skos:Concept ;
+  area:hasAlpha2Code "PE" ;
+  area:hasAlpha3Code "PER" ;
+  area:hasAreaCode 604 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Peru"@en .
+
+area:608 a skos:Concept ;
+  area:hasAlpha2Code "PH" ;
+  area:hasAlpha3Code "PHL" ;
+  area:hasAreaCode 608 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Philippines"@en .
+
+area:612 a skos:Concept ;
+  area:hasAlpha2Code "PN" ;
+  area:hasAlpha3Code "PCN" ;
+  area:hasAreaCode 612 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Pitcairn"@en .
+
+area:616 a skos:Concept ;
+  area:hasAlpha2Code "PL" ;
+  area:hasAlpha3Code "POL" ;
+  area:hasAreaCode 616 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Poland"@en .
+
+area:620 a skos:Concept ;
+  area:hasAlpha2Code "PT" ;
+  area:hasAlpha3Code "PRT" ;
+  area:hasAreaCode 620 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Portugal"@en .
+
+area:624 a skos:Concept ;
+  area:hasAlpha2Code "GW" ;
+  area:hasAlpha3Code "GNB" ;
+  area:hasAreaCode 624 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guinea-Bissau"@en .
+
+area:626 a skos:Concept ;
+  area:hasAlpha2Code "TL" ;
+  area:hasAlpha3Code "TLS" ;
+  area:hasAreaCode 626 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Timor-Leste"@en .
+
+area:630 a skos:Concept ;
+  area:hasAlpha2Code "PR" ;
+  area:hasAlpha3Code "PRI" ;
+  area:hasAreaCode 630 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Puerto Rico"@en .
+
+area:634 a skos:Concept ;
+  area:hasAlpha2Code "QA" ;
+  area:hasAlpha3Code "QAT" ;
+  area:hasAreaCode 634 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Qatar"@en .
+
+area:638 a skos:Concept ;
+  area:hasAlpha2Code "RE" ;
+  area:hasAlpha3Code "REU" ;
+  area:hasAreaCode 638 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Réunion"@en .
+
+area:642 a skos:Concept ;
+  area:hasAlpha2Code "RO" ;
+  area:hasAlpha3Code "ROU" ;
+  area:hasAreaCode 642 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Romania"@en .
+
+area:643 a skos:Concept ;
+  area:hasAlpha2Code "RU" ;
+  area:hasAlpha3Code "RUS" ;
+  area:hasAreaCode 643 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Russian Federation"@en .
+
+area:646 a skos:Concept ;
+  area:hasAlpha2Code "RW" ;
+  area:hasAlpha3Code "RWA" ;
+  area:hasAreaCode 646 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Rwanda"@en .
+
+area:652 a skos:Concept ;
+  area:hasAlpha3Code "BLM" ;
+  area:hasAreaCode 652 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Barthélemy"@en .
+
+area:654 a skos:Concept ;
+  area:hasAlpha2Code "SH" ;
+  area:hasAlpha3Code "SHN" ;
+  area:hasAreaCode 654 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Helena"@en .
+
+area:659 a skos:Concept ;
+  area:hasAlpha2Code "KN" ;
+  area:hasAlpha3Code "KNA" ;
+  area:hasAreaCode 659 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Kitts and Nevis"@en .
+
+area:660 a skos:Concept ;
+  area:hasAlpha2Code "AI" ;
+  area:hasAlpha3Code "AIA" ;
+  area:hasAreaCode 660 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Anguilla"@en .
+
+area:662 a skos:Concept ;
+  area:hasAlpha2Code "LC" ;
+  area:hasAlpha3Code "LCA" ;
+  area:hasAreaCode 662 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Lucia"@en .
+
+area:663 a skos:Concept ;
+  area:hasAlpha3Code "MAF" ;
+  area:hasAreaCode 663 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Martin (French Part)"@en .
+
+area:666 a skos:Concept ;
+  area:hasAlpha2Code "PM" ;
+  area:hasAlpha3Code "SPM" ;
+  area:hasAreaCode 666 ;
+  skos:broader area:021 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Pierre and Miquelon"@en .
+
+area:670 a skos:Concept ;
+  area:hasAlpha2Code "VC" ;
+  area:hasAlpha3Code "VCT" ;
+  area:hasAreaCode 670 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saint Vincent and the Grenadines"@en .
+
+area:674 a skos:Concept ;
+  area:hasAlpha2Code "SM" ;
+  area:hasAlpha3Code "SMR" ;
+  area:hasAreaCode 674 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "San Marino"@en .
+
+area:678 a skos:Concept ;
+  area:hasAlpha2Code "ST" ;
+  area:hasAlpha3Code "STP" ;
+  area:hasAreaCode 678 ;
+  skos:broader area:017 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sao Tome and Principe"@en .
+
+area:680 a skos:Concept ;
+  area:hasAlpha3Code "" ;
+  area:hasAreaCode 680 ;
+  skos:broader area:830 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sark"@en .
+
+area:682 a skos:Concept ;
+  area:hasAlpha2Code "SA" ;
+  area:hasAlpha3Code "SAU" ;
+  area:hasAreaCode 682 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Saudi Arabia"@en .
+
+area:686 a skos:Concept ;
+  area:hasAlpha2Code "SN" ;
+  area:hasAlpha3Code "SEN" ;
+  area:hasAreaCode 686 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Senegal"@en .
+
+area:688 a skos:Concept ;
+  area:hasAlpha3Code "SRB" ;
+  area:hasAreaCode 688 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Serbia"@en .
+
+area:690 a skos:Concept ;
+  area:hasAlpha2Code "SC" ;
+  area:hasAlpha3Code "SYC" ;
+  area:hasAreaCode 690 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Seychelles"@en .
+
+area:694 a skos:Concept ;
+  area:hasAlpha2Code "SL" ;
+  area:hasAlpha3Code "SLE" ;
+  area:hasAreaCode 694 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sierra Leone"@en .
+
+area:702 a skos:Concept ;
+  area:hasAlpha2Code "SG" ;
+  area:hasAlpha3Code "SGP" ;
+  area:hasAreaCode 702 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Singapore"@en .
+
+area:703 a skos:Concept ;
+  area:hasAlpha2Code "SK" ;
+  area:hasAlpha3Code "SVK" ;
+  area:hasAreaCode 703 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Slovakia"@en .
+
+area:704 a skos:Concept ;
+  area:hasAlpha2Code "VN" ;
+  area:hasAlpha3Code "VNM" ;
+  area:hasAreaCode 704 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Viet Nam"@en .
+
+area:705 a skos:Concept ;
+  area:hasAlpha2Code "SI" ;
+  area:hasAlpha3Code "SVN" ;
+  area:hasAreaCode 705 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Slovenia"@en .
+
+area:706 a skos:Concept ;
+  area:hasAlpha2Code "SO" ;
+  area:hasAlpha3Code "SOM" ;
+  area:hasAreaCode 706 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Somalia"@en .
+
+area:710 a skos:Concept ;
+  area:hasAlpha2Code "ZA" ;
+  area:hasAlpha3Code "ZAF" ;
+  area:hasAreaCode 710 ;
+  skos:broader area:018 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "South Africa"@en .
+
+area:716 a skos:Concept ;
+  area:hasAlpha2Code "ZW" ;
+  area:hasAlpha3Code "ZWE" ;
+  area:hasAreaCode 716 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Zimbabwe"@en .
+
+area:724 a skos:Concept ;
+  area:hasAlpha2Code "ES" ;
+  area:hasAlpha3Code "ESP" ;
+  area:hasAreaCode 724 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Spain"@en .
+
+area:728 a skos:Concept ;
+  area:hasAlpha3Code "SSD" ;
+  area:hasAreaCode 728 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "South Sudan"@en .
+
+area:729 a skos:Concept ;
+  area:hasAlpha2Code "SD" ;
+  area:hasAlpha3Code "SDN" ;
+  area:hasAreaCode 729 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sudan"@en .
+
+area:732 a skos:Concept ;
+  area:hasAlpha2Code "EH" ;
+  area:hasAlpha3Code "ESH" ;
+  area:hasAreaCode 732 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Western Sahara"@en .
+
+area:740 a skos:Concept ;
+  area:hasAlpha2Code "SR" ;
+  area:hasAlpha3Code "SUR" ;
+  area:hasAreaCode 740 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Suriname"@en .
+
+area:744 a skos:Concept ;
+  area:hasAlpha2Code "SJ" ;
+  area:hasAlpha3Code "SJM" ;
+  area:hasAreaCode 744 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Svalbard and Jan Mayen Islands"@en .
+
+area:748 a skos:Concept ;
+  area:hasAlpha2Code "SZ" ;
+  area:hasAlpha3Code "SWZ" ;
+  area:hasAreaCode 748 ;
+  skos:broader area:018 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Eswatini"@en .
+
+area:752 a skos:Concept ;
+  area:hasAlpha2Code "SE" ;
+  area:hasAlpha3Code "SWE" ;
+  area:hasAreaCode 752 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Sweden"@en .
+
+area:756 a skos:Concept ;
+  area:hasAlpha2Code "CH" ;
+  area:hasAlpha3Code "CHE" ;
+  area:hasAreaCode 756 ;
+  skos:broader area:155 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Switzerland"@en .
+
+area:760 a skos:Concept ;
+  area:hasAlpha2Code "SY" ;
+  area:hasAlpha3Code "SYR" ;
+  area:hasAreaCode 760 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Syrian Arab Republic"@en .
+
+area:762 a skos:Concept ;
+  area:hasAlpha2Code "TJ" ;
+  area:hasAlpha3Code "TJK" ;
+  area:hasAreaCode 762 ;
+  skos:broader area:143 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Tajikistan"@en .
+
+area:764 a skos:Concept ;
+  area:hasAlpha2Code "TH" ;
+  area:hasAlpha3Code "THA" ;
+  area:hasAreaCode 764 ;
+  skos:broader area:035 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Thailand"@en .
+
+area:768 a skos:Concept ;
+  area:hasAlpha2Code "TG" ;
+  area:hasAlpha3Code "TGO" ;
+  area:hasAreaCode 768 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Togo"@en .
+
+area:772 a skos:Concept ;
+  area:hasAlpha2Code "TK" ;
+  area:hasAlpha3Code "TKL" ;
+  area:hasAreaCode 772 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Tokelau"@en .
+
+area:776 a skos:Concept ;
+  area:hasAlpha2Code "TO" ;
+  area:hasAlpha3Code "TON" ;
+  area:hasAreaCode 776 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Tonga"@en .
+
+area:780 a skos:Concept ;
+  area:hasAlpha2Code "TT" ;
+  area:hasAlpha3Code "TTO" ;
+  area:hasAreaCode 780 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Trinidad and Tobago"@en .
+
+area:784 a skos:Concept ;
+  area:hasAlpha2Code "AE" ;
+  area:hasAlpha3Code "ARE" ;
+  area:hasAreaCode 784 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United Arab Emirates"@en .
+
+area:788 a skos:Concept ;
+  area:hasAlpha2Code "TN" ;
+  area:hasAlpha3Code "TUN" ;
+  area:hasAreaCode 788 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Tunisia"@en .
+
+area:792 a skos:Concept ;
+  area:hasAlpha2Code "TR" ;
+  area:hasAlpha3Code "TUR" ;
+  area:hasAreaCode 792 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Türkiye"@en .
+
+area:795 a skos:Concept ;
+  area:hasAlpha2Code "TM" ;
+  area:hasAlpha3Code "TKM" ;
+  area:hasAreaCode 795 ;
+  skos:broader area:143 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Turkmenistan"@en .
+
+area:796 a skos:Concept ;
+  area:hasAlpha2Code "TC" ;
+  area:hasAlpha3Code "TCA" ;
+  area:hasAreaCode 796 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Turks and Caicos Islands"@en .
+
+area:798 a skos:Concept ;
+  area:hasAlpha2Code "TV" ;
+  area:hasAlpha3Code "TUV" ;
+  area:hasAreaCode 798 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Tuvalu"@en .
+
+area:800 a skos:Concept ;
+  area:hasAlpha2Code "UG" ;
+  area:hasAlpha3Code "UGA" ;
+  area:hasAreaCode 800 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Uganda"@en .
+
+area:804 a skos:Concept ;
+  area:hasAlpha2Code "UA" ;
+  area:hasAlpha3Code "UKR" ;
+  area:hasAreaCode 804 ;
+  skos:broader area:151 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Ukraine"@en .
+
+area:807 a skos:Concept ;
+  area:hasAlpha2Code "MK" ;
+  area:hasAlpha3Code "MKD" ;
+  area:hasAreaCode 807 ;
+  skos:broader area:039 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "North Macedonia"@en .
+
+area:818 a skos:Concept ;
+  area:hasAlpha2Code "EG" ;
+  area:hasAlpha3Code "EGY" ;
+  area:hasAreaCode 818 ;
+  skos:broader area:015 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Egypt"@en .
+
+area:826 a skos:Concept ;
+  area:hasAlpha2Code "GB" ;
+  area:hasAlpha3Code "GBR" ;
+  area:hasAreaCode 826 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United Kingdom of Great Britain and Northern Ireland"@en .
+
+area:830 a skos:Concept ;
+  area:hasAreaCode 830 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:narrower area:680 ;
+  skos:narrower area:831 ;
+  skos:narrower area:832 ;
+  skos:prefLabel "Channel Islands"@en .
+
+area:831 a skos:Concept ;
+  area:hasAlpha3Code "GGY" ;
+  area:hasAreaCode 831 ;
+  skos:broader area:830 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Guernsey"@en .
+
+area:832 a skos:Concept ;
+  area:hasAlpha3Code "JEY" ;
+  area:hasAreaCode 832 ;
+  skos:broader area:830 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Jersey"@en .
+
+area:833 a skos:Concept ;
+  area:hasAlpha2Code "IM" ;
+  area:hasAlpha3Code "IMN" ;
+  area:hasAreaCode 833 ;
+  skos:broader area:154 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Isle of Man"@en .
+
+area:834 a skos:Concept ;
+  area:hasAlpha2Code "TZ" ;
+  area:hasAlpha3Code "TZA" ;
+  area:hasAreaCode 834 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United Republic of Tanzania"@en .
+
+area:840 a skos:Concept ;
+  area:hasAlpha2Code "US" ;
+  area:hasAlpha3Code "USA" ;
+  area:hasAreaCode 840 ;
+  skos:broader area:021 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United States of America"@en .
+
+area:850 a skos:Concept ;
+  area:hasAlpha2Code "VI" ;
+  area:hasAlpha3Code "VIR" ;
+  area:hasAreaCode 850 ;
+  skos:broader area:029 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "United States Virgin Islands"@en .
+
+area:854 a skos:Concept ;
+  area:hasAlpha2Code "BF" ;
+  area:hasAlpha3Code "BFA" ;
+  area:hasAreaCode 854 ;
+  skos:broader area:011 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Burkina Faso"@en .
+
+area:858 a skos:Concept ;
+  area:hasAlpha2Code "UY" ;
+  area:hasAlpha3Code "URY" ;
+  area:hasAreaCode 858 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Uruguay"@en .
+
+area:860 a skos:Concept ;
+  area:hasAlpha2Code "UZ" ;
+  area:hasAlpha3Code "UZB" ;
+  area:hasAreaCode 860 ;
+  skos:broader area:143 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Uzbekistan"@en .
+
+area:862 a skos:Concept ;
+  area:hasAlpha2Code "VE" ;
+  area:hasAlpha3Code "VEN" ;
+  area:hasAreaCode 862 ;
+  skos:broader area:005 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Venezuela (Bolivarian Republic of)"@en .
+
+area:876 a skos:Concept ;
+  area:hasAlpha2Code "WF" ;
+  area:hasAlpha3Code "WLF" ;
+  area:hasAreaCode 876 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Wallis and Futuna Islands"@en .
+
+area:882 a skos:Concept ;
+  area:hasAlpha2Code "WS" ;
+  area:hasAlpha3Code "WSM" ;
+  area:hasAreaCode 882 ;
+  skos:broader area:061 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Samoa"@en .
+
+area:887 a skos:Concept ;
+  area:hasAlpha2Code "YE" ;
+  area:hasAlpha3Code "YEM" ;
+  area:hasAreaCode 887 ;
+  skos:broader area:145 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Yemen"@en .
+
+area:894 a skos:Concept ;
+  area:hasAlpha2Code "ZM" ;
+  area:hasAlpha3Code "ZMB" ;
+  area:hasAreaCode 894 ;
+  skos:broader area:014 ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:prefLabel "Zambia"@en .
+
+<https://ontology.okp4.space/thesaurus/area> a skos:ConceptScheme ;
+  rdfs:label "Area Code Thesaurus"@en ;
+  dcterms:description "This thesaurus defines a controlled vocabulary referencing the different area codes as developed and maintained by the United Nations Statistics Division."@en ;
+  dcterms:title "Area Codes for Statistical Use (Series M, No. 49) Thesaurus"@en ;
+  rdfs:seeAlso <https://en.wikipedia.org/wiki/UN_M49> ;
+  skos:hasTopConcept area:001 .
+
+

--- a/src/vocab-category-service.ttl
+++ b/src/vocab-category-service.ttl
@@ -2,6 +2,7 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix svccat: <https://ontology.okp4.space/thesaurus/service-category/> .
 
 <https://ontology.okp4.space/thesaurus/service-category> a skos:ConceptScheme ;
   rdfs:label "Service Category Thesaurus"@en ;
@@ -11,43 +12,43 @@
   """@en ;
   dcterms:title "The OKP4 Service Category Thesaurus"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/ClassificationModel> a skos:Concept ;
+svccat:ClassificationModel a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Classification Model"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/ClusteringModel> a skos:Concept ;
+svccat:ClusteringModel a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Clustering Model"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/ComputerVision> a skos:Concept ;
+svccat:ComputerVision a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Computer Vision"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/DataCleaning> a skos:Concept ;
+svccat:DataCleaning a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Data Cleaning"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/DataIntegration> a skos:Concept ;
+svccat:DataIntegration a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Data Integration"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/DataTransformation> a skos:Concept ;
+svccat:DataTransformation a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Data Transformation"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/DeepLearning> a skos:Concept ;
+svccat:DeepLearning a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Deep Learning"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/NaturalLanguageProcessing> a skos:Concept ;
+svccat:NaturalLanguageProcessing a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Natural Language Processing"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/RegressionModel> a skos:Concept ;
+svccat:RegressionModel a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Regression Model"@en .
 
-<https://ontology.okp4.space/thesaurus/service-category/StatisticsAndAnalytics> a skos:Concept ;
+svccat:StatisticsAndAnalytics a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/service-category> ;
   skos:prefLabel "Statistics & Analytics"@en .
 

--- a/src/vocab-license.ttl
+++ b/src/vocab-license.ttl
@@ -1,0 +1,593 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://ontology.okp4.space/thesaurus/license> a skos:ConceptScheme ;
+  rdfs:label "Open Source Licenses Thesaurus"@en ;
+  dct:description "This thesaurus defines a controlled vocabulary referencing the (major) Open Source licenses."@en ;
+  dct:title "Open Source licenses Thesaurus"@en ;
+  rdfs:seeAlso <https://licenses.opendefinition.org/> .
+
+license:AAL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Attribution Assurance Licenses"@en .
+
+license:AFL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Academic Free License 3.0"@en .
+
+license:AGPL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU Affero General Public License v3"@en .
+
+license:APL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Adaptive Public License 1.0"@en .
+
+license:APSL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Apple Public Source License 2.0"@en .
+
+license:Against-DRM a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Against DRM"@en .
+
+license:Apache-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Apache Software License 1.1"@en .
+
+license:Apache-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Apache Software License 2.0"@en .
+
+license:Artistic-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Artistic License 2.0"@en .
+
+license:BSD-2-Clause a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel """BSD 2-Clause "Simplified" or "FreeBSD" License (BSD-2-Clause)"""@en .
+
+license:BSD-3-Clause a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel """BSD 3-Clause "New" or "Revised" License (BSD-3-Clause)"""@en .
+
+license:BSL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Boost Software License 1.0"@en .
+
+license:BitTorrent-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "BitTorrent Open Source License 1.1"@en .
+
+license:CATOSL-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Computer Associates Trusted Open Source License 1.1 (CATOSL-1.1)"@en .
+
+license:CC-BY-4_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Creative Commons Attribution 4.0"@en .
+
+license:CC-BY-NC-4_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Creative Commons Attribution-NonCommercial 4.0"@en .
+
+license:CC-BY-SA-4_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Creative Commons Attribution Share-Alike 4.0"@en .
+
+license:CC0-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "CC0 1.0"@en .
+
+license:CDDL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Common Development and Distribution License 1.0"@en .
+
+license:CECILL-2_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "CeCILL License 2.1"@en .
+
+license:CNRI-Python a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "CNRI Python License"@en .
+
+license:CPAL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Common Public Attribution License 1.0"@en .
+
+license:CUA-OPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "CUA Office Public License 1.0"@en .
+
+license:DSL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Design Science License"@en .
+
+license:ECL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Educational Community License 2.0"@en .
+
+license:EFL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Eiffel Forum License 2.0"@en .
+
+license:EPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Eclipse Public License 1.0"@en .
+
+license:EPL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Eclipse Public License 2.0"@en .
+
+license:EUDatagrid a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "EU DataGrid Software License"@en .
+
+license:EUPL-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "European Union Public License 1.1"@en .
+
+license:Entessa a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Entessa Public License"@en .
+
+license:FAL-1_3 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Free Art License 1.3"@en .
+
+license:Fair a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Fair License"@en .
+
+license:Frameworx-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Frameworx License 1.0"@en .
+
+license:GFDL-1_3-no-cover-texts-no-invariant-sections a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU Free Documentation License 1.3 with no cover texts and no invariant sections"@en .
+
+license:GPL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU General Public License 2.0"@en .
+
+license:GPL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU General Public License 3.0"@en .
+
+license:HPND a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Historical Permission Notice and Disclaimer"@en .
+
+license:IPA a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "IPA Font License"@en .
+
+license:IPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "IBM Public License 1.0"@en .
+
+license:ISC a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "ISC License"@en .
+
+license:Intel a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Intel Open Source License"@en .
+
+license:LGPL-2_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU Lesser General Public License 2.1"@en .
+
+license:LGPL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "GNU Lesser General Public License 3.0"@en .
+
+license:LO-FR-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open License 2.0"@en .
+
+license:LPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel """Lucent Public License ("Plan9") 1.0"""@en .
+
+license:LPL-1_02 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Lucent Public License 1.02"@en .
+
+license:LPPL-1_3c a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "LaTeX Project Public License 1.3c"@en .
+
+license:MIT a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "MIT License"@en .
+
+license:MPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Mozilla Public License 1.0"@en .
+
+license:MPL-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Mozilla Public License 1.1"@en .
+
+license:MPL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Mozilla Public License 2.0"@en .
+
+license:MS-PL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Microsoft Public License"@en .
+
+license:MS-RL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Microsoft Reciprocal License"@en .
+
+license:MirOS a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "MirOS Licence"@en .
+
+license:Motosoto a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Motosoto License"@en .
+
+license:Multics a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Multics License"@en .
+
+license:NASA-1_3 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "NASA Open Source Agreement 1.3"@en .
+
+license:NCSA a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "University of Illinois/NCSA Open Source License"@en .
+
+license:NGPL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Nethack General Public License"@en .
+
+license:NPOSL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Non-Profit Open Software License 3.0"@en .
+
+license:NTP a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "NTP License"@en .
+
+license:Naumen a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Naumen Public License"@en .
+
+license:Nokia a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Nokia Open Source License"@en .
+
+license:OCLC-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "OCLC Research Public License 2.0"@en .
+
+license:ODC-BY-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Data Commons Attribution License 1.0"@en .
+
+license:ODbL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Data Commons Open Database License 1.0"@en .
+
+license:OFL-1_1 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Font License 1.1"@en .
+
+license:OGL-Canada-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Government License 2.0 (Canada)"@en .
+
+license:OGL-UK-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Government Licence 1.0 (United Kingdom)"@en .
+
+license:OGL-UK-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Government Licence 2.0 (United Kingdom)"@en .
+
+license:OGL-UK-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Government Licence 3.0 (United Kingdom)"@en .
+
+license:OGTSL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Group Test Suite License"@en .
+
+license:OSL-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Software License 3.0"@en .
+
+license:PDDL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open Data Commons Public Domain Dedication and Licence 1.0"@en .
+
+license:PHP-3_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "PHP License 3.0"@en .
+
+license:PostgreSQL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "PostgreSQL License"@en .
+
+license:Python-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Python License 2.0"@en .
+
+license:QPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Q Public License 1.0"@en .
+
+license:RPL-1_5 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Reciprocal Public License 1.5"@en .
+
+license:RPSL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "RealNetworks Public Source License 1.0"@en .
+
+license:RSCPL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Ricoh Source Code Public License"@en .
+
+license:SISSL a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Sun Industry Standards Source License 1.1"@en .
+
+license:SPL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Sun Public License 1.0"@en .
+
+license:SimPL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Simple Public License 2.0"@en .
+
+license:Sleepycat a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Sleepycat License"@en .
+
+license:Talis a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Talis Community License"@en .
+
+license:Unlicense a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Unlicense"@en .
+
+license:VSL-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Vovida Software License 1.0"@en .
+
+license:W3C a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "W3C License"@en .
+
+license:WXwindows a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "wxWindows Library License"@en .
+
+license:Watcom-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Sybase Open Watcom Public License 1.0"@en .
+
+license:Xnet a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "X.Net License"@en .
+
+license:ZPL-2_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Zope Public License 2.0"@en .
+
+license:Zlib a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "zlib/libpng license"@en .
+
+license:contentLicenses a skos:Collection ;
+  rdfs:label "Content Licenses"@en ;
+  dct:description "Collection of licenses which applies to a content."@en ;
+  dct:title "Content Licenses"@en ;
+  skos:member license:AFL-3_0 ;
+  skos:member license:Against-DRM ;
+  skos:member license:CC-BY-4_0 ;
+  skos:member license:CC-BY-NC-4_0 ;
+  skos:member license:CC-BY-SA-4_0 ;
+  skos:member license:CC0-1_0 ;
+  skos:member license:DSL ;
+  skos:member license:FAL-1_3 ;
+  skos:member license:GFDL-1_3-no-cover-texts-no-invariant-sections ;
+  skos:member license:MirOS ;
+  skos:member license:NPOSL-3_0 ;
+  skos:member license:OGL-Canada-2_0 ;
+  skos:member license:OGL-UK-1_0 ;
+  skos:member license:OGL-UK-2_0 ;
+  skos:member license:OGL-UK-3_0 ;
+  skos:member license:OSL-3_0 ;
+  skos:member license:Talis ;
+  skos:member license:hesa-withrights ;
+  skos:member license:localauth-withrights ;
+  skos:member license:other-at ;
+  skos:member license:other-open ;
+  skos:member license:other-pd ;
+  skos:member license:ukclickusepsi ;
+  skos:member license:ukcrown-withrights ;
+  skos:member license:ukpsi .
+
+license:dataLicenses a skos:Collection ;
+  rdfs:label "Data Licenses"@en ;
+  dct:description "Collection of licenses which applies to a data."@en ;
+  dct:title "Data Licenses"@en ;
+  skos:member license:CC-BY-4_0 ;
+  skos:member license:CC-BY-NC-4_0 ;
+  skos:member license:CC-BY-SA-4_0 ;
+  skos:member license:CC0-1_0 ;
+  skos:member license:LO-FR-2_0 ;
+  skos:member license:ODC-BY-1_0 ;
+  skos:member license:ODbL-1_0 ;
+  skos:member license:OGL-Canada-2_0 ;
+  skos:member license:OGL-UK-1_0 ;
+  skos:member license:OGL-UK-2_0 ;
+  skos:member license:OGL-UK-3_0 ;
+  skos:member license:PDDL-1_0 ;
+  skos:member license:dli-model-use ;
+  skos:member license:geogratis .
+
+license:dli-model-use a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Statistics Canada: Data Liberation Initiative (DLI) - Model Data Use Licence"@en .
+
+license:geogratis a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Geogratis"@en .
+
+license:hesa-withrights a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Higher Education Statistics Agency Copyright with data.gov.uk rights"@en .
+
+license:localauth-withrights a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Local Authority Copyright with data.gov.uk rights"@en .
+
+license:met-office-cp a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Met Office UK Climate Projections Licence Agreement"@en .
+
+license:mitre a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "MITRE Collaborative Virtual Workspace License (CVW License)"@en .
+
+license:notspecified a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "License Not Specified"@en .
+
+license:other-at a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Other (Attribution)"@en .
+
+license:other-closed a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Other (Not Open)"@en .
+
+license:other-nc a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Other (Non-Commercial)"@en .
+
+license:other-open a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Other (Open)"@en .
+
+license:other-pd a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Other (Public Domain)"@en .
+
+license:softwareLicenses a skos:Collection ;
+  rdfs:label "Software Licenses"@en ;
+  dct:description "Collection of licenses which applies to a software."@en ;
+  dct:title "Software Licenses"@en ;
+  skos:member license:AAL ;
+  skos:member license:AFL-3_0 ;
+  skos:member license:AGPL-3_0 ;
+  skos:member license:APL-1_0 ;
+  skos:member license:APSL-2_0 ;
+  skos:member license:Apache-1_1 ;
+  skos:member license:Apache-2_0 ;
+  skos:member license:Artistic-2_0 ;
+  skos:member license:BSD-2-Clause ;
+  skos:member license:BSD-3-Clause ;
+  skos:member license:BSL-1_0 ;
+  skos:member license:BitTorrent-1_1 ;
+  skos:member license:CATOSL-1_1 ;
+  skos:member license:CC0-1_0 ;
+  skos:member license:CDDL-1_0 ;
+  skos:member license:CECILL-2_1 ;
+  skos:member license:CNRI-Python ;
+  skos:member license:CPAL-1_0 ;
+  skos:member license:CUA-OPL-1_0 ;
+  skos:member license:ECL-2_0 ;
+  skos:member license:EFL-2_0 ;
+  skos:member license:EPL-1_0 ;
+  skos:member license:EPL-2_0 ;
+  skos:member license:EUDatagrid ;
+  skos:member license:EUPL-1_1 ;
+  skos:member license:Entessa ;
+  skos:member license:Fair ;
+  skos:member license:Frameworx-1_0 ;
+  skos:member license:GPL-2_0 ;
+  skos:member license:GPL-3_0 ;
+  skos:member license:HPND ;
+  skos:member license:IPA ;
+  skos:member license:IPL-1_0 ;
+  skos:member license:ISC ;
+  skos:member license:Intel ;
+  skos:member license:LGPL-2_1 ;
+  skos:member license:LGPL-3_0 ;
+  skos:member license:LPL-1_0 ;
+  skos:member license:LPL-1_02 ;
+  skos:member license:LPPL-1_3c ;
+  skos:member license:MIT ;
+  skos:member license:MPL-1_0 ;
+  skos:member license:MPL-1_1 ;
+  skos:member license:MPL-2_0 ;
+  skos:member license:MS-PL ;
+  skos:member license:MS-RL ;
+  skos:member license:MirOS ;
+  skos:member license:Motosoto ;
+  skos:member license:Multics ;
+  skos:member license:NASA-1_3 ;
+  skos:member license:NCSA ;
+  skos:member license:NGPL ;
+  skos:member license:NPOSL-3_0 ;
+  skos:member license:NTP ;
+  skos:member license:Naumen ;
+  skos:member license:Nokia ;
+  skos:member license:OCLC-2_0 ;
+  skos:member license:OFL-1_1 ;
+  skos:member license:OGL-UK-1_0 ;
+  skos:member license:OGL-UK-2_0 ;
+  skos:member license:OGL-UK-3_0 ;
+  skos:member license:OGTSL ;
+  skos:member license:OSL-3_0 ;
+  skos:member license:PHP-3_0 ;
+  skos:member license:PostgreSQL ;
+  skos:member license:Python-2_0 ;
+  skos:member license:QPL-1_0 ;
+  skos:member license:RPL-1_5 ;
+  skos:member license:RPSL-1_0 ;
+  skos:member license:RSCPL ;
+  skos:member license:SISSL ;
+  skos:member license:SPL-1_0 ;
+  skos:member license:SimPL-2_0 ;
+  skos:member license:Sleepycat ;
+  skos:member license:Unlicense ;
+  skos:member license:VSL-1_0 ;
+  skos:member license:W3C ;
+  skos:member license:WXwindows ;
+  skos:member license:Watcom-1_0 ;
+  skos:member license:Xnet ;
+  skos:member license:ZPL-2_0 ;
+  skos:member license:Zlib ;
+  skos:member license:mitre .
+
+license:ukclickusepsi a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "UK Click Use PSI"@en .
+
+license:ukcrown a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "UK Crown Copyright"@en .
+
+license:ukcrown-withrights a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "UK Crown Copyright with data.gov.uk rights"@en .
+
+license:ukpsi a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "UK PSI Public Sector Information"@en .
+
+


### PR DESCRIPTION
## Purpose

This PR adds a new class, `meta:GeneralMetadata`, to the ontology which represents metadata that describes the basic characteristics of a dataset, such as its title, description, and tags, as well as its topic, temporal coverage, and spatial coverage.

## What's included

### Thesauri

The ontology is enriched with 2 new thesauri to define controlled vocabularies of certain properties:
- `Open Source Licenses`, a thesaurus referencing the (major) Open Source licenses, whose terms are gathered around 3 collections according to the field of application: `content`, `data` and `software`.
- `Area code` referencing the different area codes as developed and maintained by the [United Nations Statistics Division](https://en.wikipedia.org/wiki/UN_M49), with the materialization of the hierarchical level.

### GeneralMetadata class

`GeneralMetadata` represents metadata that describes the basic characteristics of a dataset. The class is defined as a subclass of `core:Metadata`.

```text
    SubClassOf: 
        Metadata,
        'has image' only xsd:uri,
        'has license' only (skos:member value 'Data Licenses'),
        'has topic' only 'Topic Thesaurus',
        'has spatial coverage' min 0 'Area Code Thesaurus',
        'has temporal coverage' min 0 Period,
        'has creator' only xsd:string,
        'has description' only xsd:string,
        'has publisher' only xsd:string,
        'has tag' only xsd:string,
        'has title' only xsd:string
```

### DIDURI class

A new class called `DIDURI` has been added to represent a decentralized identifier URI as defined in the [W3C DID specification](https://www.w3.org/TR/did-core/).

```
    SubClassOf: 
        xsd:anyURI
```

### hasRegistrar property

A new property called `hasRegistrar` has been added to link a resource with the entity (individual, company, or organization) responsible for its registration. While similar to the concept of resource ownership, the focus of this property is on the role that the entity plays in the registration process, rather than on ownership per se.

The range of the `hasRegistrar` property is `DIDURI`.

### Dataset class amendment

The `Dataset` class is modified to include a subclass restriction that specifies that all values of the `hasRegistrar` property must be of the `DIDURI` class. This means that any `Dataset` must be associated with a decentralized identifier URI via the `hasRegistrar` property.

```
    SubClassOf: 
        Data,
        'has registrar' only 'Decentralized Identifier URI'
```

## Example

From Rhizome dataspace (as specified [here](https://github.com/okp4/portal-web/blob/main/data/dataset.json)):

```turtle
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix dataset: <https://ontology.okp4.space/metadata/dataset/> .
@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
@prefix topic: <https://ontology.okp4.space/thesaurus/topic/>.
@prefix core: <https://ontology.okp4.space/core/> .

<https://ontology.okp4.space/dataverse/dataset/79ec2986-0d71-4e92-a48d-95379b3da9ed> a dataset:GeneralMetadata ;
    core:hasLicense license:LO-FR-2_0 ;
    core:hasPublisher "IGN" ;
    core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition « COG », conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
    core:hasCreator "IGN" ;
    core:hasTopic topic:AgricultureEnvironmentAndForestry ;
    core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
    core:hasTag "open data" ;
    core:hasTag "INSEE" ;
    core:hasTag "departement"@fr ;
    core:hasTag "territoire"@fr ;
    core:hasTag "france"@fr ;
    core:hasTitle "ADMIN EXPRESS COG 2020 DEPARTEMENT" .
```