### PR TITLE
Feat/general metadata service

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -5,6 +5,7 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix okp4core: <https://ontology.okp4.space/core/> .
 @prefix okp4th: <https://ontology.okp4.space/thesaurus/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 okp4core:DIDURI a owl:Class ;
   rdfs:label "Decentralized Identifier URI"@en ;
@@ -52,13 +53,13 @@ okp4core:Dataset a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:anyURI ;
-    owl:onProperty okp4core:hasIdentifier ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom okp4core:DIDURI ;
-    owl:onProperty okp4core:hasRegistrar ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
   ] ;
   rdfs:subClassOf okp4core:Data .
 
@@ -116,8 +117,8 @@ okp4core:Service a owl:Class ;
   """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom okp4core:DIDURI ;
-    owl:onProperty okp4core:hasRegistrar ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -126,8 +127,8 @@ okp4core:Service a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:anyURI ;
-    owl:onProperty okp4core:hasIdentifier ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
   ] ;
   rdfs:subClassOf okp4core:Data .
 
@@ -138,6 +139,11 @@ okp4core:belongsTo a owl:ObjectProperty ;
 okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "describes"@en ;
   rdfs:comment "Description link between a resource (i.e. the data) and the description of that resource (i.e. metadata)."@en .
+
+okp4core:hasCategory a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has category"@en ;
+  rdfs:comment "A category of the resource."@en ;
+  rdfs:range skos:Concept .
 
 okp4core:hasIdentifier a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has identifier"@en ;

--- a/src/core.ttl
+++ b/src/core.ttl
@@ -185,7 +185,7 @@ okp4core:hasTemporalCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
 okp4core:hasTopic a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has topic"@en ;
   rdfs:comment "A topic of the resource."@en ;
-  rdfs:range okp4th:topic .
+  rdfs:range skos:Concept .
 
 okp4core:providedBy a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "provided by"@en ;

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -10,7 +10,7 @@
 meta:GeneralMetadata a owl:Class ;
   rdfs:label "General Metadata"@en ;
   rdfs:comment """
-  Generalmetadata is a metadata that describes the basic characteristics of a dataset. It typically includes information such as the title, description, and tags of the dataset, as well as its topic and temporal and spatial coverages.
+  GeneralMetadata is a metadata that describes the basic characteristics of a dataset. It typically includes information such as the title, description, and tags of the dataset, as well as its topic and temporal and spatial coverages.
 
   The purpose of this metadata is to provide a broad overview of the dataset, making it easier for users to understand what the dataset is about and how it can be used. It is often used in conjunction with more detailed metadata, which provides more specific information about the dataset.
    """@en ;

--- a/src/metadata-service-general.ttl
+++ b/src/metadata-service-general.ttl
@@ -1,0 +1,48 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix core: <https://ontology.okp4.space/core/> .
+@prefix meta: <https://ontology.okp4.space/metadata/service/> .
+@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+
+meta:GeneralMetadata a owl:Class ;
+  rdfs:label "General Metadata"@en ;
+  rdfs:comment """
+  General Metadata is a type of metadata that gives a broad overview of a service's characteristics, such as its title, description, and tags. 
+  
+  Its purpose is to make it easier for users to comprehend the service's purpose and usage. It is commonly paired with additional metadata that 
+  offers more in-depth information about the service.
+   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTag ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:uri ;
+    owl:onProperty core:hasImage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasPublisher ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom thesaurus:service-category ;
+    owl:onProperty core:hasCategory ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] ;
+  rdfs:subClassOf core:Metadata .
+
+


### PR DESCRIPTION
## Purpose

This PR adds a new class, `meta:GeneralMetadata`, to the ontology which represents metadata that describes the basic characteristics of a service, such as its title, description, and tags, as well as its category.

The implementation is quite straightforward. This is a first projection of the different information considered, and we can refine it according to the needs.