### PR TITLE
Feat/metadata dataspace general

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -31,6 +31,11 @@ okp4core:DataSpace a owl:Class ;
 
 A Data Space is highly customizable to allow its members to create a space of sharing designed exactly as they need.
   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
+  ] ;
   rdfs:subClassOf okp4core:Data .
 
 okp4core:Dataset a owl:Class ;

--- a/src/metadata-dataspace-general.ttl
+++ b/src/metadata-dataspace-general.ttl
@@ -1,0 +1,50 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix core: <https://ontology.okp4.space/core/> .
+@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
+@prefix meta: <https://ontology.okp4.space/metadata/dataspace/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+
+meta:GeneralMetadata a owl:Class ;
+  rdfs:label "General Metadata"@en ;
+  rdfs:comment """
+  GeneralMetadata is a type of metadata that provides a general description of the essential information about a dataspace.
+    
+  This typically comprises details like the dataspace's title, description, and tags. The primary objective of this metadata is to provide a broad overview 
+  of the dataspace, facilitating users' comprehension of its purpose and potential use cases. Typically, GeneralMetadata is used along with additional metadata 
+  that provides a more specific perspective on a particular aspect of the dataspace.
+   """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom thesaurus:topic ;
+    owl:onProperty core:hasTopic ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasPublisher ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:uri ;
+    owl:onProperty core:hasImage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTag ;
+  ] ;
+  rdfs:subClassOf core:Metadata .
+


### PR DESCRIPTION
## Purpose

This PR introduces a new `meta:GeneralMetadata` class to the ontology (it was missing), which contains metadata related to fundamental properties of a `dataspace`, such as its `title`, `description`, `tags`, and `category`. Additionally, it declares the `core:hasRegistrar` property to specify the identity responsible for registering and managing the dataspace, similar to how we define it for `service` and `dataset`.

The implementation is quite straightforward. This is a first projection of the different information considered, and we can refine it according to the needs.

```text
Class: 'General Metadata'
  SubClassOf: 
        Metadata,
        hasImage only xsd:uri,
        hasTopic only topic,
        hasDescription only xsd:string,
        hasPublisher only xsd:string,
        hasTag only xsd:string,
        hasTitle only xsd:string
```

## Example

From Rhizome dataspace (as specified [here](https://github.com/okp4/portal-web/blob/v1.1.0/data/dataspaces/ef347285-e52a-430d-9679-dcb76b962ce7/dataspace.json)):

```turtle
@prefix core: <https://ontology.okp4.space/core/> .

<https://ontology.okp4.space/dataverse/metadata/dataspace/ef347285-e52a-430d-9679-dcb76b962ce7>
  a <https://ontology.okp4.space/metadata/dataspace/GeneralMetadata> ;
  core:hasPublisher "OKP4" ;
  core:hasDescription """
      Rhizome est un data space exploité par OKP4, actuellement en cours de développement sur la base de la technologie OKP4. 
      Rhizome démontre la puissance du traitement et du partage des données, et la valeur que nous pouvons obtenir en connectant efficacement 
      différentes sources de données agricoles en libre accès sous différents formats de données. Rhizome vise à connecter autant de données que 
      possible et à fournir des visuels et métriques de grande valeur dans différents domaines liés à l'agriculture, tels que l'utilisation des 
      terres et la gestion du territoire, la gestion des cultures et du bétail, ainsi que les ressources forestières et l'industrie du bois.
    """@fr ;
  core:hasTitle "Rhizome" ;
  core:hasTopic <https://ontology.okp4.space/thesaurus/topic/AgricultureEnvironmentAndForestry> ;
  core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
  core:hasTag "agriculture", "open data", "demonstrateur"@fr, "dataviz" .
```

## Note

For those wondering about the management of governance rules, I can share that the proposed approach is to define rules using logical formalism (Prolog) stored in a smart contract in the OKP4 chain. However, a description will be extracted and included in specific metadata to facilitate its consultation and interpretation, particularly for web interfaces.