### PR TITLE
Feat/dataset-format

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -53,8 +53,8 @@ okp4core:Dataset a owl:Class ;
   """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom okp4core:Service ;
-    owl:onProperty okp4core:providedBy ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -63,8 +63,8 @@ okp4core:Dataset a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:anyURI ;
-    owl:onProperty okp4core:hasIdentifier ;
+    owl:allValuesFrom okp4core:Service ;
+    owl:onProperty okp4core:providedBy ;
   ] ;
   rdfs:subClassOf okp4core:Data .
 
@@ -122,8 +122,8 @@ okp4core:Service a owl:Class ;
   """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:anyURI ;
-    owl:onProperty okp4core:hasIdentifier ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -132,8 +132,8 @@ okp4core:Service a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom okp4core:DIDURI ;
-    owl:onProperty okp4core:hasRegistrar ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
   ] ;
   rdfs:subClassOf okp4core:Data .
 
@@ -148,6 +148,11 @@ okp4core:describes a owl:ObjectProperty, owl:FunctionalProperty ;
 okp4core:hasCategory a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has category"@en ;
   rdfs:comment "A category of the resource."@en ;
+  rdfs:range skos:Concept .
+
+okp4core:hasFormat a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "has format"@en ;
+  rdfs:comment "The format of the resource."@en ;
   rdfs:range skos:Concept .
 
 okp4core:hasIdentifier a owl:ObjectProperty, owl:FunctionalProperty ;

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -16,8 +16,13 @@ meta:GeneralMetadata a owl:Class ;
    """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:topic ;
-    owl:onProperty core:hasTopic ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTag ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasCreator ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -31,29 +36,14 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:uri ;
-    owl:onProperty core:hasImage ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
     owl:allValuesFrom xsd:string ;
     owl:onProperty core:hasTitle ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-    owl:onClass core:Period ;
-    owl:onProperty core:hasTemporalCoverage ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasCreator ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom xsd:string ;
-    owl:onProperty core:hasTag ;
+    owl:onClass thesaurus:area ;
+    owl:onProperty core:hasSpatialCoverage ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
@@ -66,9 +56,24 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
+    owl:allValuesFrom thesaurus:topic ;
+    owl:onProperty core:hasTopic ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom thesaurus:media-type ;
+    owl:onProperty core:hasFormat ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-    owl:onClass thesaurus:area ;
-    owl:onProperty core:hasSpatialCoverage ;
+    owl:onClass core:Period ;
+    owl:onProperty core:hasTemporalCoverage ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:uri ;
+    owl:onProperty core:hasImage ;
   ] ;
   rdfs:subClassOf core:Metadata .
 

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -4462,6 +4462,16 @@ media-type:text_css a skos:Concept ;
   skos:prefLabel "Каскадна стилска страна (CSS)"@sr ;
   skos:prefLabel "다단 스타일시트"@ko .
 
+media-type:text_csv a skos:Concept ;
+  media-type:hasMediaType "text/csv" ;
+  rdfs:seeAlso <https://www.rfc-editor.org/rfc/rfc7111> ;
+  skos:altLabel "CSV"@en ;
+  skos:exactMatch media-type:text_x-comma-separated-values ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CSV (valeurs séparées par des virgules)"@fr ;
+  skos:prefLabel "Comma Separated Values"@en ;
+  skos:prefLabel "Werte durch Komma getrennt"@de .
+
 media-type:text_directory a skos:Concept ;
   media-type:hasMediaType "text/directory" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -1,0 +1,5596 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix media-type: <https://ontology.okp4.space/thesaurus/license/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+media-type:hasMediaType a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has media type"@en ;
+  rdfs:comment "Specifies the Media Type for the term of this vocabulary."@en ;
+  rdfs:domain skos:Concept ;
+  rdfs:range rdfs:String .
+
+<https://ontology.okp4.space/thesaurus/media-type> a skos:ConceptScheme ;
+  rdfs:label "Media types Thesaurus"@en ;
+  dct:description "This thesaurus identifyies a sef of Internet media types (originally called MIME type) that are awareness and usage significant."@en ;
+  dct:title "Media types Thesaurus"@en ;
+  rdfs:seeAlso <http://en.wikipedia.org/wiki/Internet_media_type> ;
+  rdfs:seeAlso <http://standards.freedesktop.org/shared-mime-info-spec/> .
+
+media-type:application a skos:Collection ;
+  rdfs:label "Application types"@en ;
+  dct:description "The collection of application types"@en ;
+  dct:title "Application types"@en ;
+  skos:member media-type:application_andrew-inset ;
+  skos:member media-type:application_illustrator ;
+  skos:member media-type:application_mac-binhex40 ;
+  skos:member media-type:application_octet-stream ;
+  skos:member media-type:application_oda ;
+  skos:member media-type:application_ogg ;
+  skos:member media-type:application_pdf ;
+  skos:member media-type:application_pgp ;
+  skos:member media-type:application_pgp-encrypted ;
+  skos:member media-type:application_pgp-keys ;
+  skos:member media-type:application_pgp-signature ;
+  skos:member media-type:application_pkcs7-mime ;
+  skos:member media-type:application_pkcs7-signature ;
+  skos:member media-type:application_postscript ;
+  skos:member media-type:application_rtf ;
+  skos:member media-type:application_smil ;
+  skos:member media-type:application_vndcorel-draw ;
+  skos:member media-type:application_vndhp-hpgl ;
+  skos:member media-type:application_vndhp-pcl ;
+  skos:member media-type:application_vndlotus-1-2-3 ;
+  skos:member media-type:application_vndms-excel ;
+  skos:member media-type:application_vndms-powerpoint ;
+  skos:member media-type:application_vndms-word ;
+  skos:member media-type:application_vndpalm ;
+  skos:member media-type:application_vndrn-realmedia ;
+  skos:member media-type:application_vndstardivisioncalc ;
+  skos:member media-type:application_vndstardivisionchart ;
+  skos:member media-type:application_vndstardivisiondraw ;
+  skos:member media-type:application_vndstardivisionimpress ;
+  skos:member media-type:application_vndstardivisionmail ;
+  skos:member media-type:application_vndstardivisionmath ;
+  skos:member media-type:application_vndstardivisionwriter ;
+  skos:member media-type:application_vndsunxmlcalc ;
+  skos:member media-type:application_vndsunxmlcalctemplate ;
+  skos:member media-type:application_vndsunxmldraw ;
+  skos:member media-type:application_vndsunxmldrawtemplate ;
+  skos:member media-type:application_vndsunxmlimpress ;
+  skos:member media-type:application_vndsunxmlimpresstemplate ;
+  skos:member media-type:application_vndsunxmlmath ;
+  skos:member media-type:application_vndsunxmlwriter ;
+  skos:member media-type:application_vndsunxmlwriterglobal ;
+  skos:member media-type:application_vndsunxmlwritertemplate ;
+  skos:member media-type:application_vndwordperfect ;
+  skos:member media-type:application_x-abiword ;
+  skos:member media-type:application_x-amipro ;
+  skos:member media-type:application_x-applix-spreadsheet ;
+  skos:member media-type:application_x-applix-word ;
+  skos:member media-type:application_x-arc ;
+  skos:member media-type:application_x-archive ;
+  skos:member media-type:application_x-arj ;
+  skos:member media-type:application_x-asp ;
+  skos:member media-type:application_x-awk ;
+  skos:member media-type:application_x-bcpio ;
+  skos:member media-type:application_x-bittorrent ;
+  skos:member media-type:application_x-blender ;
+  skos:member media-type:application_x-bzip ;
+  skos:member media-type:application_x-bzip-compressed-tar ;
+  skos:member media-type:application_x-cd-image ;
+  skos:member media-type:application_x-cgi ;
+  skos:member media-type:application_x-chess-pgn ;
+  skos:member media-type:application_x-class-file ;
+  skos:member media-type:application_x-compress ;
+  skos:member media-type:application_x-compressed-tar ;
+  skos:member media-type:application_x-core ;
+  skos:member media-type:application_x-cpio ;
+  skos:member media-type:application_x-cpio-compressed ;
+  skos:member media-type:application_x-csh ;
+  skos:member media-type:application_x-dbase ;
+  skos:member media-type:application_x-dbm ;
+  skos:member media-type:application_x-dc-rom ;
+  skos:member media-type:application_x-deb ;
+  skos:member media-type:application_x-designer ;
+  skos:member media-type:application_x-desktop ;
+  skos:member media-type:application_x-dia-diagram ;
+  skos:member media-type:application_x-dvi ;
+  skos:member media-type:application_x-e-theme ;
+  skos:member media-type:application_x-egon ;
+  skos:member media-type:application_x-executable ;
+  skos:member media-type:application_x-font-afm ;
+  skos:member media-type:application_x-font-bdf ;
+  skos:member media-type:application_x-font-dos ;
+  skos:member media-type:application_x-font-framemaker ;
+  skos:member media-type:application_x-font-libgrx ;
+  skos:member media-type:application_x-font-linux-psf ;
+  skos:member media-type:application_x-font-otf ;
+  skos:member media-type:application_x-font-pcf ;
+  skos:member media-type:application_x-font-speedo ;
+  skos:member media-type:application_x-font-sunos-news ;
+  skos:member media-type:application_x-font-tex ;
+  skos:member media-type:application_x-font-tex-tfm ;
+  skos:member media-type:application_x-font-ttf ;
+  skos:member media-type:application_x-font-type1 ;
+  skos:member media-type:application_x-font-vfont ;
+  skos:member media-type:application_x-frame ;
+  skos:member media-type:application_x-gameboy-rom ;
+  skos:member media-type:application_x-gdbm ;
+  skos:member media-type:application_x-genesis-rom ;
+  skos:member media-type:application_x-gettext-translation ;
+  skos:member media-type:application_x-glade ;
+  skos:member media-type:application_x-gmc-link ;
+  skos:member media-type:application_x-gnucash ;
+  skos:member media-type:application_x-gnumeric ;
+  skos:member media-type:application_x-graphite ;
+  skos:member media-type:application_x-gtar ;
+  skos:member media-type:application_x-gtktalog ;
+  skos:member media-type:application_x-gzip ;
+  skos:member media-type:application_x-gzpostscript ;
+  skos:member media-type:application_x-hdf ;
+  skos:member media-type:application_x-ipod-firmware ;
+  skos:member media-type:application_x-jar ;
+  skos:member media-type:application_x-java ;
+  skos:member media-type:application_x-javascript ;
+  skos:member media-type:application_x-jbuilder-project ;
+  skos:member media-type:application_x-karbon ;
+  skos:member media-type:application_x-kchart ;
+  skos:member media-type:application_x-kformula ;
+  skos:member media-type:application_x-killustrator ;
+  skos:member media-type:application_x-kivio ;
+  skos:member media-type:application_x-kontour ;
+  skos:member media-type:application_x-kpovmodeler ;
+  skos:member media-type:application_x-kpresenter ;
+  skos:member media-type:application_x-krita ;
+  skos:member media-type:application_x-kspread ;
+  skos:member media-type:application_x-kspread-crypt ;
+  skos:member media-type:application_x-ksysv-package ;
+  skos:member media-type:application_x-kugar ;
+  skos:member media-type:application_x-kword ;
+  skos:member media-type:application_x-kword-crypt ;
+  skos:member media-type:application_x-lha ;
+  skos:member media-type:application_x-lhz ;
+  skos:member media-type:application_x-linguist ;
+  skos:member media-type:application_x-lyx ;
+  skos:member media-type:application_x-lzop ;
+  skos:member media-type:application_x-macbinary ;
+  skos:member media-type:application_x-magicpoint ;
+  skos:member media-type:application_x-matroska ;
+  skos:member media-type:application_x-mif ;
+  skos:member media-type:application_x-mozilla-bookmarks ;
+  skos:member media-type:application_x-ms-dos-executable ;
+  skos:member media-type:application_x-mswinurl ;
+  skos:member media-type:application_x-mswrite ;
+  skos:member media-type:application_x-msx-rom ;
+  skos:member media-type:application_x-n64-rom ;
+  skos:member media-type:application_x-nautilus-link ;
+  skos:member media-type:application_x-nes-rom ;
+  skos:member media-type:application_x-netcdf ;
+  skos:member media-type:application_x-netscape-bookmarks ;
+  skos:member media-type:application_x-object ;
+  skos:member media-type:application_x-ole-storage ;
+  skos:member media-type:application_x-oleo ;
+  skos:member media-type:application_x-palm-database ;
+  skos:member media-type:application_x-pef-executable ;
+  skos:member media-type:application_x-perl ;
+  skos:member media-type:application_x-php ;
+  skos:member media-type:application_x-pkcs12 ;
+  skos:member media-type:application_x-profile ;
+  skos:member media-type:application_x-pw ;
+  skos:member media-type:application_x-python ;
+  skos:member media-type:application_x-python-bytecode ;
+  skos:member media-type:application_x-quattropro ;
+  skos:member media-type:application_x-qw ;
+  skos:member media-type:application_x-rar ;
+  skos:member media-type:application_x-reject ;
+  skos:member media-type:application_x-rpm ;
+  skos:member media-type:application_x-ruby ;
+  skos:member media-type:application_x-sc ;
+  skos:member media-type:application_x-shar ;
+  skos:member media-type:application_x-shared-library-la ;
+  skos:member media-type:application_x-sharedlib ;
+  skos:member media-type:application_x-shellscript ;
+  skos:member media-type:application_x-shockwave-flash ;
+  skos:member media-type:application_x-siag ;
+  skos:member media-type:application_x-slp ;
+  skos:member media-type:application_x-sms-rom ;
+  skos:member media-type:application_x-stuffit ;
+  skos:member media-type:application_x-sv4cpio ;
+  skos:member media-type:application_x-sv4crc ;
+  skos:member media-type:application_x-tar ;
+  skos:member media-type:application_x-tarz ;
+  skos:member media-type:application_x-tex-gf ;
+  skos:member media-type:application_x-tex-pk ;
+  skos:member media-type:application_x-tgif ;
+  skos:member media-type:application_x-theme ;
+  skos:member media-type:application_x-toutdoux ;
+  skos:member media-type:application_x-trash ;
+  skos:member media-type:application_x-troff ;
+  skos:member media-type:application_x-troff-man ;
+  skos:member media-type:application_x-troff-man-compressed ;
+  skos:member media-type:application_x-tzo ;
+  skos:member media-type:application_x-ustar ;
+  skos:member media-type:application_x-wais-source ;
+  skos:member media-type:application_x-wpg ;
+  skos:member media-type:application_x-x509-ca-cert ;
+  skos:member media-type:application_x-xbel ;
+  skos:member media-type:application_x-zerosize ;
+  skos:member media-type:application_x-zoo ;
+  skos:member media-type:application_xhtmlxml ;
+  skos:member media-type:application_zip .
+
+media-type:application_andrew-inset a skos:Concept ;
+  media-type:hasMediaType "application/andrew-inset" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Andrew Toolkit -osio"@fi ;
+  skos:prefLabel "Andrew Toolkit innsats"@nn ;
+  skos:prefLabel "Andrew Toolkit inset"@cs ;
+  skos:prefLabel "Andrew Toolkit inset"@en ;
+  skos:prefLabel "Andrew Toolkit inset"@hu ;
+  skos:prefLabel "Andrew Toolkit sənədi"@az ;
+  skos:prefLabel "Andrew Toolkit-Inset"@de ;
+  skos:prefLabel "Andrew verktøysett insett"@no ;
+  skos:prefLabel "Andrew додатаг групе алата"@sr ;
+  skos:prefLabel "Andrew 툴킷 inset"@ko ;
+  skos:prefLabel "Andrew-verktygssamling insatt"@sv ;
+  skos:prefLabel "Mewnosodiad Andrew Toolkit"@cy ;
+  skos:prefLabel "ajout Andrew Toolkit"@fr .
+
+media-type:application_illustrator a skos:Concept ;
+  media-type:hasMediaType "application/illustrator" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Adobe Illustrator -asiakirja"@fi ;
+  skos:prefLabel "Adobe Illustrator document"@en ;
+  skos:prefLabel "Adobe Illustrator-Dokument"@de ;
+  skos:prefLabel "Adobe Illustrator-dokument"@no ;
+  skos:prefLabel "Adobe Illustrator-dokument"@sv ;
+  skos:prefLabel "Έγγραφο Adobe Illustrator"@el .
+
+media-type:application_mac-binhex40 a skos:Concept ;
+  media-type:hasMediaType "application/mac-binhex40" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil BinHex-amgodwyd Macintosh"@cy ;
+  skos:prefLabel "Macintosh BinHe-kodet arkiv"@no ;
+  skos:prefLabel "Macintosh BinHex -koodattu tiedosto"@fi ;
+  skos:prefLabel "Macintosh BinHex kódolású fájl"@hu ;
+  skos:prefLabel "Macintosh BinHex-encoded file"@en ;
+  skos:prefLabel "Macintosh BinHex-gecodeerd bestand"@nl ;
+  skos:prefLabel "Macintosh BinHex-koda fil"@nn ;
+  skos:prefLabel "Macintosh BinHex-kodad fil"@sv ;
+  skos:prefLabel "Macintosh BinHex-kodlanmış fayl"@az ;
+  skos:prefLabel "Macintosh-Datei (BinHex-kodiert)"@de ;
+  skos:prefLabel "Soubor kódovaný Macintosh BinHex"@cs ;
+  skos:prefLabel "fichier encode Macintosh BinHex"@fr ;
+  skos:prefLabel "Αρχείο Macintosh κωδικοποίησης BinHex"@el ;
+  skos:prefLabel "Мекинтош BinHex-encoded датотека"@sr ;
+  skos:prefLabel "맥킨토시 BinHex-encoded 압축파일"@ko .
+
+media-type:application_octet-stream a skos:Concept ;
+  media-type:hasMediaType "application/octet-stream" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tuntematon"@fi ;
+  skos:prefLabel "ukjent"@no ;
+  skos:prefLabel "unbekannt"@de ;
+  skos:prefLabel "unknown"@en ;
+  skos:prefLabel "άγνωστο"@el .
+
+media-type:application_oda a skos:Concept ;
+  media-type:hasMediaType "application/oda" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen ODA"@cy ;
+  skos:prefLabel "Dokument ODA"@cs ;
+  skos:prefLabel "ODA document"@en ;
+  skos:prefLabel "ODA document"@nl ;
+  skos:prefLabel "ODA sənədi"@az ;
+  skos:prefLabel "ODA документ"@sr ;
+  skos:prefLabel "ODA 문서"@ko ;
+  skos:prefLabel "ODA-Dokument"@de ;
+  skos:prefLabel "ODA-asiakirja"@fi ;
+  skos:prefLabel "ODA-dokument"@nn ;
+  skos:prefLabel "ODA-dokument"@no ;
+  skos:prefLabel "ODA-dokument"@sv ;
+  skos:prefLabel "ODA-dokumentum"@hu ;
+  skos:prefLabel "document ODA"@fr ;
+  skos:prefLabel "Έγγραφο ODA"@el .
+
+media-type:application_ogg a skos:Concept ;
+  media-type:hasMediaType "application/ogg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ogg Vorbis -ääni"@fi ;
+  skos:prefLabel "Ogg Vorbis audio faylı"@az ;
+  skos:prefLabel "Ogg Vorbis audio"@en ;
+  skos:prefLabel "Ogg Vorbis geluidsbestand"@nl ;
+  skos:prefLabel "Ogg Vorbis 오디오"@ko ;
+  skos:prefLabel "Ogg Vorbis-Audio"@de ;
+  skos:prefLabel "Ogg Vorbis-hangfájl"@hu ;
+  skos:prefLabel "Ogg Vorbis-ljud"@sv ;
+  skos:prefLabel "Ogg Vorbis-lyd"@nn ;
+  skos:prefLabel "Ogg Vorbis-lyd"@no ;
+  skos:prefLabel "Sain Ogg Vorbis"@cy ;
+  skos:prefLabel "Zvuk Ogg Vorbis"@cs ;
+  skos:prefLabel "audio Ogg Vorbis"@fr ;
+  skos:prefLabel "Ήχος Ogg Vobris"@el ;
+  skos:prefLabel "Ог-ворбис звучни запис"@sr .
+
+media-type:application_pdf a skos:Concept ;
+  media-type:hasMediaType "application/pdf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen PDF"@cy ;
+  skos:prefLabel "PDF document"@en ;
+  skos:prefLabel "PDF документ"@sr ;
+  skos:prefLabel "PDF-Dokument"@de ;
+  skos:prefLabel "PDF-asiakirja"@fi ;
+  skos:prefLabel "PDF-dokument"@nn ;
+  skos:prefLabel "PDF-dokument"@no ;
+  skos:prefLabel "PDF-dokument"@sv ;
+  skos:prefLabel "Έγγραφο PDF"@el .
+
+media-type:application_pgp a skos:Concept ;
+  media-type:hasMediaType "application/pgp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Neges PGP"@cy ;
+  skos:prefLabel "PGP bericht"@nl ;
+  skos:prefLabel "PGP ismarışı"@az ;
+  skos:prefLabel "PGP message"@en ;
+  skos:prefLabel "PGP порука"@sr ;
+  skos:prefLabel "PGP 메세지"@ko ;
+  skos:prefLabel "PGP-Nachricht"@de ;
+  skos:prefLabel "PGP-meddelande"@sv ;
+  skos:prefLabel "PGP-melding"@nn ;
+  skos:prefLabel "PGP-melding"@no ;
+  skos:prefLabel "PGP-viesti"@fi ;
+  skos:prefLabel "PGP-üzenet"@hu ;
+  skos:prefLabel "Zpráva PGP"@cs ;
+  skos:prefLabel "message PGP"@fr ;
+  skos:prefLabel "Μήνυμα PGP"@el .
+
+media-type:application_pgp-encrypted a skos:Concept ;
+  media-type:hasMediaType "application/pgp-encrypted" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PGP/MIME-encrypted message header"@en ;
+  skos:prefLabel "PGP/MIME-kryptert meldingshode"@no ;
+  skos:prefLabel "PGP/MIME-salattu viestiotsikko"@fi ;
+  skos:prefLabel "PGP/MIME-verschlüsselter Nachrichtenkopf"@de .
+
+media-type:application_pgp-keys a skos:Concept ;
+  media-type:hasMediaType "application/pgp-keys" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Allweddi PGP"@cy ;
+  skos:prefLabel "Klíče PGP"@cs ;
+  skos:prefLabel "PGP açarları"@az ;
+  skos:prefLabel "PGP keys"@en ;
+  skos:prefLabel "PGP sleutels"@nl ;
+  skos:prefLabel "PGP кључ"@sr ;
+  skos:prefLabel "PGP 키"@ko ;
+  skos:prefLabel "PGP-Schlüssel"@de ;
+  skos:prefLabel "PGP-avainrengas"@fi ;
+  skos:prefLabel "PGP-kulcs"@hu ;
+  skos:prefLabel "PGP-nycklar"@sv ;
+  skos:prefLabel "PGP-nøkler"@nn ;
+  skos:prefLabel "PGP-nøkler"@no ;
+  skos:prefLabel "clés PGP"@fr ;
+  skos:prefLabel "Κλειδιά PGP"@el .
+
+media-type:application_pgp-signature a skos:Concept ;
+  media-type:hasMediaType "application/pgp-signature" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "detached OpenPGP signature"@en ;
+  skos:prefLabel "erillinen OpenPGP-allekirjoitus"@fi ;
+  skos:prefLabel "frakoblet OpenPGP-signatur"@no ;
+  skos:prefLabel "isolierte OpenPGP-Signatur"@de .
+
+media-type:application_pkcs7-mime a skos:Concept ;
+  media-type:hasMediaType "application/pkcs7-mime" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil S/MIME"@cy ;
+  skos:prefLabel "S/MIME bestand"@nl ;
+  skos:prefLabel "S/MIME faylı"@az ;
+  skos:prefLabel "S/MIME file"@en ;
+  skos:prefLabel "S/MIME датотека"@sr ;
+  skos:prefLabel "S/MIME 파일"@ko ;
+  skos:prefLabel "S/MIME-Datei"@de ;
+  skos:prefLabel "S/MIME-fil"@nn ;
+  skos:prefLabel "S/MIME-fil"@no ;
+  skos:prefLabel "S/MIME-fil"@sv ;
+  skos:prefLabel "S/MIME-fájl"@hu ;
+  skos:prefLabel "S/MIME-tiedosto"@fi ;
+  skos:prefLabel "Soubor S/MIME"@cs ;
+  skos:prefLabel "fichier S/MIME"@fr ;
+  skos:prefLabel "Αρχείο S/MIME"@el .
+
+media-type:application_pkcs7-signature a skos:Concept ;
+  media-type:hasMediaType "application/pkcs7-signature" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "detached S/MIME signature"@en ;
+  skos:prefLabel "erillinen S/MIME-allekirjoitus"@fi ;
+  skos:prefLabel "frakoblet S/MIME-signatur"@no ;
+  skos:prefLabel "isolierte S/MIME-Signatur"@de .
+
+media-type:application_postscript a skos:Concept ;
+  media-type:hasMediaType "application/postscript" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PostScript document"@en ;
+  skos:prefLabel "PostScript-Dokument"@de ;
+  skos:prefLabel "PostScript-asiakirja"@fi ;
+  skos:prefLabel "PostScript-dokument"@no ;
+  skos:prefLabel "PostScript-dokument"@sv ;
+  skos:prefLabel "Έγγραφο PostScript"@el .
+
+media-type:application_rtf a skos:Concept ;
+  media-type:hasMediaType "application/rtf" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Testun Gyfoethog"@cy ;
+  skos:prefLabel "RTF-asiakirja"@fi ;
+  skos:prefLabel "RTF-fájl"@hu ;
+  skos:prefLabel "Rich Text Format"@cs ;
+  skos:prefLabel "Rich Text Format"@en ;
+  skos:prefLabel "Rich Text Format"@fr ;
+  skos:prefLabel "Rich Text 형식"@ko ;
+  skos:prefLabel "Richt-Text-Format"@de ;
+  skos:prefLabel "Rijke Tekst Formaat"@nl ;
+  skos:prefLabel "Rik tekst-dokument"@nn ;
+  skos:prefLabel "Rik tekst-format"@no ;
+  skos:prefLabel "Rikt textdokument"@sv ;
+  skos:prefLabel "Zəngin Mətn Formatı"@az ;
+  skos:prefLabel "Обогаћени текстуални запис (RTF)"@sr .
+
+media-type:application_smil a skos:Concept ;
+  media-type:hasMediaType "application/smil" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Gesynchroniseerde multimedia integratie taal"@nl ;
+  skos:prefLabel "Iaith Integreiddio Aml-Gyfrwng wedi ei Chydweddu"@cy ;
+  skos:prefLabel "SMIL-Dokument"@de ;
+  skos:prefLabel "Sinxronlaşdırılmış Multemediya İnteqrasiya Dili"@az ;
+  skos:prefLabel "Språk för synkroniserad multimediaintegration"@sv ;
+  skos:prefLabel "Synchronized Multimedia Integration Language"@cs ;
+  skos:prefLabel "Synchronized Multimedia Integration Language"@en ;
+  skos:prefLabel "Synchronized Multimedia Integration Language"@fi ;
+  skos:prefLabel "Synchronized Multimedia Integration Language"@fr ;
+  skos:prefLabel "Synchronized Multimedia Integration Language"@nn ;
+  skos:prefLabel "Szinkronizált multimédiaintegrációs nyelv"@hu ;
+  skos:prefLabel "Синхронизовани језик за интеграцију мултимедије (SMIL)"@sr ;
+  skos:prefLabel "동기화 멀티미디어 통합 언어"@ko .
+
+media-type:application_vndcorel-draw a skos:Concept ;
+  media-type:hasMediaType "application/vnd.corel-draw" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Corel Draw -piirros"@fi ;
+  skos:prefLabel "Corel Draw drawing"@en ;
+  skos:prefLabel "Corel Draw tekening"@nl ;
+  skos:prefLabel "Corel Draw çəkimi"@az ;
+  skos:prefLabel "Corel Draw цртеж"@sr ;
+  skos:prefLabel "Corel Draw-Zeichnung"@de ;
+  skos:prefLabel "Corel Draw-rajz"@hu ;
+  skos:prefLabel "Corel Draw-teckning"@sv ;
+  skos:prefLabel "Corel Draw-tegning"@no ;
+  skos:prefLabel "Corel Draw-teikning"@nn ;
+  skos:prefLabel "Darlun Corel Draw"@cy ;
+  skos:prefLabel "Kresba Corel Draw"@cs ;
+  skos:prefLabel "dessin Corel Draw"@fr ;
+  skos:prefLabel "Σχέδιο Corel Draw "@el ;
+  skos:prefLabel "코렐 드로우 드로잉"@ko .
+
+media-type:application_vndhp-hpgl a skos:Concept ;
+  media-type:hasMediaType "application/vnd.hp-hpgl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "HP Graphics Language (piirturi)"@fi ;
+  skos:prefLabel "HP Graphics Language (plotter)"@en ;
+  skos:prefLabel "HP-Grafiksprache (Plotter)"@de .
+
+media-type:application_vndhp-pcl a skos:Concept ;
+  media-type:hasMediaType "application/vnd.hp-pcl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "HP Printer Control Language -tiedosto"@fi ;
+  skos:prefLabel "HP Printer Control Language file"@en ;
+  skos:prefLabel "HP-Druckersteuerungs-Sprachdatei"@de .
+
+media-type:application_vndlotus-1-2-3 a skos:Concept ;
+  media-type:hasMediaType "application/vnd.lotus-1-2-3" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Lotus 1-2-3 -taulukko"@fi ;
+  skos:prefLabel "Lotus 1-2-3 hesab cədvəli"@az ;
+  skos:prefLabel "Lotus 1-2-3 regneark"@no ;
+  skos:prefLabel "Lotus 1-2-3 rekneark"@nn ;
+  skos:prefLabel "Lotus 1-2-3 spreadsheet"@en ;
+  skos:prefLabel "Lotus 1-2-3 spreadsheet"@nl ;
+  skos:prefLabel "Lotus 1-2-3 табеларни прорачун"@sr ;
+  skos:prefLabel "Lotus 1-2-3 스프레드시트"@ko ;
+  skos:prefLabel "Lotus 1-2-3-Tabellendokument"@de ;
+  skos:prefLabel "Lotus 1-2-3-kalkylblad"@sv ;
+  skos:prefLabel "Lotus 1-2-3-munkafüzet"@hu ;
+  skos:prefLabel "Tabulka Lotus 1-2-3"@cs ;
+  skos:prefLabel "Taenlen Lotus 1-2-3"@cy ;
+  skos:prefLabel "chiffrier Lotus 1-2-3"@fr ;
+  skos:prefLabel "Λογιστικό φύλλο Lotus 1-2-3"@el .
+
+media-type:application_vndms-excel a skos:Concept ;
+  media-type:hasMediaType "application/vnd.ms-excel" ;
+  skos:exactMatch media-type:application_msexcel ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft Excel -taulukko"@fi ;
+  skos:prefLabel "Microsoft Excel hesab cədvəli"@az ;
+  skos:prefLabel "Microsoft Excel regneark"@no ;
+  skos:prefLabel "Microsoft Excel reikneark"@nn ;
+  skos:prefLabel "Microsoft Excel spreadsheet"@en ;
+  skos:prefLabel "Microsoft Excel spreadsheet"@nl ;
+  skos:prefLabel "Microsoft Excel-Tabellendokument"@de ;
+  skos:prefLabel "Microsoft Excel-kalkylblad"@sv ;
+  skos:prefLabel "Microsoft Excel-munkafüzet"@hu ;
+  skos:prefLabel "Tabulka Microsoft Excel"@cs ;
+  skos:prefLabel "Taenlen Microsoft Excel"@cy ;
+  skos:prefLabel "chiffrier Microsoft Excel"@fr ;
+  skos:prefLabel "Λογιστικό φύλλο Microsoft Excel"@el ;
+  skos:prefLabel "Микрософт Ексел табеларни прорачун"@sr ;
+  skos:prefLabel "마이크로소프트 엑셀 스프레드시트"@ko .
+
+media-type:application_vndms-powerpoint a skos:Concept ;
+  media-type:hasMediaType "application/vnd.ms-powerpoint" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft PowerPoint -esitys"@fi ;
+  skos:prefLabel "Microsoft PowerPoint presentation"@en ;
+  skos:prefLabel "Microsoft PowerPoint-Präsentation"@de ;
+  skos:prefLabel "Microsoft PowerPoint-presentasjon"@no ;
+  skos:prefLabel "Παρουσίαση Microsoft PowerPoint"@el .
+
+media-type:application_vndms-word a skos:Concept ;
+  media-type:hasMediaType "application/vnd.ms-word" ;
+  skos:exactMatch media-type:application_msword ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Miscrosoft Word"@cy ;
+  skos:prefLabel "Dokument Microsoft Word"@cs ;
+  skos:prefLabel "Microsoft Word -asiakirja"@fi ;
+  skos:prefLabel "Microsoft Word document"@en ;
+  skos:prefLabel "Microsoft Word document"@nl ;
+  skos:prefLabel "Microsoft Word dokument"@no ;
+  skos:prefLabel "Microsoft Word sənədi"@az ;
+  skos:prefLabel "Microsoft Word-Dokument"@de ;
+  skos:prefLabel "Microsoft Word-dokument"@nn ;
+  skos:prefLabel "Microsoft Word-dokument"@sv ;
+  skos:prefLabel "Microsoft Word-dokumentum"@hu ;
+  skos:prefLabel "document Microsoft Word"@fr ;
+  skos:prefLabel "Έγγραφο Microsoft Word"@el ;
+  skos:prefLabel "Микрософт Word документ"@sr ;
+  skos:prefLabel "마이크로소프트 워드 문서"@ko .
+
+media-type:application_vndpalm a skos:Concept ;
+  media-type:hasMediaType "application/vnd.palm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Palmpilot database/document"@en ;
+  skos:prefLabel "Palmpilot-Datenbank/-Dokument"@de ;
+  skos:prefLabel "Palmpilot-tietokanta tai -asiakirja"@fi .
+
+media-type:application_vndrn-realmedia a skos:Concept ;
+  media-type:hasMediaType "application/vnd.rn-realmedia" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen RealAudio neu RealVideo"@cy ;
+  skos:prefLabel "Dokument RealAudio/Video"@cs ;
+  skos:prefLabel "RealAudio/Video document"@en ;
+  skos:prefLabel "RealAudio/Video document"@nl ;
+  skos:prefLabel "RealAudio/Video sənədi"@az ;
+  skos:prefLabel "RealAudio/Video документ"@sr ;
+  skos:prefLabel "RealAudio/Video-Dokument"@de ;
+  skos:prefLabel "RealAudio/Video-asiakirja"@fi ;
+  skos:prefLabel "RealAudio/Video-dokument"@nn ;
+  skos:prefLabel "RealAudio/Video-dokument"@no ;
+  skos:prefLabel "RealAudio/Video-dokument"@sv ;
+  skos:prefLabel "RealAudio/Video-dokumentum"@hu ;
+  skos:prefLabel "document RealAudio/Video"@fr ;
+  skos:prefLabel "Έγγραφο RealAudio/Video"@el ;
+  skos:prefLabel "리얼오디오/비디오 문서"@ko .
+
+media-type:application_vndstardivisioncalc a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.calc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "StarCalc hesab cədvəli"@az ;
+  skos:prefLabel "StarCalc spreadsheet"@en ;
+  skos:prefLabel "StarCalc spreadsheet"@nl ;
+  skos:prefLabel "StarCalc табеларни прорачун"@sr ;
+  skos:prefLabel "StarCalc 스프레드시트"@ko ;
+  skos:prefLabel "StarCalc-Tabellendokument"@de ;
+  skos:prefLabel "StarCalc-kalkylblad"@sv ;
+  skos:prefLabel "StarCalc-munkafüzet"@hu ;
+  skos:prefLabel "StarCalc-regneark"@no ;
+  skos:prefLabel "StarCalc-rekneark"@nn ;
+  skos:prefLabel "StarCalc-taulukko"@fi ;
+  skos:prefLabel "Tabulka StarCalc"@cs ;
+  skos:prefLabel "Taenlen StarCalc"@cy ;
+  skos:prefLabel "chiffier StarCalc"@fr ;
+  skos:prefLabel "Λογιστικό φύλλο StarCalc"@el .
+
+media-type:application_vndstardivisionchart a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.chart" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Graf StarChart"@cs ;
+  skos:prefLabel "Siart StarChart"@cy ;
+  skos:prefLabel "StarCalc 표"@ko ;
+  skos:prefLabel "StarChart chart"@en ;
+  skos:prefLabel "StarChart cədvəli"@az ;
+  skos:prefLabel "StarChart graf"@no ;
+  skos:prefLabel "StarChart grafiek"@nl ;
+  skos:prefLabel "StarChart графикон"@sr ;
+  skos:prefLabel "StarChart-Diagramm"@de ;
+  skos:prefLabel "StarChart-diagram"@sv ;
+  skos:prefLabel "StarChart-graf"@nn ;
+  skos:prefLabel "StarChart-grafikon"@hu ;
+  skos:prefLabel "StarChart-kaavio"@fi ;
+  skos:prefLabel "graphique StarChart"@fr ;
+  skos:prefLabel "Γράφημα StarChart"@el .
+
+media-type:application_vndstardivisiondraw a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.draw" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Darlun StarDraw"@cy ;
+  skos:prefLabel "Kresba StarDraw"@cs ;
+  skos:prefLabel "StarCalc 드로잉"@ko ;
+  skos:prefLabel "StarDraw drawing"@en ;
+  skos:prefLabel "StarDraw drawing"@sr ;
+  skos:prefLabel "StarDraw tegning"@no ;
+  skos:prefLabel "StarDraw tekening"@nl ;
+  skos:prefLabel "StarDraw çəkimi"@az ;
+  skos:prefLabel "StarDraw-Zeichnung"@de ;
+  skos:prefLabel "StarDraw-piirros"@fi ;
+  skos:prefLabel "StarDraw-rajz"@hu ;
+  skos:prefLabel "StarDraw-teckning"@sv ;
+  skos:prefLabel "StarDraw-teikning"@nn ;
+  skos:prefLabel "dessin StarDraw"@fr ;
+  skos:prefLabel "Σχέδιο StarDraw"@el .
+
+media-type:application_vndstardivisionimpress a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.impress" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Cyflwyniad StarImpress"@cy ;
+  skos:prefLabel "Prezentace StarImpress"@cs ;
+  skos:prefLabel "StarImpress presentatie"@nl ;
+  skos:prefLabel "StarImpress presentation"@en ;
+  skos:prefLabel "StarImpress təqdimatı"@az ;
+  skos:prefLabel "StarImpress презентација"@sr ;
+  skos:prefLabel "StarImpress 프리젠테이션"@ko ;
+  skos:prefLabel "StarImpress-Präsentation"@de ;
+  skos:prefLabel "StarImpress-bemutató"@hu ;
+  skos:prefLabel "StarImpress-esitys"@fi ;
+  skos:prefLabel "StarImpress-presentasjon"@nn ;
+  skos:prefLabel "StarImpress-presentasjon"@no ;
+  skos:prefLabel "StarImpress-presentation"@sv ;
+  skos:prefLabel "présentation StarImpress"@fr ;
+  skos:prefLabel "Παρουσίαση StarImpress"@el .
+
+media-type:application_vndstardivisionmail a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.mail" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "StarMail email"@en ;
+  skos:prefLabel "StarMail-E-Mail"@de ;
+  skos:prefLabel "StarMail-melding"@no ;
+  skos:prefLabel "StarMail-tiedosto"@fi .
+
+media-type:application_vndstardivisionmath a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.math" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "StarMath formula"@en ;
+  skos:prefLabel "StarMath-Formel"@de ;
+  skos:prefLabel "StarMath-asiakirja"@fi ;
+  skos:prefLabel "StarMath-formel"@no .
+
+media-type:application_vndstardivisionwriter a skos:Concept ;
+  media-type:hasMediaType "application/vnd.stardivision.writer" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen StarWriter"@cy ;
+  skos:prefLabel "Dokument StarWriter"@cs ;
+  skos:prefLabel "StarWriter document"@en ;
+  skos:prefLabel "StarWriter document"@nl ;
+  skos:prefLabel "StarWriter document"@nn ;
+  skos:prefLabel "StarWriter sənədi"@az ;
+  skos:prefLabel "StarWriter документ"@sr ;
+  skos:prefLabel "StarWriter 문서"@ko ;
+  skos:prefLabel "StarWriter-Dokument"@de ;
+  skos:prefLabel "StarWriter-asiakirja"@fi ;
+  skos:prefLabel "StarWriter-dokument"@no ;
+  skos:prefLabel "StarWriter-dokument"@sv ;
+  skos:prefLabel "StarWriter-dokumentum"@hu ;
+  skos:prefLabel "document StarWriter"@fr ;
+  skos:prefLabel "Έγγραφο StarWriter"@el .
+
+media-type:application_vndsunxmlcalc a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.calc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Calc -taulukko"@fi ;
+  skos:prefLabel "OpenOffice.org Calc spreadsheet"@en ;
+  skos:prefLabel "OpenOffice.org Calc-Tabellendokumen"@de ;
+  skos:prefLabel "OpenOffice.org Calc-regneark"@no ;
+  skos:prefLabel "Λογιστικό φύλλο OpenOffice.org Calc"@el .
+
+media-type:application_vndsunxmlcalctemplate a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.calc.template" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Calc -taulukkomalli"@fi ;
+  skos:prefLabel "OpenOffice.org Calc spreadsheet template"@en ;
+  skos:prefLabel "OpenOffice.org Calc-Vorlage für Tabellendokument"@de ;
+  skos:prefLabel "OpenOffice.org Calc-regnearkmal"@no ;
+  skos:prefLabel "Πρότυπο λογιστικό φύλλο OpenOffice.org Calc"@el .
+
+media-type:application_vndsunxmldraw a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.draw" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Draw drawing"@en ;
+  skos:prefLabel "OpenOffice.org Draw-Zeichnung"@de ;
+  skos:prefLabel "OpenOffice.org Draw-tegning"@no ;
+  skos:prefLabel "OpenOffice.org-Draw -piirros"@fi .
+
+media-type:application_vndsunxmldrawtemplate a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.draw.template" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Draw -piirrosmalli"@fi ;
+  skos:prefLabel "OpenOffice.org Draw drawing template"@en ;
+  skos:prefLabel "OpenOffice.org Draw-tegningsmal"@no ;
+  skos:prefLabel "OpenOffice.org·Draw-Zeichnungsvorlage"@de .
+
+media-type:application_vndsunxmlimpress a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.impress" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Impress -esitys"@fi ;
+  skos:prefLabel "OpenOffice.org Impress presentation"@en ;
+  skos:prefLabel "OpenOffice.org Impress-presentasjon"@no ;
+  skos:prefLabel "OpenOffice.org Impress-presentation"@sv ;
+  skos:prefLabel "OpenOffice.org·Impress-Präsentation"@de ;
+  skos:prefLabel "Παρουσίαση OpenOffice.org Impress"@el .
+
+media-type:application_vndsunxmlimpresstemplate a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.impress.template" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Impress -esitysmalli"@fi ;
+  skos:prefLabel "OpenOffice.org Impress presentation template"@en ;
+  skos:prefLabel "OpenOffice.org Impress-presentasjonsmal"@no ;
+  skos:prefLabel "OpenOffice.org Impress-presentationsmall"@sv ;
+  skos:prefLabel "OpenOffice.org·Impress-Präsentationsvorlage"@de ;
+  skos:prefLabel "Πρότυπο Παρουσίασης OpenOffice.org Impress"@el .
+
+media-type:application_vndsunxmlmath a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.math" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Math formula"@en ;
+  skos:prefLabel "OpenOffice.org Math-asiakirja"@fi ;
+  skos:prefLabel "OpenOffice.org Math-dokument"@no ;
+  skos:prefLabel "OpenOffice.org·Math-Formel"@de .
+
+media-type:application_vndsunxmlwriter a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.writer" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Writer -asiakirja"@fi ;
+  skos:prefLabel "OpenOffice.org Writer document"@en ;
+  skos:prefLabel "OpenOffice.org Writer-dokument"@no ;
+  skos:prefLabel "OpenOffice.org Writer-dokument"@sv ;
+  skos:prefLabel "OpenOffice.org·Writer-Dokument"@de ;
+  skos:prefLabel "Έγγραφο OpenOffice.org Writer"@el .
+
+media-type:application_vndsunxmlwriterglobal a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.writer.global" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Globalt OpenOffice.org Writer-dokument"@no ;
+  skos:prefLabel "OpenOffice.org Writer global document"@en ;
+  skos:prefLabel "OpenOffice.org Writer-globaldokument"@sv ;
+  skos:prefLabel "OpenOffice.org·Writer-Globaldokument"@de ;
+  skos:prefLabel "yleinen OpenOffice.org Write -asiakirja"@fi .
+
+media-type:application_vndsunxmlwritertemplate a skos:Concept ;
+  media-type:hasMediaType "application/vnd.sun.xml.writer.template" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OpenOffice.org Writer -asiakirjamalli"@fi ;
+  skos:prefLabel "OpenOffice.org Writer document template"@en ;
+  skos:prefLabel "OpenOffice.org Writer-dokumentmal"@no ;
+  skos:prefLabel "OpenOffice.org·Writer-Dokumentenvorlage"@de ;
+  skos:prefLabel "Πρότυπο έγγραφο OpenOffice.org Writer"@el .
+
+media-type:application_vndwordperfect a skos:Concept ;
+  media-type:hasMediaType "application/vnd.wordperfect" ;
+  skos:exactMatch media-type:application_wordperfect ;
+  skos:exactMatch media-type:application_x-wordperfect ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen WordPerfect"@cy ;
+  skos:prefLabel "Dokument WordPerfect"@cs ;
+  skos:prefLabel "WordPerfect document"@en ;
+  skos:prefLabel "WordPerfect document"@nl ;
+  skos:prefLabel "WordPerfect sənədi"@az ;
+  skos:prefLabel "WordPerfect документ"@sr ;
+  skos:prefLabel "WordPerfect-Dokument"@de ;
+  skos:prefLabel "WordPerfect-asiakirja"@fi ;
+  skos:prefLabel "WordPerfect-dokument"@nn ;
+  skos:prefLabel "WordPerfect-dokument"@no ;
+  skos:prefLabel "WordPerfect-dokument"@sv ;
+  skos:prefLabel "WordPerfect-dokumentum"@hu ;
+  skos:prefLabel "document WordPerfect"@fr ;
+  skos:prefLabel "Έγγραφο WordPerfect"@el ;
+  skos:prefLabel "워드퍼펙트 문서"@ko .
+
+media-type:application_x-abiword a skos:Concept ;
+  media-type:hasMediaType "application/x-abiword" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AbiWord document"@en ;
+  skos:prefLabel "AbiWord-Dokument"@de ;
+  skos:prefLabel "AbiWord-asiakirja"@fi ;
+  skos:prefLabel "AbiWord-dokument"@no ;
+  skos:prefLabel "AbiWord-dokument"@sv ;
+  skos:prefLabel "Έγγραφο AbiWord"@el .
+
+media-type:application_x-amipro a skos:Concept ;
+  media-type:hasMediaType "application/x-amipro" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Lotus AmiPro"@cy ;
+  skos:prefLabel "Dokument Lotus AmiPro"@cs ;
+  skos:prefLabel "Lotus AmiPro -asiakirja"@fi ;
+  skos:prefLabel "Lotus AmiPro document"@en ;
+  skos:prefLabel "Lotus AmiPro document"@nl ;
+  skos:prefLabel "Lotus AmiPro sənədi"@az ;
+  skos:prefLabel "Lotus AmiPro 문서"@ko ;
+  skos:prefLabel "Lotus AmiPro-Dokument"@de ;
+  skos:prefLabel "Lotus AmiPro-dokument"@nn ;
+  skos:prefLabel "Lotus AmiPro-dokument"@no ;
+  skos:prefLabel "Lotus AmiPro-dokument"@sv ;
+  skos:prefLabel "Lotus AmiPro-dokumentum"@hu ;
+  skos:prefLabel "document Lotus AmiPro"@fr ;
+  skos:prefLabel "Έγγραφο Lotus AmiPro"@el ;
+  skos:prefLabel "Лотус АмиПро документ"@sr .
+
+media-type:application_x-applix-spreadsheet a skos:Concept ;
+  media-type:hasMediaType "application/x-applix-spreadsheet" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Applix Spreadsheets -taulukko"@fi ;
+  skos:prefLabel "Applix Spreadsheets spreadsheet"@en ;
+  skos:prefLabel "Applix Spreadsheets-Tabellendokument"@de ;
+  skos:prefLabel "Applix Spreadsheets-regneark"@no ;
+  skos:prefLabel "Λογιστικό φύλλο Applix Spreadsheets"@el .
+
+media-type:application_x-applix-word a skos:Concept ;
+  media-type:hasMediaType "application/x-applix-word" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Applix Word 문서"@ko ;
+  skos:prefLabel "Applix Words -asiakirja"@fi ;
+  skos:prefLabel "Applix Words document"@en ;
+  skos:prefLabel "Applix Words document"@nl ;
+  skos:prefLabel "Applix Words dokument"@nn ;
+  skos:prefLabel "Applix Words sənədi"@az ;
+  skos:prefLabel "Applix Words документ"@sr ;
+  skos:prefLabel "Applix Words-Dokument"@de ;
+  skos:prefLabel "Applix Words-dokument"@no ;
+  skos:prefLabel "Applix Words-dokument"@sv ;
+  skos:prefLabel "Applix Words-dokumentum"@hu ;
+  skos:prefLabel "Dogfen Applix Words"@cy ;
+  skos:prefLabel "Dokument Applix Words"@cs ;
+  skos:prefLabel "document Applix Words"@fr ;
+  skos:prefLabel "Έγγραφο Applix Words"@el .
+
+media-type:application_x-arc a skos:Concept ;
+  media-type:hasMediaType "application/x-arc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-archive a skos:Concept ;
+  media-type:hasMediaType "application/x-archive" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AR archive"@en ;
+  skos:prefLabel "AR-Archiv"@de ;
+  skos:prefLabel "AR-arkisto"@fi ;
+  skos:prefLabel "AR-arkiv"@no .
+
+media-type:application_x-arj a skos:Concept ;
+  media-type:hasMediaType "application/x-arj" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "ARJ archief"@nl ;
+  skos:prefLabel "ARJ archive"@en ;
+  skos:prefLabel "ARJ arxivi"@az ;
+  skos:prefLabel "ARJ архива"@sr ;
+  skos:prefLabel "ARJ 아카이브"@ko ;
+  skos:prefLabel "ARJ-Archiv"@de ;
+  skos:prefLabel "ARJ-archívum"@hu ;
+  skos:prefLabel "ARJ-arkisto"@fi ;
+  skos:prefLabel "ARJ-arkiv"@nn ;
+  skos:prefLabel "ARJ-arkiv"@no ;
+  skos:prefLabel "ARJ-arkiv"@sv ;
+  skos:prefLabel "Archif ARJ"@cy ;
+  skos:prefLabel "Archiv ARJ"@cs ;
+  skos:prefLabel "archive ARJ"@fr .
+
+media-type:application_x-asp a skos:Concept ;
+  media-type:hasMediaType "application/x-asp" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "ASP (active server page)"@hu ;
+  skos:prefLabel "Active server page"@cs ;
+  skos:prefLabel "Active-Server-Page-Seite"@de ;
+  skos:prefLabel "actieve server pagina"@nl ;
+  skos:prefLabel "active server page sənədi"@az ;
+  skos:prefLabel "active server page"@en ;
+  skos:prefLabel "active server page"@nn ;
+  skos:prefLabel "active server page"@no ;
+  skos:prefLabel "aktiivinen palvelinsivu"@fi ;
+  skos:prefLabel "aktiv serversida"@sv ;
+  skos:prefLabel "page active du serveur"@fr ;
+  skos:prefLabel "tudalen ASP"@cy ;
+  skos:prefLabel "Активна серверска страна"@sr ;
+  skos:prefLabel "액티브 서버 페이지"@ko .
+
+media-type:application_x-awk a skos:Concept ;
+  media-type:hasMediaType "application/x-awk" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AWK script"@en ;
+  skos:prefLabel "AWK script"@nl ;
+  skos:prefLabel "AWK skripti"@az ;
+  skos:prefLabel "AWK скрипта"@sr ;
+  skos:prefLabel "AWK 스크립트"@ko ;
+  skos:prefLabel "AWK-Skript"@de ;
+  skos:prefLabel "AWK-skript"@no ;
+  skos:prefLabel "AWK-skript"@sv ;
+  skos:prefLabel "AWK-skripti"@fi ;
+  skos:prefLabel "AWK-szkript"@hu ;
+  skos:prefLabel "Sgript AWK"@cy ;
+  skos:prefLabel "Skript AWK"@cs ;
+  skos:prefLabel "WAK-skript"@nn ;
+  skos:prefLabel "script AWK"@fr .
+
+media-type:application_x-bcpio a skos:Concept ;
+  media-type:hasMediaType "application/x-bcpio" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "BCPIO document"@en ;
+  skos:prefLabel "BCPIO document"@nl ;
+  skos:prefLabel "BCPIO sənədi"@az ;
+  skos:prefLabel "BCPIO документ"@sr ;
+  skos:prefLabel "BCPIO 문서"@ko ;
+  skos:prefLabel "BCPIO-Dokument"@de ;
+  skos:prefLabel "BCPIO-asiakirja"@fi ;
+  skos:prefLabel "BCPIO-dokument"@nn ;
+  skos:prefLabel "BCPIO-dokument"@no ;
+  skos:prefLabel "BCPIO-dokument"@sv ;
+  skos:prefLabel "BCPIO-dokumentum"@hu ;
+  skos:prefLabel "Dogfen BCPIO"@cy ;
+  skos:prefLabel "Dokument BCPIO"@cs ;
+  skos:prefLabel "document BCPIO"@fr ;
+  skos:prefLabel "Έγγραφο BCPIO"@el .
+
+media-type:application_x-bittorrent a skos:Concept ;
+  media-type:hasMediaType "application/x-bittorrent" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "BitTorrent seed faylı"@az ;
+  skos:prefLabel "BitTorrent seed file"@en ;
+  skos:prefLabel "BitTorrent zaad-bestand"@nl ;
+  skos:prefLabel "BitTorrent 시드 파일"@ko ;
+  skos:prefLabel "BitTorrent-Seed-Datei"@de ;
+  skos:prefLabel "BitTorrent-fröfil"@sv ;
+  skos:prefLabel "BitTorrent-magfájl"@hu ;
+  skos:prefLabel "BitTorrent-siementiedosto"@fi ;
+  skos:prefLabel "Ffeil hadu BitTorrent"@cy ;
+  skos:prefLabel "Fil med utgangsverdi for BitTorrent"@no ;
+  skos:prefLabel "Nedlastingsfil for BitTorrent"@nn ;
+  skos:prefLabel "Soubor BitTorrent"@cs ;
+  skos:prefLabel "fichier racine BitTorrent"@fr ;
+  skos:prefLabel "Αρχείο BitTorrent seed"@el ;
+  skos:prefLabel "Датотека са БитТорентовим полазиштима"@sr .
+
+media-type:application_x-blender a skos:Concept ;
+  media-type:hasMediaType "application/x-blender" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Blender scene"@en ;
+  skos:prefLabel "Blender-Szene"@de ;
+  skos:prefLabel "Blender-scene"@no ;
+  skos:prefLabel "Blender-tiedosto"@fi .
+
+media-type:application_x-bzip a skos:Concept ;
+  media-type:hasMediaType "application/x-bzip" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "bzip archive"@en ;
+  skos:prefLabel "bzip-Archiv"@de ;
+  skos:prefLabel "bzip-arkisto"@fi ;
+  skos:prefLabel "bzip-arkiv"@no .
+
+media-type:application_x-bzip-compressed-tar a skos:Concept ;
+  media-type:hasMediaType "application/x-bzip-compressed-tar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tar archive (bzip-compressed)"@en ;
+  skos:prefLabel "tar-Archiv (bzip-komprimiert)"@de ;
+  skos:prefLabel "tar-arkisto (bzip-pakattu)"@fi ;
+  skos:prefLabel "tar-arkiv (bzip-komprimert)"@no .
+
+media-type:application_x-cd-image a skos:Concept ;
+  media-type:hasMediaType "application/x-cd-image" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CD-Roh-Image"@de ;
+  skos:prefLabel "raaka CD-vedos"@fi ;
+  skos:prefLabel "raw CD image"@en ;
+  skos:prefLabel "rått CD-bilde"@no .
+
+media-type:application_x-cgi a skos:Concept ;
+  media-type:hasMediaType "application/x-cgi" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CGI script"@en ;
+  skos:prefLabel "CGI-Skript"@de ;
+  skos:prefLabel "CGI-skript"@no ;
+  skos:prefLabel "CGI-skripti"@fi .
+
+media-type:application_x-chess-pgn a skos:Concept ;
+  media-type:hasMediaType "application/x-chess-pgn" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Gêm wyddbwyll PGN"@cy ;
+  skos:prefLabel "PGN chess game"@en ;
+  skos:prefLabel "PGN schaakspel"@nl ;
+  skos:prefLabel "PGN skakspil"@no ;
+  skos:prefLabel "PGN şahmat oyunu"@az ;
+  skos:prefLabel "PGN шаховска игра"@sr ;
+  skos:prefLabel "PGN 체스게임"@ko ;
+  skos:prefLabel "PGN-Schachspiel"@de ;
+  skos:prefLabel "PGN-sakkjátszma"@hu ;
+  skos:prefLabel "PGN-schackparti"@sv ;
+  skos:prefLabel "PGN-sjakkspel"@nn ;
+  skos:prefLabel "PGN-šakkipeli"@fi ;
+  skos:prefLabel "jeu d'échec PGN"@fr ;
+  skos:prefLabel "Šachová hra PGN"@cs ;
+  skos:prefLabel "Παρτίδα σκακιού PGN"@el .
+
+media-type:application_x-class-file a skos:Concept ;
+  media-type:hasMediaType "application/x-class-file" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Côd beit Java"@cy ;
+  skos:prefLabel "Java bajtový kód"@cs ;
+  skos:prefLabel "Java bayt kodu"@az ;
+  skos:prefLabel "Java byte code"@en ;
+  skos:prefLabel "Java byte code"@nl ;
+  skos:prefLabel "Java бајтни кôд"@sr ;
+  skos:prefLabel "Java-Bytecode"@de ;
+  skos:prefLabel "Java-bytekod"@sv ;
+  skos:prefLabel "Java-bytekode"@no ;
+  skos:prefLabel "Java-bájtkód"@hu ;
+  skos:prefLabel "Java-tavukoodi"@fi ;
+  skos:prefLabel "Jave byte-kode"@nn ;
+  skos:prefLabel "code byte Java"@fr ;
+  skos:prefLabel "Κώδικας Java byte"@el ;
+  skos:prefLabel "자바 바이트코드"@ko .
+
+media-type:application_x-compress a skos:Concept ;
+  media-type:hasMediaType "application/x-compress" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "UNIX-compressed file"@en ;
+  skos:prefLabel "UNIX-komprimert fil"@no ;
+  skos:prefLabel "UNIX-komprimierte Datei"@de ;
+  skos:prefLabel "UNIX-pakattu tiedosto"@fi .
+
+media-type:application_x-compressed-tar a skos:Concept ;
+  media-type:hasMediaType "application/x-compressed-tar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tar archive (gzip-compressed)"@en ;
+  skos:prefLabel "tar-Archiv (gzip-komprimiert)"@de ;
+  skos:prefLabel "tar-arkisto (gzip-pakattu)"@fi ;
+  skos:prefLabel "tar-arkiv (gzip-komprimert)"@no .
+
+media-type:application_x-core a skos:Concept ;
+  media-type:hasMediaType "application/x-core" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Daten zu Programmabsturz"@de ;
+  skos:prefLabel "ohjelman kaatumistiedot"@fi ;
+  skos:prefLabel "program crash data"@en .
+
+media-type:application_x-cpio a skos:Concept ;
+  media-type:hasMediaType "application/x-cpio" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif CPIO"@cy ;
+  skos:prefLabel "Archiv CPIO"@cs ;
+  skos:prefLabel "CPIO archief"@nl ;
+  skos:prefLabel "CPIO archive"@en ;
+  skos:prefLabel "CPIO arxivi"@az ;
+  skos:prefLabel "CPIO архива"@sr ;
+  skos:prefLabel "CPIO 아카이브"@ko ;
+  skos:prefLabel "CPIO-Archiv"@de ;
+  skos:prefLabel "CPIO-archívum"@hu ;
+  skos:prefLabel "CPIO-arkisto"@fi ;
+  skos:prefLabel "CPIO-arkiv"@nn ;
+  skos:prefLabel "CPIO-arkiv"@no ;
+  skos:prefLabel "CPIO-arkiv"@sv ;
+  skos:prefLabel "archive CPIO"@fr .
+
+media-type:application_x-cpio-compressed a skos:Concept ;
+  media-type:hasMediaType "application/x-cpio-compressed" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif CPIO (gywasgwyd drwy gzip)"@cy ;
+  skos:prefLabel "Archiv CPIO (komprimovaný gzip)"@cs ;
+  skos:prefLabel "CPIO archief (gzip-ingepakt)"@nl ;
+  skos:prefLabel "CPIO archive (gzip-compressed)"@en ;
+  skos:prefLabel "CPIO arxivi (gzip ilə sıxışdırılmış)"@az ;
+  skos:prefLabel "CPIO архива (компресована gzip-ом)"@sr ;
+  skos:prefLabel "CPIO 아카이브 (gzip압축)"@ko ;
+  skos:prefLabel "CPIO-Archiv (gzip-komprimiert)"@de ;
+  skos:prefLabel "CPIO-archívum (Gzip-pel tömörítve)"@hu ;
+  skos:prefLabel "CPIO-arkisto (gzip-pakattu)"@fi ;
+  skos:prefLabel "CPIO-arkiv (gzip-komprimerat)"@sv ;
+  skos:prefLabel "CPIO-arkiv (gzip-komprimert)"@no ;
+  skos:prefLabel "CPIO-arkiv (gzip-pakka)"@nn ;
+  skos:prefLabel "archive CPIO (compressé gzip)"@fr .
+
+media-type:application_x-csh a skos:Concept ;
+  media-type:hasMediaType "application/x-csh" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "C qabıq skripti"@az ;
+  skos:prefLabel "C shell script"@en ;
+  skos:prefLabel "C shell script"@nl ;
+  skos:prefLabel "C shell-parancsfájl"@hu ;
+  skos:prefLabel "C скрипта окружења"@sr ;
+  skos:prefLabel "C-Shell-Skript"@de ;
+  skos:prefLabel "C-skallskript"@no ;
+  skos:prefLabel "C-skalskript"@nn ;
+  skos:prefLabel "Csh-komentotiedosto"@fi ;
+  skos:prefLabel "C쉘 스크립트"@ko ;
+  skos:prefLabel "Sgript plisgyn C"@cy ;
+  skos:prefLabel "Skalskript (csh)"@sv ;
+  skos:prefLabel "Skript C shellu"@cs ;
+  skos:prefLabel "script C shell"@fr ;
+  skos:prefLabel "Πρόγραμμα εντολών φλοιού C"@el .
+
+media-type:application_x-dbase a skos:Concept ;
+  media-type:hasMediaType "application/x-dbase" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen dBASE"@cy ;
+  skos:prefLabel "Dokument dBASE"@cs ;
+  skos:prefLabel "dBASE document"@en ;
+  skos:prefLabel "dBASE document"@nl ;
+  skos:prefLabel "dBASE sənədi"@az ;
+  skos:prefLabel "dBASE документ"@sr ;
+  skos:prefLabel "dBASE 문서"@ko ;
+  skos:prefLabel "dBASE-Dokument"@de ;
+  skos:prefLabel "dBASE-asiakirja"@fi ;
+  skos:prefLabel "dBASE-dokument"@nn ;
+  skos:prefLabel "dBASE-dokument"@no ;
+  skos:prefLabel "dBASE-dokument"@sv ;
+  skos:prefLabel "dBASE-dokumentum"@hu ;
+  skos:prefLabel "document dBASE"@fr ;
+  skos:prefLabel "Έγγραφο dBASE"@el .
+
+media-type:application_x-dbm a skos:Concept ;
+  media-type:hasMediaType "application/x-dbm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-dc-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-dc-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dreamcast ROM"@el ;
+  skos:prefLabel "Dreamcast ROM"@en ;
+  skos:prefLabel "Dreamcast-ROM"@de ;
+  skos:prefLabel "Dreamcast-ROM"@fi ;
+  skos:prefLabel "Dreamcast-ROM"@no .
+
+media-type:application_x-deb a skos:Concept ;
+  media-type:hasMediaType "application/x-deb" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Balíček Debianu"@cs ;
+  skos:prefLabel "Debian package"@en ;
+  skos:prefLabel "Debian paketi"@az ;
+  skos:prefLabel "Debian pakke"@nn ;
+  skos:prefLabel "Debian pakke"@no ;
+  skos:prefLabel "Debian pakket"@nl ;
+  skos:prefLabel "Debian пакет"@sr ;
+  skos:prefLabel "Debian-Paket"@de ;
+  skos:prefLabel "Debian-csomag"@hu ;
+  skos:prefLabel "Debian-paketti"@fi ;
+  skos:prefLabel "Debianpaket"@sv ;
+  skos:prefLabel "Pecyn Debian"@cy ;
+  skos:prefLabel "package Debian"@fr ;
+  skos:prefLabel "Πακέτο Debian"@el ;
+  skos:prefLabel "데비안 꾸러미"@ko .
+
+media-type:application_x-designer a skos:Concept ;
+  media-type:hasMediaType "application/x-designer" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "QT Designer-Datei"@de ;
+  skos:prefLabel "Qt Designer -tiedosto"@fi ;
+  skos:prefLabel "Qt Designer file"@en ;
+  skos:prefLabel "Qt Designer-fil"@no ;
+  skos:prefLabel "Qt Designer-fil"@sv ;
+  skos:prefLabel "Αρχείο Qt Designer"@el .
+
+media-type:application_x-desktop a skos:Concept ;
+  media-type:hasMediaType "application/x-desktop" ;
+  skos:broader media-type:text_plain ;
+  skos:exactMatch media-type:application_x-gnome-app-info ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Desktop-Konfigurationsdatei"@de ;
+  skos:prefLabel "desktop configuration file"@en ;
+  skos:prefLabel "konfigurasjonsfil for skrivebordet"@no ;
+  skos:prefLabel "työpöydän asetustiedosto"@fi .
+
+media-type:application_x-dia-diagram a skos:Concept ;
+  media-type:hasMediaType "application/x-dia-diagram" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dia diagram"@en ;
+  skos:prefLabel "Dia diagram"@nl ;
+  skos:prefLabel "Dia diagram"@nn ;
+  skos:prefLabel "Dia diaqramı"@az ;
+  skos:prefLabel "Dia 도표"@ko ;
+  skos:prefLabel "Dia-Diagramm"@de ;
+  skos:prefLabel "Dia-diagram"@hu ;
+  skos:prefLabel "Dia-diagram"@no ;
+  skos:prefLabel "Dia-diagram"@sv ;
+  skos:prefLabel "Dia-kaavio"@fi ;
+  skos:prefLabel "Diagram Dia"@cs ;
+  skos:prefLabel "Diagram Dia"@cy ;
+  skos:prefLabel "diagramme Dia"@fr ;
+  skos:prefLabel "Διάγραμμα Dia"@el ;
+  skos:prefLabel "Диа дијаграм"@sr .
+
+media-type:application_x-dvi a skos:Concept ;
+  media-type:hasMediaType "application/x-dvi" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "TeX DVI -asiakirja"@fi ;
+  skos:prefLabel "TeX DVI document"@en ;
+  skos:prefLabel "TeX DVI-dokument"@no ;
+  skos:prefLabel "TeX-DVI-Dokument"@de .
+
+media-type:application_x-e-theme a skos:Concept ;
+  media-type:hasMediaType "application/x-e-theme" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Enlightenment tema"@no ;
+  skos:prefLabel "Enlightenment thema"@nl ;
+  skos:prefLabel "Enlightenment theme"@en ;
+  skos:prefLabel "Enlightenment örtüyü"@az ;
+  skos:prefLabel "Enlightenment тема"@sr ;
+  skos:prefLabel "Enlightenment-Thema"@de ;
+  skos:prefLabel "Enlightenment-teema"@fi ;
+  skos:prefLabel "Enlightenment-tema"@nn ;
+  skos:prefLabel "Enlightenment-tema"@sv ;
+  skos:prefLabel "Enlightenment-téma"@hu ;
+  skos:prefLabel "Thema Enlightenment"@cy ;
+  skos:prefLabel "Téma pro Enlightenment"@cs ;
+  skos:prefLabel "thème « Enlightenment »"@fr ;
+  skos:prefLabel "Θέμα Enlightenment"@el ;
+  skos:prefLabel "인라이트먼트 테마"@ko .
+
+media-type:application_x-egon a skos:Concept ;
+  media-type:hasMediaType "application/x-egon" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Egon Animator -animaatio"@fi ;
+  skos:prefLabel "Egon Animator animation"@en ;
+  skos:prefLabel "Egon Animator-Animation"@de ;
+  skos:prefLabel "Egon animator-animasjon"@no .
+
+media-type:application_x-executable a skos:Concept ;
+  media-type:hasMediaType "application/x-executable" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Programm"@de ;
+  skos:prefLabel "executable"@en ;
+  skos:prefLabel "kjørbar"@no ;
+  skos:prefLabel "körbar"@sv ;
+  skos:prefLabel "suoritettava ohjelma"@fi ;
+  skos:prefLabel "Εκτελέσιμο"@el .
+
+media-type:application_x-font-afm a skos:Concept ;
+  media-type:hasMediaType "application/x-font-afm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Adobe font metrics"@en ;
+  skos:prefLabel "Adobe lettertype-metrieken"@nl ;
+  skos:prefLabel "Adobe skrifttypefil"@no ;
+  skos:prefLabel "Adobe skrifttypemetrikk"@nn ;
+  skos:prefLabel "Adobe yazı növü metrikləri"@az ;
+  skos:prefLabel "Adobe метрика фонта"@sr ;
+  skos:prefLabel "Adobe 글꼴 메트릭스"@ko ;
+  skos:prefLabel "Adobe-Schriftmetriken"@de ;
+  skos:prefLabel "Adobe-betűmetrika"@hu ;
+  skos:prefLabel "Adobe-kirjasinmitat"@fi ;
+  skos:prefLabel "Adobe-typsnittsmetrik"@sv ;
+  skos:prefLabel "Metrigau Ffont Adobe"@cy ;
+  skos:prefLabel "Metrika písma Adobe"@cs ;
+  skos:prefLabel "métriques de fonte Adobe"@fr .
+
+media-type:application_x-font-bdf a skos:Concept ;
+  media-type:hasMediaType "application/x-font-bdf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "BDF font"@en ;
+  skos:prefLabel "BDF lettertype"@nl ;
+  skos:prefLabel "BDF yazı növü"@az ;
+  skos:prefLabel "BDF фонт"@sr ;
+  skos:prefLabel "BDF 글꼴"@ko ;
+  skos:prefLabel "BDF-Schrift"@de ;
+  skos:prefLabel "BDF-betűkészlet"@hu ;
+  skos:prefLabel "BDF-kirjasin"@fi ;
+  skos:prefLabel "BDF-skrifttype"@nn ;
+  skos:prefLabel "BDF-skrifttype"@no ;
+  skos:prefLabel "BDF-typsnitt"@sv ;
+  skos:prefLabel "Ffont BDF"@cy ;
+  skos:prefLabel "Písmo BDF"@cs ;
+  skos:prefLabel "fonte BDF"@fr ;
+  skos:prefLabel "Γραμματοσειρά BDF"@el .
+
+media-type:application_x-font-dos a skos:Concept ;
+  media-type:hasMediaType "application/x-font-dos" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DOS font"@en ;
+  skos:prefLabel "DOS lettertype"@nl ;
+  skos:prefLabel "DOS yazı növü"@az ;
+  skos:prefLabel "DOS фонт"@sr ;
+  skos:prefLabel "DOS-Schrift"@de ;
+  skos:prefLabel "DOS-betűkészlet"@hu ;
+  skos:prefLabel "DOS-kirjasin"@fi ;
+  skos:prefLabel "DOS-skrifttype"@nn ;
+  skos:prefLabel "DOS-skrifttype"@no ;
+  skos:prefLabel "DOS-typsnitt"@sv ;
+  skos:prefLabel "Ffont DOS"@cy ;
+  skos:prefLabel "Písmo pro DOS"@cs ;
+  skos:prefLabel "fonte DOS"@fr ;
+  skos:prefLabel "Γραμματοσειρά DOS"@el ;
+  skos:prefLabel "도스 글꼴"@ko .
+
+media-type:application_x-font-framemaker a skos:Concept ;
+  media-type:hasMediaType "application/x-font-framemaker" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Adobe FrameMaker -kirjasin"@fi ;
+  skos:prefLabel "Adobe FrameMaker font"@en ;
+  skos:prefLabel "Adobe FrameMaker lettertype"@nl ;
+  skos:prefLabel "Adobe FrameMaker skrifttype"@nn ;
+  skos:prefLabel "Adobe FrameMaker skrifttype"@no ;
+  skos:prefLabel "Adobe FrameMaker yazı növü"@az ;
+  skos:prefLabel "Adobe FrameMaker фонт"@sr ;
+  skos:prefLabel "Adobe FrameMaker 글꼴"@ko ;
+  skos:prefLabel "Adobe FrameMaker-Schrift"@de ;
+  skos:prefLabel "Adobe FrameMaker-betűkészlet"@hu ;
+  skos:prefLabel "Adobe FrameMaker-typsnitt"@sv ;
+  skos:prefLabel "Ffont Adobe FrameMaker"@cy ;
+  skos:prefLabel "Písmo Adobe FrameMaker"@cs ;
+  skos:prefLabel "fonte Adobe FrameMaker"@fr ;
+  skos:prefLabel "Γραμματοσειρά Adobe FrameMaker"@el .
+
+media-type:application_x-font-libgrx a skos:Concept ;
+  media-type:hasMediaType "application/x-font-libgrx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont LIBGRX"@cy ;
+  skos:prefLabel "LIBGRX font"@en ;
+  skos:prefLabel "LIBGRX lettertype"@nl ;
+  skos:prefLabel "LIBGRX skrifttype"@nn ;
+  skos:prefLabel "LIBGRX yazı növü"@az ;
+  skos:prefLabel "LIBGRX фонт"@sr ;
+  skos:prefLabel "LIBGRX 글꼴"@ko ;
+  skos:prefLabel "LIBGRX-Schrift"@de ;
+  skos:prefLabel "LIBGRX-betűkészlet"@hu ;
+  skos:prefLabel "LIBGRX-kirjasin"@fi ;
+  skos:prefLabel "LIBGRX-skrifttype"@no ;
+  skos:prefLabel "LIBGRX-typsnitt"@sv ;
+  skos:prefLabel "Písmo LIBGRX"@cs ;
+  skos:prefLabel "fonte LIBGRX"@fr ;
+  skos:prefLabel "Γραμματοσειρά LIBGRX"@el .
+
+media-type:application_x-font-linux-psf a skos:Concept ;
+  media-type:hasMediaType "application/x-font-linux-psf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont Linux PSF"@cy ;
+  skos:prefLabel "Linux PSF -konsolikirjasin"@fi ;
+  skos:prefLabel "Linux PSF console font"@en ;
+  skos:prefLabel "Linux PSF console lettertype"@nl ;
+  skos:prefLabel "Linux PSF konsol yazı növü"@az ;
+  skos:prefLabel "Linux PSF konsoll-skrifttype"@nn ;
+  skos:prefLabel "Linux PSF konsollskrifttype"@no ;
+  skos:prefLabel "Linux PSF konzolos betűkészlet"@hu ;
+  skos:prefLabel "Linux PSF-konsolltypsnitt"@sv ;
+  skos:prefLabel "Linux-PSF-Konsolenschrift"@de ;
+  skos:prefLabel "Písmo PSF pro konzolu Linuxu"@cs ;
+  skos:prefLabel "fonte console Linux PSF"@fr ;
+  skos:prefLabel "Γραμματοσειρά κονσόλας PSF Linux"@el ;
+  skos:prefLabel "Линукс PSF конзолни фонт"@sr ;
+  skos:prefLabel "리눅스 PSF 콘솔 글꼴"@ko .
+
+media-type:application_x-font-otf a skos:Concept ;
+  media-type:hasMediaType "application/x-font-otf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont OpenType"@cy ;
+  skos:prefLabel "OpenType font"@en ;
+  skos:prefLabel "OpenType lettertype"@nl ;
+  skos:prefLabel "OpenType yazı növü"@az ;
+  skos:prefLabel "OpenType фонт"@sr ;
+  skos:prefLabel "OpenType-Schrift"@de ;
+  skos:prefLabel "OpenType-betűkészlet"@hu ;
+  skos:prefLabel "OpenType-kirjasin"@fi ;
+  skos:prefLabel "OpenType-skrifttype"@nn ;
+  skos:prefLabel "OpenType-skrifttype"@no ;
+  skos:prefLabel "OpenType-typsnitt"@sv ;
+  skos:prefLabel "Písmo OpenType"@cs ;
+  skos:prefLabel "fonte OpenType"@fr ;
+  skos:prefLabel "Γραμματοσειρά OpenType "@el ;
+  skos:prefLabel "트루타입 글꼴"@ko .
+
+media-type:application_x-font-pcf a skos:Concept ;
+  media-type:hasMediaType "application/x-font-pcf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont PCF"@cy ;
+  skos:prefLabel "PCF font"@en ;
+  skos:prefLabel "PCF lettertype"@nl ;
+  skos:prefLabel "PCF yazı növü"@az ;
+  skos:prefLabel "PCF фонт"@sr ;
+  skos:prefLabel "PCF 글꼴"@ko ;
+  skos:prefLabel "PCF-Schrift"@de ;
+  skos:prefLabel "PCF-betűkészlet"@hu ;
+  skos:prefLabel "PCF-kirjasin"@fi ;
+  skos:prefLabel "PCF-skrifttype"@nn ;
+  skos:prefLabel "PCF-skrifttype"@no ;
+  skos:prefLabel "PCF-typsnitt"@sv ;
+  skos:prefLabel "Písmo PCF"@cs ;
+  skos:prefLabel "fonte PCF"@fr ;
+  skos:prefLabel "Γραμματοσειρά PCF"@el .
+
+media-type:application_x-font-speedo a skos:Concept ;
+  media-type:hasMediaType "application/x-font-speedo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont Speedo"@cy ;
+  skos:prefLabel "Písmo Speedo"@cs ;
+  skos:prefLabel "Speedo font"@en ;
+  skos:prefLabel "Speedo lettertype"@nl ;
+  skos:prefLabel "Speedo yazı növü"@az ;
+  skos:prefLabel "Speedo фонт"@sr ;
+  skos:prefLabel "Speedo 글꼴"@ko ;
+  skos:prefLabel "Speedo-Schrift"@de ;
+  skos:prefLabel "Speedo-betűkészlet"@hu ;
+  skos:prefLabel "Speedo-kirjasin"@fi ;
+  skos:prefLabel "Speedo-skrifttype"@nn ;
+  skos:prefLabel "Speedo-skrifttype"@no ;
+  skos:prefLabel "Speedo-typsnitt"@sv ;
+  skos:prefLabel "fonte Speedo"@fr ;
+  skos:prefLabel "Γραμματοσειρά Speedo"@el .
+
+media-type:application_x-font-sunos-news a skos:Concept ;
+  media-type:hasMediaType "application/x-font-sunos-news" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont SunOS News"@cy ;
+  skos:prefLabel "Písmo SunOS News"@cs ;
+  skos:prefLabel "SunOS NEWS-skrifttype"@nn ;
+  skos:prefLabel "SunOS News -kirjasin"@fi ;
+  skos:prefLabel "SunOS News font"@en ;
+  skos:prefLabel "SunOS News yazı növü"@az ;
+  skos:prefLabel "SunOS News фонт"@sr ;
+  skos:prefLabel "SunOS News 글꼴"@ko ;
+  skos:prefLabel "SunOS News-Schrift"@de ;
+  skos:prefLabel "SunOS News-betűkészlet"@hu ;
+  skos:prefLabel "SunOS News-skrifttype"@no ;
+  skos:prefLabel "SunOS News-typsnitt"@sv ;
+  skos:prefLabel "SunOS Nieuws lettertype"@nl ;
+  skos:prefLabel "fonte SunOS News"@fr ;
+  skos:prefLabel "Γραμματοσειρά SunOS News"@el .
+
+media-type:application_x-font-tex a skos:Concept ;
+  media-type:hasMediaType "application/x-font-tex" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont TeX"@cy ;
+  skos:prefLabel "Písmo TeX"@cs ;
+  skos:prefLabel "TeX font"@en ;
+  skos:prefLabel "TeX lettertype"@nl ;
+  skos:prefLabel "TeX yazı növü"@az ;
+  skos:prefLabel "TeX 글꼴"@ko ;
+  skos:prefLabel "TeX-Schrift"@de ;
+  skos:prefLabel "TeX-betűkészlet"@hu ;
+  skos:prefLabel "TeX-kirjasin"@fi ;
+  skos:prefLabel "TeX-skrift"@no ;
+  skos:prefLabel "TeX-skrifttype"@nn ;
+  skos:prefLabel "TeX-typsnitt"@sv ;
+  skos:prefLabel "fonte TeX"@fr ;
+  skos:prefLabel "Γραμματοσειρά TeX"@el ;
+  skos:prefLabel "ТеХ фонт"@sr .
+
+media-type:application_x-font-tex-tfm a skos:Concept ;
+  media-type:hasMediaType "application/x-font-tex-tfm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Metrigau Ffont TeX"@cy ;
+  skos:prefLabel "Metrika písma TeX"@cs ;
+  skos:prefLabel "TeX font metrics"@en ;
+  skos:prefLabel "TeX lettertype-metrieken"@nl ;
+  skos:prefLabel "TeX skrifttypemetrikk"@nn ;
+  skos:prefLabel "TeX skrifttypemetrikk"@no ;
+  skos:prefLabel "TeX yazı növü metrikləri"@az ;
+  skos:prefLabel "TeX-Schriftmetriken"@de ;
+  skos:prefLabel "TeX-betűmetrika"@hu ;
+  skos:prefLabel "TeX-kirjasinmitat"@fi ;
+  skos:prefLabel "TeX-typsnittsmetrik"@sv ;
+  skos:prefLabel "Tex 글꼴 메트릭스"@ko ;
+  skos:prefLabel "métriques de fonte TeX"@fr ;
+  skos:prefLabel "ТеХ метрика фонта"@sr .
+
+media-type:application_x-font-ttf a skos:Concept ;
+  media-type:hasMediaType "application/x-font-ttf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "TrueType font"@en ;
+  skos:prefLabel "TrueType-Schrift"@de ;
+  skos:prefLabel "TrueType-skrift"@no ;
+  skos:prefLabel "Truetype-kirjasin"@fi ;
+  skos:prefLabel "Γραμματοσειρά TrueType"@el .
+
+media-type:application_x-font-type1 a skos:Concept ;
+  media-type:hasMediaType "application/x-font-type1" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Schrift"@de ;
+  skos:prefLabel "font"@en ;
+  skos:prefLabel "kirjasin"@fi ;
+  skos:prefLabel "skrift"@no ;
+  skos:prefLabel "typsnitt"@sv ;
+  skos:prefLabel "γραμματοσειρά"@el .
+
+media-type:application_x-font-vfont a skos:Concept ;
+  media-type:hasMediaType "application/x-font-vfont" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffont V"@cy ;
+  skos:prefLabel "Písmo V"@cs ;
+  skos:prefLabel "V font"@en ;
+  skos:prefLabel "V lettertype"@nl ;
+  skos:prefLabel "V yazı növü"@az ;
+  skos:prefLabel "V фонт"@sr ;
+  skos:prefLabel "V 글꼴"@ko ;
+  skos:prefLabel "V-Schrift"@de ;
+  skos:prefLabel "V-betűkészlet"@hu ;
+  skos:prefLabel "V-kirjasin"@fi ;
+  skos:prefLabel "V-skrift"@no ;
+  skos:prefLabel "V-skrifttype"@nn ;
+  skos:prefLabel "V-typsnitt"@sv ;
+  skos:prefLabel "fonte V"@fr ;
+  skos:prefLabel "Γραμματοσειρά V"@el .
+
+media-type:application_x-frame a skos:Concept ;
+  media-type:hasMediaType "application/x-frame" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-gameboy-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-gameboy-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Game Boy -ROM"@fi ;
+  skos:prefLabel "Game Boy ROM"@el ;
+  skos:prefLabel "Game Boy ROM"@en ;
+  skos:prefLabel "Game Boy-ROM"@de ;
+  skos:prefLabel "Game Boy-ROM"@no .
+
+media-type:application_x-gdbm a skos:Concept ;
+  media-type:hasMediaType "application/x-gdbm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-genesis-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-genesis-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Genesis ROM"@el ;
+  skos:prefLabel "Genesis ROM"@en ;
+  skos:prefLabel "Genesis-ROM"@de ;
+  skos:prefLabel "Genesis-ROM"@fi ;
+  skos:prefLabel "Genesis-ROM"@no .
+
+media-type:application_x-gettext-translation a skos:Concept ;
+  media-type:hasMediaType "application/x-gettext-translation" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "käännetyt viestit (koneluettava)"@fi ;
+  skos:prefLabel "oversatte meldinger (maskinlesbar)"@no ;
+  skos:prefLabel "translated messages (machine-readable)"@en ;
+  skos:prefLabel "übersetzte Meldungen (maschinenlesbar)"@de .
+
+media-type:application_x-glade a skos:Concept ;
+  media-type:hasMediaType "application/x-glade" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Glade layihəsi"@az ;
+  skos:prefLabel "Glade project"@en ;
+  skos:prefLabel "Glade project"@nl ;
+  skos:prefLabel "Glade prosjekt"@nn ;
+  skos:prefLabel "Glade prosjekt"@no ;
+  skos:prefLabel "Glade 프로젝트"@ko ;
+  skos:prefLabel "Glade-Projekt"@de ;
+  skos:prefLabel "Glade-projekt"@hu ;
+  skos:prefLabel "Glade-projekt"@sv ;
+  skos:prefLabel "Glade-projekti"@fi ;
+  skos:prefLabel "Projekt Glade"@cs ;
+  skos:prefLabel "Prosiect Glade"@cy ;
+  skos:prefLabel "projet Glade"@fr ;
+  skos:prefLabel "Глејд пројекат"@sr .
+
+media-type:application_x-gmc-link a skos:Concept ;
+  media-type:hasMediaType "application/x-gmc-link" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Cyswllt GMC"@cy ;
+  skos:prefLabel "GMC koppeling"@nl ;
+  skos:prefLabel "GMC körpüsü"@az ;
+  skos:prefLabel "GMC link"@en ;
+  skos:prefLabel "GMC веза"@sr ;
+  skos:prefLabel "GMC 링크"@ko ;
+  skos:prefLabel "GMC-Link"@de ;
+  skos:prefLabel "GMC-lenke"@no ;
+  skos:prefLabel "GMC-lenkje"@nn ;
+  skos:prefLabel "GMC-link"@hu ;
+  skos:prefLabel "GMC-linkki"@fi ;
+  skos:prefLabel "GMC-länk"@sv ;
+  skos:prefLabel "Odkaz GMC"@cs ;
+  skos:prefLabel "lien GMC"@fr ;
+  skos:prefLabel "Σύνδεσμος GMC"@el .
+
+media-type:application_x-gnucash a skos:Concept ;
+  media-type:hasMediaType "application/x-gnucash" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GnuCash spreadsheet"@en ;
+  skos:prefLabel "GnuCash-Tabellendokument"@de ;
+  skos:prefLabel "GnuCash-regneark"@no ;
+  skos:prefLabel "GnuCash-taulukko"@fi ;
+  skos:prefLabel "Λογιστικό φύλλο Gnucash"@el .
+
+media-type:application_x-gnumeric a skos:Concept ;
+  media-type:hasMediaType "application/x-gnumeric" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Gnumeric spreadsheet"@en ;
+  skos:prefLabel "Gnumeric-Tabellendokument"@de ;
+  skos:prefLabel "Gnumeric-kalkylblad"@sv ;
+  skos:prefLabel "Gnumeric-regneark"@no ;
+  skos:prefLabel "Gnumeric-taulukko"@fi ;
+  skos:prefLabel "Λογιστικό φύλλο Gnumeric"@el .
+
+media-type:application_x-graphite a skos:Concept ;
+  media-type:hasMediaType "application/x-graphite" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Graphite scientific graph"@en ;
+  skos:prefLabel "Graphite-graafi"@fi ;
+  skos:prefLabel "wissenschaftlicher Graphite-Graph"@de .
+
+media-type:application_x-gtar a skos:Concept ;
+  media-type:hasMediaType "application/x-gtar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archiv gtar"@cs ;
+  skos:prefLabel "archif gtar"@cy ;
+  skos:prefLabel "archive gtar"@fr ;
+  skos:prefLabel "gtar archief"@nl ;
+  skos:prefLabel "gtar archive"@en ;
+  skos:prefLabel "gtar arxivi"@az ;
+  skos:prefLabel "gtar 아카이브"@ko ;
+  skos:prefLabel "gtar-Archiv"@de ;
+  skos:prefLabel "gtar-archívum"@hu ;
+  skos:prefLabel "gtar-arkisto"@fi ;
+  skos:prefLabel "gtar-arkiv"@nn ;
+  skos:prefLabel "gtar-arkiv"@no ;
+  skos:prefLabel "gtar-arkiv"@sv ;
+  skos:prefLabel "гтар архива"@sr .
+
+media-type:application_x-gtktalog a skos:Concept ;
+  media-type:hasMediaType "application/x-gtktalog" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GTKtalog catalog"@en ;
+  skos:prefLabel "GTKtalog-Katalog"@de ;
+  skos:prefLabel "GTKtalog-katalog"@no ;
+  skos:prefLabel "GTKtalog-katalogi"@fi .
+
+media-type:application_x-gzip a skos:Concept ;
+  media-type:hasMediaType "application/x-gzip" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "gzip archive"@en ;
+  skos:prefLabel "gzip-Archiv"@de ;
+  skos:prefLabel "gzip-arkisto"@fi ;
+  skos:prefLabel "gzip-arkiv"@no ;
+  skos:prefLabel "gzip-arkiv"@sv .
+
+media-type:application_x-gzpostscript a skos:Concept ;
+  media-type:hasMediaType "application/x-gzpostscript" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PostScript document (gzip-compressed)"@en ;
+  skos:prefLabel "PostScript-Dokument (gzip-komprimiert)"@de ;
+  skos:prefLabel "PostScript-asiakirja (gzip-pakattu)"@fi ;
+  skos:prefLabel "PostScript-dokument (gzip-komprimert)"@no ;
+  skos:prefLabel "Έγγραφο PostScript (συμπίεση-gzip)"@el .
+
+media-type:application_x-hdf a skos:Concept ;
+  media-type:hasMediaType "application/x-hdf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen HDF"@cy ;
+  skos:prefLabel "Dokument HDF"@cs ;
+  skos:prefLabel "HDF document"@en ;
+  skos:prefLabel "HDF document"@nl ;
+  skos:prefLabel "HDF sənədi"@az ;
+  skos:prefLabel "HDF документ"@sr ;
+  skos:prefLabel "HDF 문서"@ko ;
+  skos:prefLabel "HDF-Dokument"@de ;
+  skos:prefLabel "HDF-asiakirja"@fi ;
+  skos:prefLabel "HDF-dokument"@nn ;
+  skos:prefLabel "HDF-dokument"@no ;
+  skos:prefLabel "HDF-dokument"@sv ;
+  skos:prefLabel "HDF-dokumentum"@hu ;
+  skos:prefLabel "document HDF"@fr ;
+  skos:prefLabel "Έγγραφο HDF"@el .
+
+media-type:application_x-ipod-firmware a skos:Concept ;
+  media-type:hasMediaType "application/x-ipod-firmware" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "iPod firmware"@en ;
+  skos:prefLabel "iPod-Firmware"@de ;
+  skos:prefLabel "iPod-firmware"@no ;
+  skos:prefLabel "iPod-ohjelmisto"@fi .
+
+media-type:application_x-jar a skos:Concept ;
+  media-type:hasMediaType "application/x-jar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Java archive"@en ;
+  skos:prefLabel "Java-Archiv"@de ;
+  skos:prefLabel "Java-arkisto"@fi ;
+  skos:prefLabel "Java-arkiv"@no ;
+  skos:prefLabel "Java-arkiv"@sv .
+
+media-type:application_x-java a skos:Concept ;
+  media-type:hasMediaType "application/x-java" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Java class"@en ;
+  skos:prefLabel "Java-Klasse"@de ;
+  skos:prefLabel "Java-klass"@sv ;
+  skos:prefLabel "Java-klasse"@no ;
+  skos:prefLabel "Java-luokka"@fi .
+
+media-type:application_x-javascript a skos:Concept ;
+  media-type:hasMediaType "application/x-javascript" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Javascript program"@en ;
+  skos:prefLabel "Javascript-Programm"@de ;
+  skos:prefLabel "Πρόγραμμα Javascript"@el .
+
+media-type:application_x-jbuilder-project a skos:Concept ;
+  media-type:hasMediaType "application/x-jbuilder-project" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "JBuilder project"@en ;
+  skos:prefLabel "JBuilder-Projekt"@de ;
+  skos:prefLabel "JBuilder-projekti"@fi ;
+  skos:prefLabel "JBuilder-prosjekt"@no .
+
+media-type:application_x-karbon a skos:Concept ;
+  media-type:hasMediaType "application/x-karbon" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Karbon14 drawing"@en ;
+  skos:prefLabel "Karbon14-Zeichnung"@de ;
+  skos:prefLabel "Karbon14-piirros"@fi ;
+  skos:prefLabel "Karbon14-tegning"@no .
+
+media-type:application_x-kchart a skos:Concept ;
+  media-type:hasMediaType "application/x-kchart" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KChart chart"@en ;
+  skos:prefLabel "KChart-Diagramm"@de ;
+  skos:prefLabel "KChart-graf"@no ;
+  skos:prefLabel "KChart-kaavio"@fi .
+
+media-type:application_x-kformula a skos:Concept ;
+  media-type:hasMediaType "application/x-kformula" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KFormula formula"@en ;
+  skos:prefLabel "KFormula-Formel"@de ;
+  skos:prefLabel "KFormula-formel"@no ;
+  skos:prefLabel "KFormula-kaava"@fi .
+
+media-type:application_x-killustrator a skos:Concept ;
+  media-type:hasMediaType "application/x-killustrator" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KIllustrator drawing"@en ;
+  skos:prefLabel "KIllustrator-Zeichnung"@de ;
+  skos:prefLabel "KIllustrator-piirros"@fi ;
+  skos:prefLabel "KIllustrator-tegning"@no ;
+  skos:prefLabel "Σχέδιο KIllustrator"@el .
+
+media-type:application_x-kivio a skos:Concept ;
+  media-type:hasMediaType "application/x-kivio" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Kivio flowchart"@en ;
+  skos:prefLabel "Kivio-Flussdiagramm"@de ;
+  skos:prefLabel "Kivio-flytdiagram"@no ;
+  skos:prefLabel "Kivio-vuokaavio"@fi .
+
+media-type:application_x-kontour a skos:Concept ;
+  media-type:hasMediaType "application/x-kontour" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Kontour drawing"@en ;
+  skos:prefLabel "Kontour-Zeichnung"@de ;
+  skos:prefLabel "Kontour-piirros"@fi ;
+  skos:prefLabel "Kontour-tegning"@no .
+
+media-type:application_x-kpovmodeler a skos:Concept ;
+  media-type:hasMediaType "application/x-kpovmodeler" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KPovModeler scene"@en ;
+  skos:prefLabel "KPovModeler-Szene"@de ;
+  skos:prefLabel "KPovModeler-tiedosto"@fi .
+
+media-type:application_x-kpresenter a skos:Concept ;
+  media-type:hasMediaType "application/x-kpresenter" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KPresenter presentation"@en ;
+  skos:prefLabel "KPresenter-Präsentation"@de ;
+  skos:prefLabel "KPresenter-esitys"@fi ;
+  skos:prefLabel "KPresenter-presentasjon"@no ;
+  skos:prefLabel "KPresenter-presentation"@sv ;
+  skos:prefLabel "Παρουσίαση KPresenter"@el .
+
+media-type:application_x-krita a skos:Concept ;
+  media-type:hasMediaType "application/x-krita" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Krita document"@en ;
+  skos:prefLabel "Krita-Dokument"@de ;
+  skos:prefLabel "Krita-asiakirja"@fi ;
+  skos:prefLabel "Krita-dokument"@no ;
+  skos:prefLabel "Έγγραφο Krita"@el .
+
+media-type:application_x-kspread a skos:Concept ;
+  media-type:hasMediaType "application/x-kspread" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KSpread spreadsheet"@en ;
+  skos:prefLabel "KSpread-Tabellendokument"@de ;
+  skos:prefLabel "KSpread-regneark"@no ;
+  skos:prefLabel "KSpread-taulukko"@fi ;
+  skos:prefLabel "Λογιστικό φύλλο KSpread"@el .
+
+media-type:application_x-kspread-crypt a skos:Concept ;
+  media-type:hasMediaType "application/x-kspread-crypt" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KSpread spreadsheet (encrypted)"@en ;
+  skos:prefLabel "KSpread-Tabellendokument (verschlüsselt)"@de ;
+  skos:prefLabel "KSpread-regneark (kryptert)"@no ;
+  skos:prefLabel "KSpread-taulukko (salattu)"@fi .
+
+media-type:application_x-ksysv-package a skos:Concept ;
+  media-type:hasMediaType "application/x-ksysv-package" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-kugar a skos:Concept ;
+  media-type:hasMediaType "application/x-kugar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Kugar document"@en ;
+  skos:prefLabel "Kugar-Dokument"@de ;
+  skos:prefLabel "Kugar-asiakirja"@fi ;
+  skos:prefLabel "Kugar-dokument"@no ;
+  skos:prefLabel "Έγγραφο Kugar"@el .
+
+media-type:application_x-kword a skos:Concept ;
+  media-type:hasMediaType "application/x-kword" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen KWord"@cy ;
+  skos:prefLabel "KWord document"@en ;
+  skos:prefLabel "KWord документ"@sr ;
+  skos:prefLabel "KWord-Dokument"@de ;
+  skos:prefLabel "KWord-asiakirja"@fi ;
+  skos:prefLabel "KWord-dokument"@nn ;
+  skos:prefLabel "KWord-dokument"@no ;
+  skos:prefLabel "Έγγραφο KWord"@el .
+
+media-type:application_x-kword-crypt a skos:Concept ;
+  media-type:hasMediaType "application/x-kword-crypt" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "KWord document (encrypted)"@en ;
+  skos:prefLabel "KWord-Dokument (verschlüsselt)"@de ;
+  skos:prefLabel "KWord-asiakirja (salattu)"@fi ;
+  skos:prefLabel "KWord-dokument (kryptert)"@no .
+
+media-type:application_x-lha a skos:Concept ;
+  media-type:hasMediaType "application/x-lha" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif LHA"@cy ;
+  skos:prefLabel "Archiv LHA"@cs ;
+  skos:prefLabel "LHA archief"@nl ;
+  skos:prefLabel "LHA archive"@en ;
+  skos:prefLabel "LHA arxivi"@az ;
+  skos:prefLabel "LHA архива"@sr ;
+  skos:prefLabel "LHA 아카이브"@ko ;
+  skos:prefLabel "LHA-Archiv"@de ;
+  skos:prefLabel "LHA-archívum"@hu ;
+  skos:prefLabel "LHA-arkisto"@fi ;
+  skos:prefLabel "LHA-arkiv"@nn ;
+  skos:prefLabel "LHA-arkiv"@no ;
+  skos:prefLabel "LHA-arkiv"@sv ;
+  skos:prefLabel "archive LHA"@fr .
+
+media-type:application_x-lhz a skos:Concept ;
+  media-type:hasMediaType "application/x-lhz" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "LHZ archive"@en ;
+  skos:prefLabel "LHZ-Archiv"@de ;
+  skos:prefLabel "LHZ-arkisto"@fi ;
+  skos:prefLabel "LHZ-arkiv"@no .
+
+media-type:application_x-linguist a skos:Concept ;
+  media-type:hasMediaType "application/x-linguist" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Nachrichtenkatalog"@de ;
+  skos:prefLabel "meldingskatalog"@no ;
+  skos:prefLabel "message catalog"@en ;
+  skos:prefLabel "viestiluettelo"@fi .
+
+media-type:application_x-lyx a skos:Concept ;
+  media-type:hasMediaType "application/x-lyx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "LyX document"@en ;
+  skos:prefLabel "LyX-Dokument"@de ;
+  skos:prefLabel "LyX-asiakirja"@fi ;
+  skos:prefLabel "LyX-dokument"@no ;
+  skos:prefLabel "LyX-dokument"@sv ;
+  skos:prefLabel "Έγγραφο LyX "@el .
+
+media-type:application_x-lzop a skos:Concept ;
+  media-type:hasMediaType "application/x-lzop" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "LZO archive"@en ;
+  skos:prefLabel "LZO-Archiv"@de ;
+  skos:prefLabel "LZO-arkisto"@fi ;
+  skos:prefLabel "LZO-arkiv"@no .
+
+media-type:application_x-macbinary a skos:Concept ;
+  media-type:hasMediaType "application/x-macbinary" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MacBinary-tiedosto"@fi ;
+  skos:prefLabel "Macintosh MacBinary file"@en ;
+  skos:prefLabel "Macintosh MacBinary-fil"@no ;
+  skos:prefLabel "Macintosh-MacBinary-Datei"@de .
+
+media-type:application_x-magicpoint a skos:Concept ;
+  media-type:hasMediaType "application/x-magicpoint" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Cyflwyniad MagicPoint"@cy ;
+  skos:prefLabel "MagicPoint presentation"@en ;
+  skos:prefLabel "MagicPoint презентација"@sr ;
+  skos:prefLabel "MagicPoint-Präsentation"@de ;
+  skos:prefLabel "MagicPoint-esitys"@fi ;
+  skos:prefLabel "MagicPoint-presentasjon"@nn ;
+  skos:prefLabel "MagicPoint-presentasjon"@no ;
+  skos:prefLabel "MagicPoint-presentation"@sv ;
+  skos:prefLabel "Παρουσίαση MagicPoint"@el .
+
+media-type:application_x-matroska a skos:Concept ;
+  media-type:hasMediaType "application/x-matroska" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Matroska video"@en ;
+  skos:prefLabel "Matroska-Video"@de ;
+  skos:prefLabel "Matroska-film"@no ;
+  skos:prefLabel "Matroska-video"@fi ;
+  skos:prefLabel "Βίντεο Matroska"@el .
+
+media-type:application_x-mif a skos:Concept ;
+  media-type:hasMediaType "application/x-mif" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "FrameMaker MIF document"@en ;
+  skos:prefLabel "FrameMaker MIF-dokument"@no ;
+  skos:prefLabel "FrameMaker-MIF-Dokument"@de ;
+  skos:prefLabel "FrameMaker-välitysasiakirja"@fi ;
+  skos:prefLabel "Έγγραφο FrameMaker MIF"@el .
+
+media-type:application_x-mozilla-bookmarks a skos:Concept ;
+  media-type:hasMediaType "application/x-mozilla-bookmarks" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Mozilla bookmarks"@en ;
+  skos:prefLabel "Mozilla-Lesezeichen"@de ;
+  skos:prefLabel "Mozilla-bokmerker"@no ;
+  skos:prefLabel "Mozilla-kirjanmerkit"@fi ;
+  skos:prefLabel "Σελιδοδείκτες Mozilla"@el .
+
+media-type:application_x-ms-dos-executable a skos:Concept ;
+  media-type:hasMediaType "application/x-ms-dos-executable" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DOS/Windows executable"@en ;
+  skos:prefLabel "DOS/Windows suoritettava ohjema"@fi ;
+  skos:prefLabel "DOS/Windows-Programm"@de ;
+  skos:prefLabel "Kjørbar fil for DOS/Windows"@no ;
+  skos:prefLabel "Εκτελέσιμο DOS/Windows"@el .
+
+media-type:application_x-mswinurl a skos:Concept ;
+  media-type:hasMediaType "application/x-mswinurl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-mswrite a skos:Concept ;
+  media-type:hasMediaType "application/x-mswrite" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Microsoft Write"@cy ;
+  skos:prefLabel "Dokument Microsoft Write"@cs ;
+  skos:prefLabel "Microsoft Write -asiakirja"@fi ;
+  skos:prefLabel "Microsoft Write -dokument"@nn ;
+  skos:prefLabel "Microsoft Write document"@en ;
+  skos:prefLabel "Microsoft Write document"@nl ;
+  skos:prefLabel "Microsoft Write sənədi"@az ;
+  skos:prefLabel "Microsoft Write-Dokument"@de ;
+  skos:prefLabel "Microsoft Write-dokument"@no ;
+  skos:prefLabel "Microsoft Write-dokument"@sv ;
+  skos:prefLabel "Microsoft Write-dokumentum"@hu ;
+  skos:prefLabel "document Microsoft Write"@fr ;
+  skos:prefLabel "Έγγραφο Microsoft Write"@el ;
+  skos:prefLabel "Микрософт документ Писанке"@sr ;
+  skos:prefLabel "마이크로소프트 워드패드 문서"@ko .
+
+media-type:application_x-msx-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-msx-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MSX ROM"@el ;
+  skos:prefLabel "MSX ROM"@en ;
+  skos:prefLabel "MSX ром"@sr ;
+  skos:prefLabel "MSX-ROM"@de ;
+  skos:prefLabel "MSX-ROM"@fi ;
+  skos:prefLabel "MSX-ROM"@nn ;
+  skos:prefLabel "MSX-ROM"@no ;
+  skos:prefLabel "MSX-rom"@sv ;
+  skos:prefLabel "ROM MSX"@cy .
+
+media-type:application_x-n64-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-n64-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Nintendo64 ROM"@el ;
+  skos:prefLabel "Nintendo64 ROM"@en ;
+  skos:prefLabel "Nintendo64-ROM"@de ;
+  skos:prefLabel "Nintendo64-ROM"@fi ;
+  skos:prefLabel "Nintendo64-ROM"@no .
+
+media-type:application_x-nautilus-link a skos:Concept ;
+  media-type:hasMediaType "application/x-nautilus-link" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Cyswllt Nautilus"@cy ;
+  skos:prefLabel "Nautilus koppeling"@nl ;
+  skos:prefLabel "Nautilus körpüsü"@az ;
+  skos:prefLabel "Nautilus link"@en ;
+  skos:prefLabel "Nautilus-Link"@de ;
+  skos:prefLabel "Nautilus-lenke"@nn ;
+  skos:prefLabel "Nautilus-lenke"@no ;
+  skos:prefLabel "Nautilus-link"@hu ;
+  skos:prefLabel "Nautilus-linkki"@fi ;
+  skos:prefLabel "Nautiluslänk"@sv ;
+  skos:prefLabel "Odkaz Nautilus"@cs ;
+  skos:prefLabel "lien Nautilus"@fr ;
+  skos:prefLabel "Σύνδεσμος Nautilus"@el ;
+  skos:prefLabel "Наутилус веза"@sr ;
+  skos:prefLabel "노틸러스 링크"@ko .
+
+media-type:application_x-nes-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-nes-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "NES ROM"@el ;
+  skos:prefLabel "NES ROM"@en ;
+  skos:prefLabel "NES ROM"@no ;
+  skos:prefLabel "NES ром"@sr ;
+  skos:prefLabel "NES-ROM"@de ;
+  skos:prefLabel "NES-ROM"@fi ;
+  skos:prefLabel "NES-ROM"@nn ;
+  skos:prefLabel "NES-rom"@sv ;
+  skos:prefLabel "ROM NES"@cy .
+
+media-type:application_x-netcdf a skos:Concept ;
+  media-type:hasMediaType "application/x-netcdf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Unidata NetCDF document"@en ;
+  skos:prefLabel "Unidata NetCDF-dokument"@no ;
+  skos:prefLabel "Unidata netCDF -asiakirja"@fi ;
+  skos:prefLabel "Unidata-NetCDF-Dokument"@de .
+
+media-type:application_x-netscape-bookmarks a skos:Concept ;
+  media-type:hasMediaType "application/x-netscape-bookmarks" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Netscape bookmarks"@en ;
+  skos:prefLabel "Netscape-Lesezeichen"@de ;
+  skos:prefLabel "Netscape-bokmerker"@no ;
+  skos:prefLabel "Netscape-kirjanmerkit"@fi ;
+  skos:prefLabel "Σελιδοδείκτες Netscape"@el .
+
+media-type:application_x-object a skos:Concept ;
+  media-type:hasMediaType "application/x-object" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Objekt-Code"@de ;
+  skos:prefLabel "object code"@en ;
+  skos:prefLabel "objektikoodi"@fi ;
+  skos:prefLabel "objektkode"@no .
+
+media-type:application_x-ole-storage a skos:Concept ;
+  media-type:hasMediaType "application/x-ole-storage" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "OLE2 compound document storage"@en ;
+  skos:prefLabel "OLE2-Verbunddokumentenspeicher"@de ;
+  skos:prefLabel "OLE2-yhdisteasiakirja"@fi .
+
+media-type:application_x-oleo a skos:Concept ;
+  media-type:hasMediaType "application/x-oleo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GNU Oleo -taulukko"@fi ;
+  skos:prefLabel "GNU Oleo regneark"@no ;
+  skos:prefLabel "GNU Oleo spreadsheet"@en ;
+  skos:prefLabel "GNU-Oleo-Tabellendokument"@de ;
+  skos:prefLabel "Λογιστικό φύλλο GNU Oleo"@el .
+
+media-type:application_x-palm-database a skos:Concept ;
+  media-type:hasMediaType "application/x-palm-database" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Cronfa Ddata Palm OS"@cy ;
+  skos:prefLabel "Databáze Palm OS"@cs ;
+  skos:prefLabel "Palm OS -tietokanta"@fi ;
+  skos:prefLabel "Palm OS database"@en ;
+  skos:prefLabel "Palm OS gegevensbank"@nl ;
+  skos:prefLabel "Palm OS mə'lumat bazası"@az ;
+  skos:prefLabel "Palm OS база података"@sr ;
+  skos:prefLabel "Palm OS-Datenbank"@de ;
+  skos:prefLabel "Palm OS-adatbázis"@hu ;
+  skos:prefLabel "Palm OS-databas"@sv ;
+  skos:prefLabel "Palm OS-database"@nn ;
+  skos:prefLabel "Palm OS-database"@no ;
+  skos:prefLabel "base de données Palm OS"@fr ;
+  skos:prefLabel "Βάση δεδομένων Palm OS"@el ;
+  skos:prefLabel "팜OS 데이터베이스"@ko .
+
+media-type:application_x-pef-executable a skos:Concept ;
+  media-type:hasMediaType "application/x-pef-executable" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PEF executable"@en ;
+  skos:prefLabel "PEF suoritettava ohjelma"@fi ;
+  skos:prefLabel "PEF-Programm"@de ;
+  skos:prefLabel "PEF-kjørbar"@no ;
+  skos:prefLabel "εκτελέσιμο PEF"@el .
+
+media-type:application_x-perl a skos:Concept ;
+  media-type:hasMediaType "application/x-perl" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Perl script"@en ;
+  skos:prefLabel "Perl skript"@nn ;
+  skos:prefLabel "Perl skript"@no ;
+  skos:prefLabel "Perl скрипта"@sr ;
+  skos:prefLabel "Perl-Skript"@de ;
+  skos:prefLabel "Perl-skripti"@fi ;
+  skos:prefLabel "Perlskript"@sv ;
+  skos:prefLabel "Sgript Perl"@cy ;
+  skos:prefLabel "Πρόγραμμα εντολών Perl"@el .
+
+media-type:application_x-php a skos:Concept ;
+  media-type:hasMediaType "application/x-php" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PHP script"@en ;
+  skos:prefLabel "PHP script"@nl ;
+  skos:prefLabel "PHP skripti"@az ;
+  skos:prefLabel "PHP скрипта"@sr ;
+  skos:prefLabel "PHP 스크립트"@ko ;
+  skos:prefLabel "PHP-Skript"@de ;
+  skos:prefLabel "PHP-program"@hu ;
+  skos:prefLabel "PHP-skript"@nn ;
+  skos:prefLabel "PHP-skript"@no ;
+  skos:prefLabel "PHP-skript"@sv ;
+  skos:prefLabel "PHP-skripti"@fi ;
+  skos:prefLabel "Sgript PHP"@cy ;
+  skos:prefLabel "Skript PHP"@cs ;
+  skos:prefLabel "script PHP"@fr ;
+  skos:prefLabel "Πρόγραμμα εντολών PHP"@el .
+
+media-type:application_x-pkcs12 a skos:Concept ;
+  media-type:hasMediaType "application/x-pkcs12" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PKCS#12 certificate bundle"@en ;
+  skos:prefLabel "PKCS#12 sertifikathaug"@no ;
+  skos:prefLabel "PKCS#12-Zertifikatspaket"@de ;
+  skos:prefLabel "PKCS#12-varmennenippu"@fi .
+
+media-type:application_x-profile a skos:Concept ;
+  media-type:hasMediaType "application/x-profile" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Profiler-Ergebnisse"@de ;
+  skos:prefLabel "Výsledky profileru"@cs ;
+  skos:prefLabel "canlyniadau proffeilio"@cy ;
+  skos:prefLabel "profileerder resultaten"@nl ;
+  skos:prefLabel "profileingsresultat"@no ;
+  skos:prefLabel "profiler nəticələri"@az ;
+  skos:prefLabel "profiler results"@en ;
+  skos:prefLabel "profiler-eredmények"@hu ;
+  skos:prefLabel "profilerarresultat"@sv ;
+  skos:prefLabel "profileringsresultat"@nn ;
+  skos:prefLabel "profilointitulokset"@fi ;
+  skos:prefLabel "résultat du profileur"@fr ;
+  skos:prefLabel "резултати профилатора"@sr ;
+  skos:prefLabel "프로파일러 결과"@ko .
+
+media-type:application_x-pw a skos:Concept ;
+  media-type:hasMediaType "application/x-pw" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Pathetic Writer -asiakirja"@fi ;
+  skos:prefLabel "Pathetic Writer document"@en ;
+  skos:prefLabel "Pathetic Writer-Dokument"@de ;
+  skos:prefLabel "Pathetic Writer-dokument"@no .
+
+media-type:application_x-python a skos:Concept ;
+  media-type:hasMediaType "application/x-python" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Python script"@en ;
+  skos:prefLabel "Python-Skript"@de ;
+  skos:prefLabel "Python-skript"@no ;
+  skos:prefLabel "Python-skripti"@fi ;
+  skos:prefLabel "Pythonskript"@sv ;
+  skos:prefLabel "Πρόγραμμα εντολών Python"@el .
+
+media-type:application_x-python-bytecode a skos:Concept ;
+  media-type:hasMediaType "application/x-python-bytecode" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bajtový kód Python"@cs ;
+  skos:prefLabel "Côd beit Python"@cy ;
+  skos:prefLabel "Python bayt kodu"@az ;
+  skos:prefLabel "Python bytecode"@en ;
+  skos:prefLabel "Python bytecode"@nl ;
+  skos:prefLabel "Python-Bytecode"@de ;
+  skos:prefLabel "Python-bytekod"@sv ;
+  skos:prefLabel "Python-bytekode"@nn ;
+  skos:prefLabel "Python-bytekode"@no ;
+  skos:prefLabel "Python-bytekód"@hu ;
+  skos:prefLabel "Python-tavukoodi"@fi ;
+  skos:prefLabel "bytecode Python"@fr ;
+  skos:prefLabel "Питонов бајт кôд"@sr ;
+  skos:prefLabel "파이썬 바이트코드"@ko .
+
+media-type:application_x-quattropro a skos:Concept ;
+  media-type:hasMediaType "application/x-quattropro" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Quattro Pro -taulukko"@fi ;
+  skos:prefLabel "Quattro Pro spreadsheet"@en ;
+  skos:prefLabel "Quattro Pro-Tabellendokument"@de ;
+  skos:prefLabel "Quattro Pro-regneark"@no ;
+  skos:prefLabel "Λογιστικό φύλλο Quattro Pro"@el .
+
+media-type:application_x-qw a skos:Concept ;
+  media-type:hasMediaType "application/x-qw" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Quicken"@cy ;
+  skos:prefLabel "Dokument Quicken"@cs ;
+  skos:prefLabel "Quicken document"@en ;
+  skos:prefLabel "Quicken document"@nl ;
+  skos:prefLabel "Quicken sənədi"@az ;
+  skos:prefLabel "Quicken документ"@sr ;
+  skos:prefLabel "Quicken 문서"@ko ;
+  skos:prefLabel "Quicken-Dokument"@de ;
+  skos:prefLabel "Quicken-asiakirja"@fi ;
+  skos:prefLabel "Quicken-dokument"@nn ;
+  skos:prefLabel "Quicken-dokument"@no ;
+  skos:prefLabel "Quicken-dokument"@sv ;
+  skos:prefLabel "Quicken-dokumentum"@hu ;
+  skos:prefLabel "document Quicken"@fr ;
+  skos:prefLabel "Έγγραφο Quicken"@el .
+
+media-type:application_x-rar a skos:Concept ;
+  media-type:hasMediaType "application/x-rar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif RAR"@cy ;
+  skos:prefLabel "RAR archive"@en ;
+  skos:prefLabel "RAR-Archiv"@de ;
+  skos:prefLabel "RAR-arkisto"@fi ;
+  skos:prefLabel "RAR-arkiv"@nn ;
+  skos:prefLabel "RAR-arkiv"@no ;
+  skos:prefLabel "RAR-arkiv"@sv ;
+  skos:prefLabel "Αρχείο RAR"@el ;
+  skos:prefLabel "РАР архива"@sr .
+
+media-type:application_x-reject a skos:Concept ;
+  media-type:hasMediaType "application/x-reject" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "abgelehnter Patch"@de ;
+  skos:prefLabel "avvist patchfil"@no ;
+  skos:prefLabel "hylättyjen muutosten tiedosto"@fi ;
+  skos:prefLabel "rejected patch"@en .
+
+media-type:application_x-rpm a skos:Concept ;
+  media-type:hasMediaType "application/x-rpm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "RPM package"@en ;
+  skos:prefLabel "RPM-Paket"@de ;
+  skos:prefLabel "RPM-paket"@sv ;
+  skos:prefLabel "RPM-paketti"@fi ;
+  skos:prefLabel "RPM-pakke"@no ;
+  skos:prefLabel "Πακέτο RPM"@el .
+
+media-type:application_x-ruby a skos:Concept ;
+  media-type:hasMediaType "application/x-ruby" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ruby script"@en ;
+  skos:prefLabel "Ruby-Skript"@de ;
+  skos:prefLabel "Ruby-skript"@no ;
+  skos:prefLabel "Ruby-skripti"@fi ;
+  skos:prefLabel "Πρόγραμμα εντολών Ruby"@el .
+
+media-type:application_x-sc a skos:Concept ;
+  media-type:hasMediaType "application/x-sc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:application_x-shar a skos:Concept ;
+  media-type:hasMediaType "application/x-shar" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archiv shellu"@cs ;
+  skos:prefLabel "Shell-Archiv"@de ;
+  skos:prefLabel "archif plisgyn"@cy ;
+  skos:prefLabel "archive shell"@fr ;
+  skos:prefLabel "héjarchívum"@hu ;
+  skos:prefLabel "komentotulkkiarkisto"@fi ;
+  skos:prefLabel "qabıq arxivi"@az ;
+  skos:prefLabel "shell archief"@nl ;
+  skos:prefLabel "shell archive"@en ;
+  skos:prefLabel "skal-arkiv"@nn ;
+  skos:prefLabel "skalarkiv"@sv ;
+  skos:prefLabel "skallarkiv"@no ;
+  skos:prefLabel "Архива љуске (SHAR)"@sr ;
+  skos:prefLabel "쉘 아카이브"@ko .
+
+media-type:application_x-shared-library-la a skos:Concept ;
+  media-type:hasMediaType "application/x-shared-library-la" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "delt bibliotek (la)"@no ;
+  skos:prefLabel "gemeinsame Bibliothek (la)"@de ;
+  skos:prefLabel "jaettu kirjasto (la)"@fi ;
+  skos:prefLabel "shared library (la)"@en .
+
+media-type:application_x-sharedlib a skos:Concept ;
+  media-type:hasMediaType "application/x-sharedlib" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sdílená knihovna"@cs ;
+  skos:prefLabel "bölüşülmüş kitabxana"@az ;
+  skos:prefLabel "delat bibliotek"@sv ;
+  skos:prefLabel "delt bibliotek"@nn ;
+  skos:prefLabel "delt bibliotek"@no ;
+  skos:prefLabel "gedeelde bibliotheek"@nl ;
+  skos:prefLabel "gemeinsame Bibliothek"@de ;
+  skos:prefLabel "jaettu kirjasto"@fi ;
+  skos:prefLabel "librairie partagée « shared »"@fr ;
+  skos:prefLabel "llyfrgell wedi ei rhannu"@cy ;
+  skos:prefLabel "osztott programkönyvtár"@hu ;
+  skos:prefLabel "shared library"@en ;
+  skos:prefLabel "дељена библиотека"@sr ;
+  skos:prefLabel "공유 라이브러리"@ko .
+
+media-type:application_x-shellscript a skos:Concept ;
+  media-type:hasMediaType "application/x-shellscript" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shell-Skript"@de ;
+  skos:prefLabel "Skript shellu"@cs ;
+  skos:prefLabel "komentojono"@fi ;
+  skos:prefLabel "parancsfájl"@hu ;
+  skos:prefLabel "qabıq skripti"@az ;
+  skos:prefLabel "script shell"@fr ;
+  skos:prefLabel "sgript plisgyn"@cy ;
+  skos:prefLabel "shell script"@en ;
+  skos:prefLabel "shell script"@nl ;
+  skos:prefLabel "skallskript"@no ;
+  skos:prefLabel "skalskript"@nn ;
+  skos:prefLabel "skalskript"@sv ;
+  skos:prefLabel "скрипта љуске"@sr ;
+  skos:prefLabel "쉘 스크립트"@ko .
+
+media-type:application_x-shockwave-flash a skos:Concept ;
+  media-type:hasMediaType "application/x-shockwave-flash" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shockwave Flash -media"@fi ;
+  skos:prefLabel "Shockwave Flash file"@en ;
+  skos:prefLabel "Shockwave Flash-Datei"@de ;
+  skos:prefLabel "Shockwave Flash-fil"@no ;
+  skos:prefLabel "Αρχείο Shockwave Flash"@el .
+
+media-type:application_x-siag a skos:Concept ;
+  media-type:hasMediaType "application/x-siag" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Siag spreadsheet"@en ;
+  skos:prefLabel "Siag-kalkylblad"@sv ;
+  skos:prefLabel "Siag-regneark"@no ;
+  skos:prefLabel "Siag-taulukko"@fi ;
+  skos:prefLabel "Slag-Tabellendokument"@de ;
+  skos:prefLabel "Λογιστικό φύλλο Siag"@el .
+
+media-type:application_x-slp a skos:Concept ;
+  media-type:hasMediaType "application/x-slp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Balíček Stampede"@cs ;
+  skos:prefLabel "Pecyn Stampede"@cy ;
+  skos:prefLabel "Stampede package"@en ;
+  skos:prefLabel "Stampede paketi"@az ;
+  skos:prefLabel "Stampede pakket"@nl ;
+  skos:prefLabel "Stampede пакет"@sr ;
+  skos:prefLabel "Stampede 꾸러미"@ko ;
+  skos:prefLabel "Stampede-Paket"@de ;
+  skos:prefLabel "Stampede-csomag"@hu ;
+  skos:prefLabel "Stampede-paket"@sv ;
+  skos:prefLabel "Stampede-paketti"@fi ;
+  skos:prefLabel "Stampede-pakke"@nn ;
+  skos:prefLabel "Stampede-pakke"@no ;
+  skos:prefLabel "package Stampede"@fr ;
+  skos:prefLabel "Πακέτο Stampede"@el .
+
+media-type:application_x-sms-rom a skos:Concept ;
+  media-type:hasMediaType "application/x-sms-rom" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "SMS- tai Game Gear -ROM"@fi ;
+  skos:prefLabel "SMS/Game Gear ROM"@en ;
+  skos:prefLabel "SMS/Game Gear-ROM"@de ;
+  skos:prefLabel "SMS/Game Gear-ROM"@no .
+
+media-type:application_x-stuffit a skos:Concept ;
+  media-type:hasMediaType "application/x-stuffit" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif Macintosh StuffIt"@cy ;
+  skos:prefLabel "Archiv Macintosh StuffIt"@cs ;
+  skos:prefLabel "Macintosh StuffIt -arkisto"@fi ;
+  skos:prefLabel "Macintosh StuffIt archief"@nl ;
+  skos:prefLabel "Macintosh StuffIt archive"@en ;
+  skos:prefLabel "Macintosh StuffIt arkiv"@nn ;
+  skos:prefLabel "Macintosh StuffIt arkiv"@no ;
+  skos:prefLabel "Macintosh StuffIt arxivi"@az ;
+  skos:prefLabel "Macintosh StuffIt-Archiv"@de ;
+  skos:prefLabel "Macintosh StuffIt-archívum"@hu ;
+  skos:prefLabel "Macintosh StuffIt-arkiv "@sv ;
+  skos:prefLabel "archive Macintosh StuffIt"@fr ;
+  skos:prefLabel "Мекинтош StuffIt архива"@sr ;
+  skos:prefLabel "맥킨토시 StuffIt 아카이브"@ko .
+
+media-type:application_x-sv4cpio a skos:Concept ;
+  media-type:hasMediaType "application/x-sv4cpio" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archif CPIO SV4"@cy ;
+  skos:prefLabel "Archiv SV4 CPIO"@cs ;
+  skos:prefLabel "SV4 CPIO -arkisto"@fi ;
+  skos:prefLabel "SV4 CPIO archief"@nl ;
+  skos:prefLabel "SV4 CPIO archive"@en ;
+  skos:prefLabel "SV4 CPIO arxivi"@az ;
+  skos:prefLabel "SV4 CPIO архива"@sr ;
+  skos:prefLabel "SV4 CPIO 아카이브"@ko ;
+  skos:prefLabel "SV4 CPIO-archívum"@hu ;
+  skos:prefLabel "SV4 CPIO-arkiv"@nn ;
+  skos:prefLabel "SV4 CPIO-arkiv"@no ;
+  skos:prefLabel "SV4 CPIO-arkiv"@sv ;
+  skos:prefLabel "SV4-CPIO-Archiv"@de ;
+  skos:prefLabel "archive SV4 CPIO"@fr .
+
+media-type:application_x-sv4crc a skos:Concept ;
+  media-type:hasMediaType "application/x-sv4crc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "(CRC를 가지는) SV4 CPIP 아카이브"@ko ;
+  skos:prefLabel "Archif CPIP SV4 (efo CRC)"@cy ;
+  skos:prefLabel "Archiv SV4 CPIP (s CRC)"@cs ;
+  skos:prefLabel "SV4 CPIO-arkiv (med CRC)"@no ;
+  skos:prefLabel "SV4 CPIO-arkiv (med CRC)"@sv ;
+  skos:prefLabel "SV4 CPIP -arkisto (CRC:llä)"@fi ;
+  skos:prefLabel "SV4 CPIP archief (met CRC)"@nl ;
+  skos:prefLabel "SV4 CPIP archive (with CRC)"@en ;
+  skos:prefLabel "SV4 CPIP arkiv (med SRS)"@nn ;
+  skos:prefLabel "SV4 CPIP arxivi (CRC ilə)"@az ;
+  skos:prefLabel "SV4 CPIP архива (са CRC-ом)"@sr ;
+  skos:prefLabel "SV4 CPIP-archívum (CRC-vel)"@hu ;
+  skos:prefLabel "SV4-CPIP-Archiv (mit CRC)"@de ;
+  skos:prefLabel "archive SV4 CPIP (avec CRC)"@fr .
+
+media-type:application_x-tar a skos:Concept ;
+  media-type:hasMediaType "application/x-tar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tar archive"@en ;
+  skos:prefLabel "tar-Archiv"@de ;
+  skos:prefLabel "tar-arkisto"@fi ;
+  skos:prefLabel "tar-arkiv"@no .
+
+media-type:application_x-tarz a skos:Concept ;
+  media-type:hasMediaType "application/x-tarz" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tar archive (compressed)"@en ;
+  skos:prefLabel "tar-Archiv (komprimiert)"@de ;
+  skos:prefLabel "tar-arkisto (pakattu)"@fi ;
+  skos:prefLabel "tar-arkiv (komprimert)"@no .
+
+media-type:application_x-tex-gf a skos:Concept ;
+  media-type:hasMediaType "application/x-tex-gf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "generic font file"@en ;
+  skos:prefLabel "generische Schriftdatei"@de ;
+  skos:prefLabel "vanlig skriftfil"@no ;
+  skos:prefLabel "yleiset kirjasintiedostot"@fi .
+
+media-type:application_x-tex-pk a skos:Concept ;
+  media-type:hasMediaType "application/x-tex-pk" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "gepackte Schriftdatei"@de ;
+  skos:prefLabel "packed font file"@en ;
+  skos:prefLabel "pakattu kirjasintiedosto"@fi ;
+  skos:prefLabel "pakket skriftfil"@no .
+
+media-type:application_x-tgif a skos:Concept ;
+  media-type:hasMediaType "application/x-tgif" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "TGIF document"@en ;
+  skos:prefLabel "TGIF-Dokument"@de ;
+  skos:prefLabel "TGIF-asiakirja"@fi ;
+  skos:prefLabel "TGIF-dokument"@no ;
+  skos:prefLabel "TGIF-dokument"@sv ;
+  skos:prefLabel "Έγγραφο TGIF"@el .
+
+media-type:application_x-theme a skos:Concept ;
+  media-type:hasMediaType "application/x-theme" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Thema"@de ;
+  skos:prefLabel "Téma"@cs ;
+  skos:prefLabel "drakt"@nn ;
+  skos:prefLabel "teema"@fi ;
+  skos:prefLabel "tema"@no ;
+  skos:prefLabel "tema"@sv ;
+  skos:prefLabel "thema"@cy ;
+  skos:prefLabel "thema"@nl ;
+  skos:prefLabel "theme"@en ;
+  skos:prefLabel "thème"@fr ;
+  skos:prefLabel "téma"@hu ;
+  skos:prefLabel "örtük"@az ;
+  skos:prefLabel "θέμα"@el ;
+  skos:prefLabel "тема"@sr ;
+  skos:prefLabel "테마"@ko .
+
+media-type:application_x-toutdoux a skos:Concept ;
+  media-type:hasMediaType "application/x-toutdoux" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen ToutDoux"@cy ;
+  skos:prefLabel "Dokument ToutDoux"@cs ;
+  skos:prefLabel "ToutDoux document"@en ;
+  skos:prefLabel "ToutDoux document"@nl ;
+  skos:prefLabel "ToutDoux sənədi"@az ;
+  skos:prefLabel "ToutDoux документ"@sr ;
+  skos:prefLabel "ToutDoux 문서"@ko ;
+  skos:prefLabel "ToutDoux-Dokument"@de ;
+  skos:prefLabel "ToutDoux-asiakirja"@fi ;
+  skos:prefLabel "ToutDoux-dokument"@nn ;
+  skos:prefLabel "ToutDoux-dokument"@no ;
+  skos:prefLabel "ToutDoux-dokument"@sv ;
+  skos:prefLabel "ToutDoux-dokumentum"@hu ;
+  skos:prefLabel "document ToutDoux"@fr ;
+  skos:prefLabel "Έγγραφο ToutDoux"@el .
+
+media-type:application_x-trash a skos:Concept ;
+  media-type:hasMediaType "application/x-trash" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sicherungsdatei"@de ;
+  skos:prefLabel "backup file"@en ;
+  skos:prefLabel "sikkerhetskopi"@no ;
+  skos:prefLabel "varmuuskopio"@fi .
+
+media-type:application_x-troff a skos:Concept ;
+  media-type:hasMediaType "application/x-troff" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen troff"@cy ;
+  skos:prefLabel "Dokument troff"@cs ;
+  skos:prefLabel "Troff document"@en ;
+  skos:prefLabel "Troff document"@nl ;
+  skos:prefLabel "Troff sənədi"@az ;
+  skos:prefLabel "Troff документ"@sr ;
+  skos:prefLabel "Troff 문서"@ko ;
+  skos:prefLabel "Troff-Dokument"@de ;
+  skos:prefLabel "Troff-asiakirja"@fi ;
+  skos:prefLabel "Troff-dokument"@nn ;
+  skos:prefLabel "Troff-dokument"@no ;
+  skos:prefLabel "Troff-dokument"@sv ;
+  skos:prefLabel "Troff-dokumentum"@hu ;
+  skos:prefLabel "document Troff"@fr ;
+  skos:prefLabel "Έγγραφο Troff"@el .
+
+media-type:application_x-troff-man a skos:Concept ;
+  media-type:hasMediaType "application/x-troff-man" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Troff document (with manpage macros)"@en ;
+  skos:prefLabel "Troff-Dokument (mit man-Seitenmakros)"@de ;
+  skos:prefLabel "Troff-asiakirja man-sivu-makroilla"@fi .
+
+media-type:application_x-troff-man-compressed a skos:Concept ;
+  media-type:hasMediaType "application/x-troff-man-compressed" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "(압축된) 설명서 페이지"@ko ;
+  skos:prefLabel "Handbuchseite (komprimiert)"@de ;
+  skos:prefLabel "Manuálová stránka (komprimovaná)"@cs ;
+  skos:prefLabel "handleidingspagina (ingepakt)"@nl ;
+  skos:prefLabel "kézikönyvoldal (tömörített)"@hu ;
+  skos:prefLabel "man pages (compressés)"@fr ;
+  skos:prefLabel "man səhifəsi (sıxışdırılmış)"@az ;
+  skos:prefLabel "manuaalisivu (pakattu)"@fi ;
+  skos:prefLabel "manual page (compressed)"@en ;
+  skos:prefLabel "manualsida (komprimerad)"@sv ;
+  skos:prefLabel "manualside (komprimert)"@no ;
+  skos:prefLabel "manualside (pakka)"@nn ;
+  skos:prefLabel "tudalen llawlyfr (wedi ei gywasgu)"@cy ;
+  skos:prefLabel "страна упутства (компресована)"@sr .
+
+media-type:application_x-tzo a skos:Concept ;
+  media-type:hasMediaType "application/x-tzo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "tar archive (LZO-compressed)"@en ;
+  skos:prefLabel "tar-Archiv (LZO-komprimiert)"@de ;
+  skos:prefLabel "tar-arkisto (LZO-pakattu)"@fi ;
+  skos:prefLabel "tar-arkiv (LZO-komprimert)"@no .
+
+media-type:application_x-ustar a skos:Concept ;
+  media-type:hasMediaType "application/x-ustar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Archiv ustar"@cs ;
+  skos:prefLabel "Ustar 아카이브"@ko ;
+  skos:prefLabel "archif ustar"@cy ;
+  skos:prefLabel "archive ustar"@fr ;
+  skos:prefLabel "ustar archief"@nl ;
+  skos:prefLabel "ustar archive"@en ;
+  skos:prefLabel "ustar arxivi"@az ;
+  skos:prefLabel "ustar архива"@sr ;
+  skos:prefLabel "ustar-Archiv"@de ;
+  skos:prefLabel "ustar-archívum"@hu ;
+  skos:prefLabel "ustar-arkisto"@fi ;
+  skos:prefLabel "ustar-arkiv"@nn ;
+  skos:prefLabel "ustar-arkiv"@no ;
+  skos:prefLabel "ustar-arkiv"@sv .
+
+media-type:application_x-wais-source a skos:Concept ;
+  media-type:hasMediaType "application/x-wais-source" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffynhonnell Rhaglen WAIS"@cy ;
+  skos:prefLabel "WAIS broncode"@nl ;
+  skos:prefLabel "WAIS mənbə faylı"@az ;
+  skos:prefLabel "WAIS source code"@en ;
+  skos:prefLabel "WAIS изворни кôд"@sr ;
+  skos:prefLabel "WAIS 소스 코드"@ko ;
+  skos:prefLabel "WAIS-Quelltext"@de ;
+  skos:prefLabel "WAIS-forráskód"@hu ;
+  skos:prefLabel "WAIS-kildekode"@no ;
+  skos:prefLabel "WAIS-kjeldekode"@nn ;
+  skos:prefLabel "WAIS-källkod"@sv ;
+  skos:prefLabel "WAIS-lähdekoodi"@fi ;
+  skos:prefLabel "Zdrojový kód WAIS"@cs ;
+  skos:prefLabel "code source WAIS"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας WAIS"@el .
+
+media-type:application_x-wpg a skos:Concept ;
+  media-type:hasMediaType "application/x-wpg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "WordPerfect- tai DrawPerfect -kuva"@fi ;
+  skos:prefLabel "WordPerfect/DrawPerfect-Bild"@de ;
+  skos:prefLabel "WordPerfect/Drawperfect image"@en ;
+  skos:prefLabel "Εικόνα WordPerfect/Drawperfect"@el .
+
+media-type:application_x-x509-ca-cert a skos:Concept ;
+  media-type:hasMediaType "application/x-x509-ca-cert" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DER-, PEM- tai Netscape-koodattu X.509-varmenne"@fi ;
+  skos:prefLabel "DER/PEM/Netscape-encoded X.509 certificate"@en ;
+  skos:prefLabel "DER/PEM/Netscape-kodet X.509-sertifikat"@no ;
+  skos:prefLabel "DER/PEM/Netscape-kodiertes X.509-Zertifikat"@de .
+
+media-type:application_x-xbel a skos:Concept ;
+  media-type:hasMediaType "application/x-xbel" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "XBEL bookmarks"@en ;
+  skos:prefLabel "XBEL-Lesezeichen"@de ;
+  skos:prefLabel "XBEL-bokmerker"@no ;
+  skos:prefLabel "XBEL-kirjanmerkit"@fi ;
+  skos:prefLabel "Σελιδοδείκτες XBEL"@el .
+
+media-type:application_x-zerosize a skos:Concept ;
+  media-type:hasMediaType "application/x-zerosize" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "empty document"@en ;
+  skos:prefLabel "leeres Dokument"@de ;
+  skos:prefLabel "tomt dokument"@no ;
+  skos:prefLabel "tomt dokument"@sv ;
+  skos:prefLabel "tyhjä asiakirja"@fi .
+
+media-type:application_x-zoo a skos:Concept ;
+  media-type:hasMediaType "application/x-zoo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "zoo archive"@en ;
+  skos:prefLabel "zoo-Archiv"@de ;
+  skos:prefLabel "zoo-arkisto"@fi ;
+  skos:prefLabel "zoo-arkiv"@no .
+
+media-type:application_xhtmlxml a skos:Concept ;
+  media-type:hasMediaType "application/xhtml+xml" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "XHTML page"@en ;
+  skos:prefLabel "XHTML-Seite"@de ;
+  skos:prefLabel "XHTML-sida"@sv ;
+  skos:prefLabel "XHTML-side"@no ;
+  skos:prefLabel "XHTML-sivu"@fi ;
+  skos:prefLabel "Σελίδα XHTML"@el .
+
+media-type:application_zip a skos:Concept ;
+  media-type:hasMediaType "application/zip" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "ZIP archive"@en ;
+  skos:prefLabel "ZIP-Archiv"@de ;
+  skos:prefLabel "ZIP-arkisto"@fi ;
+  skos:prefLabel "ZIP-arkiv"@no .
+
+media-type:audio a skos:Collection ;
+  rdfs:label "Audio types"@en ;
+  dct:description "The collection of audio types"@en ;
+  dct:title "Audio types"@en ;
+  skos:member media-type:audio_ac3 ;
+  skos:member media-type:audio_basic ;
+  skos:member media-type:audio_midi ;
+  skos:member media-type:audio_prssid ;
+  skos:member media-type:audio_x-adpcm ;
+  skos:member media-type:audio_x-aifc ;
+  skos:member media-type:audio_x-aiff ;
+  skos:member media-type:audio_x-aiffc ;
+  skos:member media-type:audio_x-flac ;
+  skos:member media-type:audio_x-it ;
+  skos:member media-type:audio_x-mod ;
+  skos:member media-type:audio_x-mp3 ;
+  skos:member media-type:audio_x-mp3-playlist ;
+  skos:member media-type:audio_x-mpeg ;
+  skos:member media-type:audio_x-mpegurl ;
+  skos:member media-type:audio_x-ms-asx ;
+  skos:member media-type:audio_x-pn-realaudio ;
+  skos:member media-type:audio_x-riff ;
+  skos:member media-type:audio_x-s3m ;
+  skos:member media-type:audio_x-scpls ;
+  skos:member media-type:audio_x-stm ;
+  skos:member media-type:audio_x-voc ;
+  skos:member media-type:audio_x-wav ;
+  skos:member media-type:audio_x-xi ;
+  skos:member media-type:audio_x-xm .
+
+media-type:audio_ac3 a skos:Concept ;
+  media-type:hasMediaType "audio/ac3" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dolby Digital -ääni"@fi ;
+  skos:prefLabel "Dolby Digital audio"@az ;
+  skos:prefLabel "Dolby Digital audio"@en ;
+  skos:prefLabel "Dolby Digital geluidsbestand"@nl ;
+  skos:prefLabel "Dolby Digital hang"@hu ;
+  skos:prefLabel "Dolby Digital lyd"@nn ;
+  skos:prefLabel "Dolby Digital-Audio"@de ;
+  skos:prefLabel "Dolby Digital-ljud"@sv ;
+  skos:prefLabel "Dolby digital lyd"@no ;
+  skos:prefLabel "Sain Dolby Digital"@cy ;
+  skos:prefLabel "Zvuk Dolby Digital"@cs ;
+  skos:prefLabel "audio Dolby Digital audio"@fr ;
+  skos:prefLabel "Ψηφιακός Ήχος Dolby"@el ;
+  skos:prefLabel "Дигитални Dolby звучни запис"@sr ;
+  skos:prefLabel "돌비 디지털 오디오"@ko .
+
+media-type:audio_basic a skos:Concept ;
+  media-type:hasMediaType "audio/basic" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sain ULAW (Sun)"@cy ;
+  skos:prefLabel "ULAW (Sun) -ääni"@fi ;
+  skos:prefLabel "ULAW (Sun) audio faylı"@az ;
+  skos:prefLabel "ULAW (Sun) audio"@en ;
+  skos:prefLabel "ULAW (Sun) audio"@fr ;
+  skos:prefLabel "ULAW (Sun) geluidsbestand"@nl ;
+  skos:prefLabel "ULAW (Sun) hangfájl"@hu ;
+  skos:prefLabel "ULAW (Sun) звучни запис"@sr ;
+  skos:prefLabel "ULAW (Sun) 오디오"@ko ;
+  skos:prefLabel "ULAW (Sun)-Audio"@de ;
+  skos:prefLabel "ULAW (Sun)-lyd"@nn ;
+  skos:prefLabel "ULAW-ljud (Sun)"@sv ;
+  skos:prefLabel "ULAW-lyd (Sun)"@no ;
+  skos:prefLabel "Zvuk ULAW (Sun)"@cs .
+
+media-type:audio_midi a skos:Concept ;
+  media-type:hasMediaType "audio/midi" ;
+  skos:exactMatch media-type:audio_x-midi ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MIDI audio faylı"@az ;
+  skos:prefLabel "MIDI audio"@en ;
+  skos:prefLabel "MIDI geluidsbestand"@nl ;
+  skos:prefLabel "MIDI звучни запис"@sr ;
+  skos:prefLabel "MIDI-Audio"@de ;
+  skos:prefLabel "MIDI-hang"@hu ;
+  skos:prefLabel "MIDI-ljud"@sv ;
+  skos:prefLabel "MIDI-lyd"@nn ;
+  skos:prefLabel "MIDI-lyd"@no ;
+  skos:prefLabel "MIDI-ääni"@fi ;
+  skos:prefLabel "Sain MIDI"@cy ;
+  skos:prefLabel "Zvuk MIDI"@cs ;
+  skos:prefLabel "audio MIDI"@fr ;
+  skos:prefLabel "Ήχος MIDI"@el ;
+  skos:prefLabel "미디 오디오"@ko .
+
+media-type:audio_prssid a skos:Concept ;
+  media-type:hasMediaType "audio/prs.sid" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Commodore 64 -ääni"@fi ;
+  skos:prefLabel "Commodore 64 audio"@en ;
+  skos:prefLabel "Commodore 64-Audio"@de ;
+  skos:prefLabel "Commodore 64-ljud"@sv ;
+  skos:prefLabel "Commodore 64-lyd"@no ;
+  skos:prefLabel "Ήχος Commodore 64"@el .
+
+media-type:audio_x-adpcm a skos:Concept ;
+  media-type:hasMediaType "audio/x-adpcm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "PCM audio faylı"@az ;
+  skos:prefLabel "PCM audio"@en ;
+  skos:prefLabel "PCM geluidsbestand"@nl ;
+  skos:prefLabel "PCM звучни запис"@sr ;
+  skos:prefLabel "PCM 오디오"@ko ;
+  skos:prefLabel "PCM-Audio"@de ;
+  skos:prefLabel "PCM-hang"@hu ;
+  skos:prefLabel "PCM-ljud"@sv ;
+  skos:prefLabel "PCM-lyd"@nn ;
+  skos:prefLabel "PCM-lyd"@no ;
+  skos:prefLabel "PCM-ääni"@fi ;
+  skos:prefLabel "Sain PCM"@cy ;
+  skos:prefLabel "Zvuk PCM"@cs ;
+  skos:prefLabel "audio PCM"@fr ;
+  skos:prefLabel "Ήχος PCM"@el .
+
+media-type:audio_x-aifc a skos:Concept ;
+  media-type:hasMediaType "audio/x-aifc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AIFC audio faylı"@az ;
+  skos:prefLabel "AIFC audio"@en ;
+  skos:prefLabel "AIFC geluidsbestand"@nl ;
+  skos:prefLabel "AIFC звучни запис"@sr ;
+  skos:prefLabel "AIFC 오디오"@ko ;
+  skos:prefLabel "AIFC-Audio"@de ;
+  skos:prefLabel "AIFC-hang"@hu ;
+  skos:prefLabel "AIFC-ljud"@sv ;
+  skos:prefLabel "AIFC-lyd"@nn ;
+  skos:prefLabel "AIFC-lyd"@no ;
+  skos:prefLabel "AIFC-ääni"@fi ;
+  skos:prefLabel "Sain AIFC"@cy ;
+  skos:prefLabel "Zvuk AIFC"@cs ;
+  skos:prefLabel "audio AIFC"@fr ;
+  skos:prefLabel "Ήχος AIFC"@el .
+
+media-type:audio_x-aiff a skos:Concept ;
+  media-type:hasMediaType "audio/x-aiff" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AIFF/Amiga/Mac audio faylı"@az ;
+  skos:prefLabel "AIFF/Amiga/Mac audio"@en ;
+  skos:prefLabel "AIFF/Amiga/Mac geluidsbestand"@nl ;
+  skos:prefLabel "AIFF/Amiga/Mac 오디오"@ko ;
+  skos:prefLabel "AIFF/Amiga/Mac-Audio"@de ;
+  skos:prefLabel "AIFF/Amiga/Mac-hang"@hu ;
+  skos:prefLabel "AIFF/Amiga/Mac-ljud"@sv ;
+  skos:prefLabel "AIFF/Amiga/Mac-lyd"@nn ;
+  skos:prefLabel "AIFF/Amiga/Mac-lyd"@no ;
+  skos:prefLabel "AIFF/Amiga/Mac-ääni"@fi ;
+  skos:prefLabel "AIFF/Амига/Мекинтош звучни запис"@sr ;
+  skos:prefLabel "Sain AIFF/Amiga/Mac"@cy ;
+  skos:prefLabel "Zvuk AIFF/Amiga/Mac"@cs ;
+  skos:prefLabel "audio AIFF/Amiga/Mac"@fr .
+
+media-type:audio_x-aiffc a skos:Concept ;
+  media-type:hasMediaType "audio/x-aiffc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AIFF audio faylı"@az ;
+  skos:prefLabel "AIFF audio"@en ;
+  skos:prefLabel "AIFF geluidsbestand"@nl ;
+  skos:prefLabel "AIFF звучни запис"@sr ;
+  skos:prefLabel "AIFF 오디오"@ko ;
+  skos:prefLabel "AIFF-Audio"@de ;
+  skos:prefLabel "AIFF-hang"@hu ;
+  skos:prefLabel "AIFF-ljud"@sv ;
+  skos:prefLabel "AIFF-lyd"@nn ;
+  skos:prefLabel "AIFF-lyd"@no ;
+  skos:prefLabel "AIFF-ääni"@fi ;
+  skos:prefLabel "Sain AIFF"@cy ;
+  skos:prefLabel "Zvuk AIFF"@cs ;
+  skos:prefLabel "audio AIFF"@fr ;
+  skos:prefLabel "Ήχος AIFF"@el .
+
+media-type:audio_x-flac a skos:Concept ;
+  media-type:hasMediaType "audio/x-flac" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "FLAC audio"@en ;
+  skos:prefLabel "FLAC-Audio"@de ;
+  skos:prefLabel "FLAC-lyd"@no ;
+  skos:prefLabel "FLAC-ääni"@fi ;
+  skos:prefLabel "Ήχος FLAC"@el .
+
+media-type:audio_x-it a skos:Concept ;
+  media-type:hasMediaType "audio/x-it" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Impulse Tracker -ääni"@fi ;
+  skos:prefLabel "Impulse Tracker audio faylı"@az ;
+  skos:prefLabel "Impulse Tracker audio"@en ;
+  skos:prefLabel "Impulse Tracker geluidsbestand"@nl ;
+  skos:prefLabel "Impulse Tracker hang"@hu ;
+  skos:prefLabel "Impulse Tracker lyd"@nn ;
+  skos:prefLabel "Impulse Tracker звучни запис"@sr ;
+  skos:prefLabel "Impulse Tracker 오디오"@ko ;
+  skos:prefLabel "Impulse Tracker-Audio"@de ;
+  skos:prefLabel "Impulse Tracker-ljud"@sv ;
+  skos:prefLabel "Impulse Tracker-lyd"@no ;
+  skos:prefLabel "Sain Impulse Tracker"@cy ;
+  skos:prefLabel "Zvuk Impulse Tracker"@cs ;
+  skos:prefLabel "audio Impulse Tracker"@fr ;
+  skos:prefLabel "Ήχος Impulse Tracker"@el .
+
+media-type:audio_x-mod a skos:Concept ;
+  media-type:hasMediaType "audio/x-mod" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Amiga SoundTracker -ääni"@fi ;
+  skos:prefLabel "Amiga SoundTracker audio"@en ;
+  skos:prefLabel "Amiga SoundTracker-Audio"@de ;
+  skos:prefLabel "Amiga SoundTracker-lyd"@no .
+
+media-type:audio_x-mp3 a skos:Concept ;
+  media-type:hasMediaType "audio/x-mp3" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MP3 audio faylı"@az ;
+  skos:prefLabel "MP3 audio"@en ;
+  skos:prefLabel "MP3 geluidsbestand"@nl ;
+  skos:prefLabel "MP3 звучни запис"@sr ;
+  skos:prefLabel "MP3 오디오"@ko ;
+  skos:prefLabel "MP3-Audio"@de ;
+  skos:prefLabel "MP3-hang"@hu ;
+  skos:prefLabel "MP3-ljud"@sv ;
+  skos:prefLabel "MP3-lyd"@nn ;
+  skos:prefLabel "MP3-lyd"@no ;
+  skos:prefLabel "MP3-ääni"@fi ;
+  skos:prefLabel "Sain MP3"@cy ;
+  skos:prefLabel "Zvuk MP3"@cs ;
+  skos:prefLabel "audio MP3"@fr ;
+  skos:prefLabel "Ήχος MP3"@el .
+
+media-type:audio_x-mp3-playlist a skos:Concept ;
+  media-type:hasMediaType "audio/x-mp3-playlist" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MP3 playlist"@en ;
+  skos:prefLabel "MP3-Wiedergabeliste"@de ;
+  skos:prefLabel "MP3-soittolista"@fi ;
+  skos:prefLabel "MP3-spilleliste"@no .
+
+media-type:audio_x-mpeg a skos:Concept ;
+  media-type:hasMediaType "audio/x-mpeg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MP3 audio faylı"@az ;
+  skos:prefLabel "MP3 audio"@en ;
+  skos:prefLabel "MP3 geluidsbestand"@nl ;
+  skos:prefLabel "MP3 звучни запис"@sr ;
+  skos:prefLabel "MP3 오디오"@ko ;
+  skos:prefLabel "MP3-Audio"@de ;
+  skos:prefLabel "MP3-hang"@hu ;
+  skos:prefLabel "MP3-ljud"@sv ;
+  skos:prefLabel "MP3-lyd"@nn ;
+  skos:prefLabel "MP3-lyd"@no ;
+  skos:prefLabel "MP3-ääni"@fi ;
+  skos:prefLabel "Sain MP3"@cy ;
+  skos:prefLabel "Zvuk MP3"@cs ;
+  skos:prefLabel "audio MP3"@fr ;
+  skos:prefLabel "Ήχος MP3"@el .
+
+media-type:audio_x-mpegurl a skos:Concept ;
+  media-type:hasMediaType "audio/x-mpegurl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MP3 audio (streamed)"@en ;
+  skos:prefLabel "MP3-Audio (Stream)"@de ;
+  skos:prefLabel "MP3-lyd (streaming)"@no ;
+  skos:prefLabel "MP3-ääni (virtaava)"@fi .
+
+media-type:audio_x-ms-asx a skos:Concept ;
+  media-type:hasMediaType "audio/x-ms-asx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Afspeellijst"@nl ;
+  skos:prefLabel "Lejátszható felvételek listája"@hu ;
+  skos:prefLabel "Playlist"@en ;
+  skos:prefLabel "Playlist"@fr ;
+  skos:prefLabel "Rhestr Chwarae"@cy ;
+  skos:prefLabel "Seznam skladeb"@cs ;
+  skos:prefLabel "Speleliste"@nn ;
+  skos:prefLabel "Spellista"@sv ;
+  skos:prefLabel "Spilleliste"@no ;
+  skos:prefLabel "Wiedergabeliste"@de ;
+  skos:prefLabel "soittolista"@fi ;
+  skos:prefLabel "Çalğı siyahısı"@az ;
+  skos:prefLabel "Λίστα τραγουδιών"@el ;
+  skos:prefLabel "Листа нумера"@sr ;
+  skos:prefLabel "연주목록"@ko .
+
+media-type:audio_x-pn-realaudio a skos:Concept ;
+  media-type:hasMediaType "audio/x-pn-realaudio" ;
+  skos:exactMatch media-type:audio_vndrn-realaudio ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Darllediad RealAudio"@cy ;
+  skos:prefLabel "RealAudio broadcast"@en ;
+  skos:prefLabel "RealAudio uitzending"@nl ;
+  skos:prefLabel "RealAudio yayımı"@az ;
+  skos:prefLabel "RealAudio емитовање"@sr ;
+  skos:prefLabel "RealAudio-Broadcast"@de ;
+  skos:prefLabel "RealAudio-kringkasting"@nn ;
+  skos:prefLabel "RealAudio-sending"@no ;
+  skos:prefLabel "RealAudio-sugárzás"@hu ;
+  skos:prefLabel "RealAudio-utsändning"@sv ;
+  skos:prefLabel "RealAudio-yleislähetys"@fi ;
+  skos:prefLabel "Vysílání RealAudio"@cs ;
+  skos:prefLabel "diffusion RealAudio"@fr ;
+  skos:prefLabel "리얼오디오 방송"@ko .
+
+media-type:audio_x-riff a skos:Concept ;
+  media-type:hasMediaType "audio/x-riff" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "RIFF audio faylı"@az ;
+  skos:prefLabel "RIFF audio"@en ;
+  skos:prefLabel "RIFF geluidsbestand"@nl ;
+  skos:prefLabel "RIFF звучни запис"@sr ;
+  skos:prefLabel "RIFF 오디오"@ko ;
+  skos:prefLabel "RIFF-Audio"@de ;
+  skos:prefLabel "RIFF-kép"@hu ;
+  skos:prefLabel "RIFF-ljud"@sv ;
+  skos:prefLabel "RIFF-lyd"@nn ;
+  skos:prefLabel "RIFF-lyd"@no ;
+  skos:prefLabel "RIFF-ääni"@fi ;
+  skos:prefLabel "Sain RIFF"@cy ;
+  skos:prefLabel "Zvuk RIFF"@cs ;
+  skos:prefLabel "audio RIFF"@fr ;
+  skos:prefLabel "Ήχος RIFF"@el .
+
+media-type:audio_x-s3m a skos:Concept ;
+  media-type:hasMediaType "audio/x-s3m" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sain Scream Tracker 3"@cy ;
+  skos:prefLabel "Scream Tracker 3 -ääni"@fi ;
+  skos:prefLabel "Scream Tracker 3 audio faylı"@az ;
+  skos:prefLabel "Scream Tracker 3 audio"@en ;
+  skos:prefLabel "Scream Tracker 3 geluidsbestand"@nl ;
+  skos:prefLabel "Scream Tracker 3 звучни запис"@sr ;
+  skos:prefLabel "Scream Tracker 3 오디오"@ko ;
+  skos:prefLabel "Scream Tracker 3-Audio"@de ;
+  skos:prefLabel "Scream Tracker 3-hang"@hu ;
+  skos:prefLabel "Scream Tracker 3-ljud"@sv ;
+  skos:prefLabel "Scream Tracker 3-lyd"@no ;
+  skos:prefLabel "Skladba Scream Tracker 3"@cs ;
+  skos:prefLabel "Sream Tracker 3 lyd"@nn ;
+  skos:prefLabel "aiudio Scream Tracker 3"@fr ;
+  skos:prefLabel "Ήχος Scream Tracker 3"@el .
+
+media-type:audio_x-scpls a skos:Concept ;
+  media-type:hasMediaType "audio/x-scpls" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MP3 ShoutCast -soittolista"@fi ;
+  skos:prefLabel "MP3 ShoutCast playlist"@en ;
+  skos:prefLabel "MP3 ShoutCast-spilleliste"@no ;
+  skos:prefLabel "MP3-ShoutCast-Wiedergabeliste"@de .
+
+media-type:audio_x-stm a skos:Concept ;
+  media-type:hasMediaType "audio/x-stm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sain Scream Tracker"@cy ;
+  skos:prefLabel "Scream Tracker -ääni"@fi ;
+  skos:prefLabel "Scream Tracker audio faylı"@az ;
+  skos:prefLabel "Scream Tracker audio"@en ;
+  skos:prefLabel "Scream Tracker geluidsbestand"@nl ;
+  skos:prefLabel "Scream Tracker lyd"@nn ;
+  skos:prefLabel "Scream Tracker звучни запис"@sr ;
+  skos:prefLabel "Scream Tracker 오디오"@ko ;
+  skos:prefLabel "Scream Tracker-Audio"@de ;
+  skos:prefLabel "Scream Tracker-hang"@hu ;
+  skos:prefLabel "Scream Tracker-ljud"@sv ;
+  skos:prefLabel "Scream Tracker-lyd"@no ;
+  skos:prefLabel "Skladba Scream Tracker"@cs ;
+  skos:prefLabel "audio Scream Tracker"@fr ;
+  skos:prefLabel "Ήχος Scream Tracker"@el .
+
+media-type:audio_x-voc a skos:Concept ;
+  media-type:hasMediaType "audio/x-voc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sain VOC"@cy ;
+  skos:prefLabel "VOC audio faylı"@az ;
+  skos:prefLabel "VOC audio"@en ;
+  skos:prefLabel "VOC geluidsbestand"@nl ;
+  skos:prefLabel "VOC звучни запис"@sr ;
+  skos:prefLabel "VOC 오디오"@ko ;
+  skos:prefLabel "VOC-Audio"@de ;
+  skos:prefLabel "VOC-hang"@hu ;
+  skos:prefLabel "VOC-ljud"@sv ;
+  skos:prefLabel "VOC-lyd"@nn ;
+  skos:prefLabel "VOC-lyd"@no ;
+  skos:prefLabel "VOC-ääni"@fi ;
+  skos:prefLabel "Zvuk VOC"@cs ;
+  skos:prefLabel "audio VOC"@fr ;
+  skos:prefLabel "Ήχος VOC"@el .
+
+media-type:audio_x-wav a skos:Concept ;
+  media-type:hasMediaType "audio/x-wav" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Sain WAV"@cy ;
+  skos:prefLabel "WAV audio faylı"@az ;
+  skos:prefLabel "WAV audio"@en ;
+  skos:prefLabel "WAV geluidsbestand"@nl ;
+  skos:prefLabel "WAV звучни запис"@sr ;
+  skos:prefLabel "WAV 오디오"@ko ;
+  skos:prefLabel "WAV-Audio"@de ;
+  skos:prefLabel "WAV-hang"@hu ;
+  skos:prefLabel "WAV-ljud"@sv ;
+  skos:prefLabel "WAV-lyd"@nn ;
+  skos:prefLabel "WAV-lyd"@no ;
+  skos:prefLabel "WAV-ääni"@fi ;
+  skos:prefLabel "Zvuk WAV"@cs ;
+  skos:prefLabel "audio WAV"@fr ;
+  skos:prefLabel "Ήχος WAV"@el .
+
+media-type:audio_x-xi a skos:Concept ;
+  media-type:hasMediaType "audio/x-xi" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Nástroj pro Scream Tracker"@cs ;
+  skos:prefLabel "Offeryn Scream Tracker"@cy ;
+  skos:prefLabel "Scream Tracker -soitin"@fi ;
+  skos:prefLabel "Scream Tracker instrument"@en ;
+  skos:prefLabel "Scream Tracker instrument"@nl ;
+  skos:prefLabel "Scream Tracker instrument"@nn ;
+  skos:prefLabel "Scream Tracker instrumenti"@az ;
+  skos:prefLabel "Scream Tracker инструмент"@sr ;
+  skos:prefLabel "Scream Tracker 악기"@ko ;
+  skos:prefLabel "Scream Tracker-Instrument"@de ;
+  skos:prefLabel "Scream Tracker-hangszer"@hu ;
+  skos:prefLabel "Scream Tracker-instrument"@no ;
+  skos:prefLabel "Scream Tracker-instrument"@sv ;
+  skos:prefLabel "instrument Scream Tracker"@fr ;
+  skos:prefLabel "Μουσικό όργανο Scream Tracker"@el .
+
+media-type:audio_x-xm a skos:Concept ;
+  media-type:hasMediaType "audio/x-xm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "FastTracker II -ääni"@fi ;
+  skos:prefLabel "FastTracker II audio faylı"@az ;
+  skos:prefLabel "FastTracker II audio"@en ;
+  skos:prefLabel "FastTracker II geluidsbestand"@nl ;
+  skos:prefLabel "FastTracker II lyd"@nn ;
+  skos:prefLabel "FastTracker II аудио запис"@sr ;
+  skos:prefLabel "FastTracker II 오디오"@ko ;
+  skos:prefLabel "FastTracker II-Audio"@de ;
+  skos:prefLabel "FastTracker II-hang"@hu ;
+  skos:prefLabel "FastTracker II-ljud"@sv ;
+  skos:prefLabel "FastTracker II-lyd"@no ;
+  skos:prefLabel "Sain FastTracker II"@cy ;
+  skos:prefLabel "Zvuk FastTracker II"@cs ;
+  skos:prefLabel "audio FastTracker II"@fr ;
+  skos:prefLabel "Ήχος FastTracker II"@el .
+
+media-type:example a skos:Collection ;
+  rdfs:label "Example types"@en ;
+  dct:description "The collection of example types"@en ;
+  dct:title "Example types"@en .
+
+media-type:font a skos:Collection ;
+  rdfs:label "Font types"@en ;
+  dct:description "The collection of font types"@en ;
+  dct:title "Font types"@en .
+
+media-type:image a skos:Collection ;
+  rdfs:label "Image types"@en ;
+  dct:description "The collection of image types"@en ;
+  dct:title "Image types"@en ;
+  skos:member media-type:image_bmp ;
+  skos:member media-type:image_cgm ;
+  skos:member media-type:image_dpx ;
+  skos:member media-type:image_fax-g3 ;
+  skos:member media-type:image_g3fax ;
+  skos:member media-type:image_gif ;
+  skos:member media-type:image_ief ;
+  skos:member media-type:image_jpeg ;
+  skos:member media-type:image_jpeg2000 ;
+  skos:member media-type:image_png ;
+  skos:member media-type:image_rle ;
+  skos:member media-type:image_svgxml ;
+  skos:member media-type:image_tiff ;
+  skos:member media-type:image_vnddjvu ;
+  skos:member media-type:image_vnddwg ;
+  skos:member media-type:image_vnddxf ;
+  skos:member media-type:image_x-3ds ;
+  skos:member media-type:image_x-applix-graphics ;
+  skos:member media-type:image_x-cmu-raster ;
+  skos:member media-type:image_x-compressed-xcf ;
+  skos:member media-type:image_x-dcm ;
+  skos:member media-type:image_x-dib ;
+  skos:member media-type:image_x-eps ;
+  skos:member media-type:image_x-fits ;
+  skos:member media-type:image_x-fpx ;
+  skos:member media-type:image_x-icb ;
+  skos:member media-type:image_x-ico ;
+  skos:member media-type:image_x-iff ;
+  skos:member media-type:image_x-ilbm ;
+  skos:member media-type:image_x-jng ;
+  skos:member media-type:image_x-lwo ;
+  skos:member media-type:image_x-lws ;
+  skos:member media-type:image_x-msod ;
+  skos:member media-type:image_x-niff ;
+  skos:member media-type:image_x-pcx ;
+  skos:member media-type:image_x-photo-cd ;
+  skos:member media-type:image_x-pict ;
+  skos:member media-type:image_x-portable-anymap ;
+  skos:member media-type:image_x-portable-bitmap ;
+  skos:member media-type:image_x-portable-graymap ;
+  skos:member media-type:image_x-portable-pixmap ;
+  skos:member media-type:image_x-psd ;
+  skos:member media-type:image_x-rgb ;
+  skos:member media-type:image_x-sgi ;
+  skos:member media-type:image_x-sun-raster ;
+  skos:member media-type:image_x-tga ;
+  skos:member media-type:image_x-win-bitmap ;
+  skos:member media-type:image_x-wmf ;
+  skos:member media-type:image_x-xbitmap ;
+  skos:member media-type:image_x-xcf ;
+  skos:member media-type:image_x-xfig ;
+  skos:member media-type:image_x-xpixmap ;
+  skos:member media-type:image_x-xwindowdump .
+
+media-type:image_bmp a skos:Concept ;
+  media-type:hasMediaType "image/bmp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd BMP Windows"@cy ;
+  skos:prefLabel "Obrázek Windows BMP"@cs ;
+  skos:prefLabel "Windows BMP -kuva"@fi ;
+  skos:prefLabel "Windows BMP afbeelding"@nl ;
+  skos:prefLabel "Windows BMP image"@en ;
+  skos:prefLabel "Windows BMP rəsmi"@az ;
+  skos:prefLabel "Windows BMP слика"@sr ;
+  skos:prefLabel "Windows BMP-bild"@sv ;
+  skos:prefLabel "Windows BMP-bilde"@no ;
+  skos:prefLabel "Windows BMP-bilete"@nn ;
+  skos:prefLabel "Windows BMP-fájl"@hu ;
+  skos:prefLabel "Windows-BMP-Bild"@de ;
+  skos:prefLabel "image Windows BMP"@fr ;
+  skos:prefLabel "Εικόνα Windows BMP"@el ;
+  skos:prefLabel "윈도우즈 BMP 이미지"@ko .
+
+media-type:image_cgm a skos:Concept ;
+  media-type:hasMediaType "image/cgm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CGM-Datei"@de ;
+  skos:prefLabel "Computer Graphics -metatiedosto"@fi ;
+  skos:prefLabel "Computer Graphics Metabestand"@nl ;
+  skos:prefLabel "Computer Graphics Metafil"@sv ;
+  skos:prefLabel "Computer Graphics Metafile"@cs ;
+  skos:prefLabel "Computer Graphics Metafile"@en ;
+  skos:prefLabel "Computer Graphics Metafile"@nn ;
+  skos:prefLabel "Computer Graphics Metafile"@no ;
+  skos:prefLabel "Computer Graphics-metafájl"@hu ;
+  skos:prefLabel "Delwedd ffurf CGM"@cy ;
+  skos:prefLabel "Kompüter Qrafikası Meta Faylı"@az ;
+  skos:prefLabel "métafichier Computer Graphics"@fr ;
+  skos:prefLabel "Метадатотека са рачунарском графиком (CGM)"@sr ;
+  skos:prefLabel "컴퓨터 그래픽스 메타파일"@ko .
+
+media-type:image_dpx a skos:Concept ;
+  media-type:hasMediaType "image/dpx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DPX-Bild"@de ;
+  skos:prefLabel "DPX-bild (Digital Moving Picture Exchange)"@sv ;
+  skos:prefLabel "Delwedd Digital Moving Picture Exchange"@cy ;
+  skos:prefLabel "Digital Moving Picture Exchange -kuva"@fi ;
+  skos:prefLabel "Digital Moving Picture Exchange afbeelding"@nl ;
+  skos:prefLabel "Digital Moving Picture Exchange image"@en ;
+  skos:prefLabel "Digital Moving Picture Exchange rəsmi"@az ;
+  skos:prefLabel "Digital Moving Picture Exchange 이미지"@ko ;
+  skos:prefLabel "Digital Moving Picture Exchange-bilete"@nn ;
+  skos:prefLabel "Digital Moving Picture Exchange-kép"@hu ;
+  skos:prefLabel "Digital Moving Pitcure Exchange bilde"@no ;
+  skos:prefLabel "Obrázek Digital Moving Picture Exchange"@cs ;
+  skos:prefLabel "image « Digital Moving Picture Exchange »"@fr ;
+  skos:prefLabel "Дигитални облик за размену покретних слика"@sr .
+
+media-type:image_fax-g3 a skos:Concept ;
+  media-type:hasMediaType "image/fax-g3" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CCITT G3 fax"@en ;
+  skos:prefLabel "CCITT G3-faks"@no ;
+  skos:prefLabel "CCITT g3 -faksi"@fi ;
+  skos:prefLabel "CCITT-G3-Fax"@de ;
+  skos:prefLabel "Φαξ CCITT G3"@el .
+
+media-type:image_g3fax a skos:Concept ;
+  media-type:hasMediaType "image/g3fax" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd Ffacs G3"@cy ;
+  skos:prefLabel "G3 faks rəsmi"@az ;
+  skos:prefLabel "G3 faksbilete"@nn ;
+  skos:prefLabel "G3 fax afbeelding"@nl ;
+  skos:prefLabel "G3 fax image"@en ;
+  skos:prefLabel "G3 факс слика"@sr ;
+  skos:prefLabel "G3 팩스 이미지"@ko ;
+  skos:prefLabel "G3-Faxbild"@de ;
+  skos:prefLabel "G3-faksbilde"@no ;
+  skos:prefLabel "G3-faksikuva"@fi ;
+  skos:prefLabel "G3-faxbild"@sv ;
+  skos:prefLabel "G3-faxkép"@hu ;
+  skos:prefLabel "Obrázek G3 fax"@cs ;
+  skos:prefLabel "image de télécopie G3 « fax »"@fr ;
+  skos:prefLabel "Εικόνα φαξ G3"@el .
+
+media-type:image_gif a skos:Concept ;
+  media-type:hasMediaType "image/gif" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd GIF"@cy ;
+  skos:prefLabel "GIF afbeelding"@nl ;
+  skos:prefLabel "GIF image"@en ;
+  skos:prefLabel "GIF rəsmi"@az ;
+  skos:prefLabel "GIF слика"@sr ;
+  skos:prefLabel "GIF 이미지"@ko ;
+  skos:prefLabel "GIF-Bild"@de ;
+  skos:prefLabel "GIF-bild"@sv ;
+  skos:prefLabel "GIF-bilde"@no ;
+  skos:prefLabel "GIF-bilete"@nn ;
+  skos:prefLabel "GIF-kuva"@fi ;
+  skos:prefLabel "GIF-kép"@hu ;
+  skos:prefLabel "Obrázek GIF"@cs ;
+  skos:prefLabel "image GIF"@fr ;
+  skos:prefLabel "Εικόνα GIF"@el .
+
+media-type:image_ief a skos:Concept ;
+  media-type:hasMediaType "image/ief" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd IEF"@cy ;
+  skos:prefLabel "IEF afbeelding"@nl ;
+  skos:prefLabel "IEF image"@en ;
+  skos:prefLabel "IEF rəsmi"@az ;
+  skos:prefLabel "IEF слика"@sr ;
+  skos:prefLabel "IEF 이미지"@ko ;
+  skos:prefLabel "IEF-Bild"@de ;
+  skos:prefLabel "IEF-bild"@sv ;
+  skos:prefLabel "IEF-bilde"@no ;
+  skos:prefLabel "IEF-bilete"@nn ;
+  skos:prefLabel "IEF-kuva"@fi ;
+  skos:prefLabel "IEF-kép"@hu ;
+  skos:prefLabel "Obrázek IEF"@cs ;
+  skos:prefLabel "image IEF"@fr ;
+  skos:prefLabel "Εικόνα IEF"@el .
+
+media-type:image_jpeg a skos:Concept ;
+  media-type:hasMediaType "image/jpeg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd JPEG"@cy ;
+  skos:prefLabel "JPEG afbeelding"@nl ;
+  skos:prefLabel "JPEG image"@en ;
+  skos:prefLabel "JPEG rəsmi"@az ;
+  skos:prefLabel "JPEG слика"@sr ;
+  skos:prefLabel "JPEG 이미지"@ko ;
+  skos:prefLabel "JPEG-Bild"@de ;
+  skos:prefLabel "JPEG-bild"@sv ;
+  skos:prefLabel "JPEG-bilde"@no ;
+  skos:prefLabel "JPEG-bilete"@nn ;
+  skos:prefLabel "JPEG-kuva"@fi ;
+  skos:prefLabel "JPEG-kép"@hu ;
+  skos:prefLabel "Obrázek JPEG"@cs ;
+  skos:prefLabel "image JPEG"@fr ;
+  skos:prefLabel "Εικόνα JPEG"@el .
+
+media-type:image_jpeg2000 a skos:Concept ;
+  media-type:hasMediaType "image/jpeg2000" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "JPEG-2000 -kuva"@fi ;
+  skos:prefLabel "JPEG-2000 image"@en ;
+  skos:prefLabel "JPEG-2000-Bild"@de ;
+  skos:prefLabel "Εικόνα JPEG-2000"@el .
+
+media-type:image_png a skos:Concept ;
+  media-type:hasMediaType "image/png" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd PNG"@cy ;
+  skos:prefLabel "Obrázek PNG"@cs ;
+  skos:prefLabel "PNG afbeelding"@nl ;
+  skos:prefLabel "PNG image"@en ;
+  skos:prefLabel "PNG rəsmi"@az ;
+  skos:prefLabel "PNG слика"@sr ;
+  skos:prefLabel "PNG 이미지"@ko ;
+  skos:prefLabel "PNG-Bild"@de ;
+  skos:prefLabel "PNG-bild"@sv ;
+  skos:prefLabel "PNG-bilde"@no ;
+  skos:prefLabel "PNG-bilete"@nn ;
+  skos:prefLabel "PNG-kuva"@fi ;
+  skos:prefLabel "PNG-kép"@hu ;
+  skos:prefLabel "image PNG"@fr ;
+  skos:prefLabel "Εικόνα PNG"@el .
+
+media-type:image_rle a skos:Concept ;
+  media-type:hasMediaType "image/rle" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "RLE-Bitmap"@de ;
+  skos:prefLabel "Run Length Encoded bitmap"@en .
+
+media-type:image_svgxml a skos:Concept ;
+  media-type:hasMediaType "image/svg+xml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "SVG-kuva"@fi ;
+  skos:prefLabel "scalable SVG image"@en ;
+  skos:prefLabel "skalerbart SVG-bilde"@no ;
+  skos:prefLabel "skalierbares SVG-Bild"@de .
+
+media-type:image_tiff a skos:Concept ;
+  media-type:hasMediaType "image/tiff" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "TIFF image"@en ;
+  skos:prefLabel "TIFF-Bild"@de ;
+  skos:prefLabel "TIFF-bild"@sv ;
+  skos:prefLabel "TIFF-bilde"@no ;
+  skos:prefLabel "TIFF-kuva"@fi ;
+  skos:prefLabel "Εικόνα TIFF"@el .
+
+media-type:image_vnddjvu a skos:Concept ;
+  media-type:hasMediaType "image/vnd.djvu" ;
+  skos:exactMatch media-type:image_x-djvu ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DjVu -kuva"@fi ;
+  skos:prefLabel "DjVu image"@en ;
+  skos:prefLabel "DjVu 이미지"@ko ;
+  skos:prefLabel "DjVu-Bild"@de ;
+  skos:prefLabel "DjVu-bilde"@no ;
+  skos:prefLabel "DjVu-bilete"@nn ;
+  skos:prefLabel "Εικόνα DjVu"@el .
+
+media-type:image_vnddwg a skos:Concept ;
+  media-type:hasMediaType "image/vnd.dwg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AutoCAD afbeelding"@nl ;
+  skos:prefLabel "AutoCAD image"@en ;
+  skos:prefLabel "AutoCAD rəsmi"@az ;
+  skos:prefLabel "AutoCAD слика"@sr ;
+  skos:prefLabel "AutoCAD 이미지"@ko ;
+  skos:prefLabel "AutoCAD-Bild"@de ;
+  skos:prefLabel "AutoCAD-bild"@sv ;
+  skos:prefLabel "AutoCAD-bilde"@no ;
+  skos:prefLabel "AutoCAD-bilete"@nn ;
+  skos:prefLabel "AutoCAD-kuva"@fi ;
+  skos:prefLabel "AutoCAD-kép"@hu ;
+  skos:prefLabel "Delwedd AutoCAD"@cy ;
+  skos:prefLabel "Obrázek AutoCAD"@cs ;
+  skos:prefLabel "image AutoCAD"@fr ;
+  skos:prefLabel "Εικόνα AutoCAD"@el .
+
+media-type:image_vnddxf a skos:Concept ;
+  media-type:hasMediaType "image/vnd.dxf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DXF vector image"@en ;
+  skos:prefLabel "DXF-Vektorbild"@de ;
+  skos:prefLabel "DXF-vektorgrafikk"@no ;
+  skos:prefLabel "DXF-vektorigrafiikka"@fi .
+
+media-type:image_x-3ds a skos:Concept ;
+  media-type:hasMediaType "image/x-3ds" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "3D Studio -kuva"@fi ;
+  skos:prefLabel "3D Studio afbeelding"@nl ;
+  skos:prefLabel "3D Studio image"@en ;
+  skos:prefLabel "3D Studio rəsmi"@az ;
+  skos:prefLabel "3D Studio слика"@sr ;
+  skos:prefLabel "3D Studio 이미지"@ko ;
+  skos:prefLabel "3D Studio-Bild"@de ;
+  skos:prefLabel "3D Studio-bild"@sv ;
+  skos:prefLabel "3D Studio-bilde"@no ;
+  skos:prefLabel "3D Studio-bilete"@nn ;
+  skos:prefLabel "3D Studio-kép"@hu ;
+  skos:prefLabel "Delwedd '3D Studio'"@cy ;
+  skos:prefLabel "Obrázek aplikace 3D Studio"@cs ;
+  skos:prefLabel "image 3D Studio"@fr ;
+  skos:prefLabel "Εικόνα 3D Studio"@el .
+
+media-type:image_x-applix-graphics a skos:Concept ;
+  media-type:hasMediaType "image/x-applix-graphics" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Applix Graphics -kuva"@fi ;
+  skos:prefLabel "Applix Graphics image"@en ;
+  skos:prefLabel "Applix Graphics-Bild"@de ;
+  skos:prefLabel "Applix Graphics-dokument"@no ;
+  skos:prefLabel "Εικόνα  Applix Graphics"@el .
+
+media-type:image_x-cmu-raster a skos:Concept ;
+  media-type:hasMediaType "image/x-cmu-raster" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CMU raster afbeelding"@nl ;
+  skos:prefLabel "CMU raster image"@en ;
+  skos:prefLabel "CMU raster rəsmi"@az ;
+  skos:prefLabel "CMU raster-bilete"@nn ;
+  skos:prefLabel "CMU растерска слика"@sr ;
+  skos:prefLabel "CMU 래스터 이미지"@ko ;
+  skos:prefLabel "CMU-Rasterbild"@de ;
+  skos:prefLabel "CMU-rasterbild"@sv ;
+  skos:prefLabel "CMU-rasterbilde"@no ;
+  skos:prefLabel "CMU-rasterikuva"@fi ;
+  skos:prefLabel "CMU-raszterkép"@hu ;
+  skos:prefLabel "Delwedd raster CMU"@cy ;
+  skos:prefLabel "Rastrový obrázek CMU"@cs ;
+  skos:prefLabel "image raster CMU"@fr .
+
+media-type:image_x-compressed-xcf a skos:Concept ;
+  media-type:hasMediaType "image/x-compressed-xcf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GIMP image (compressed)"@en ;
+  skos:prefLabel "GIMP-Bild (komprimiert)"@de ;
+  skos:prefLabel "GIMP-bilde (komprimert)"@no ;
+  skos:prefLabel "GIMP-kuva (pakattu)"@fi ;
+  skos:prefLabel "Εικόνα GIMP (Συμπιεσμένη)"@el .
+
+media-type:image_x-dcm a skos:Concept ;
+  media-type:hasMediaType "image/x-dcm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bildformat för digital bildbehandling och medicinsk kommunikation"@sv ;
+  skos:prefLabel "DICOM-Bild"@de ;
+  skos:prefLabel "Delwedd DCIM (Digital Imaging and Communications in Medicine)"@cy ;
+  skos:prefLabel "Digital Imaging and Communications in Medicine -kuva"@fi ;
+  skos:prefLabel "Digital Imaging and Communications in Medicine image"@en ;
+  skos:prefLabel "Digital Imaging and Communications in Medicine-bilde"@no ;
+  skos:prefLabel "Digital Imaging and Communications in Medicine-bilete"@nn ;
+  skos:prefLabel "Digital Imaging and Communications in Medicine-kép"@hu ;
+  skos:prefLabel "Dijital Rəsm və Tibbdə Rabitə rəsmi"@az ;
+  skos:prefLabel "Obrázek Digital Imaging and Communications in Medicine"@cs ;
+  skos:prefLabel "image « Digital Imaging and Communications in Medicine »"@fr ;
+  skos:prefLabel "Слика за дигиталну фотографију и комуникацију у медицини"@sr ;
+  skos:prefLabel "의료 사진용 디지털 이미지 및 통신"@ko .
+
+media-type:image_x-dib a skos:Concept ;
+  media-type:hasMediaType "image/x-dib" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Apparaat onafhankelijke bitmap"@nl ;
+  skos:prefLabel "Avadanlıqdan Müstəqil Bitmap"@az ;
+  skos:prefLabel "Bitmapa nezávislá na zařízení"@cs ;
+  skos:prefLabel "Device Independant Bitmap"@en ;
+  skos:prefLabel "Didfap Dyfais-Annibynol"@cy ;
+  skos:prefLabel "Einingsuavhengig bitkart"@nn ;
+  skos:prefLabel "Enhetsoberoende bitmapp"@sv ;
+  skos:prefLabel "Enhetsuavhengig bitkart"@no ;
+  skos:prefLabel "Eszközfüggetlen bitkép"@hu ;
+  skos:prefLabel "Geräteunabhängige Bitmap"@de ;
+  skos:prefLabel "bitmap indépendant du périphérique"@fr ;
+  skos:prefLabel "laiteriippumaton bittikartta"@fi ;
+  skos:prefLabel "Битмапа независна од уређаја"@sr ;
+  skos:prefLabel "장치 독립 비트맵"@ko .
+
+media-type:image_x-eps a skos:Concept ;
+  media-type:hasMediaType "image/x-eps" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd PostScript wedi ei chrisialu"@cy ;
+  skos:prefLabel "EPS-Bild"@de ;
+  skos:prefLabel "Encapsulated PostScript image"@en ;
+  skos:prefLabel "Encapsulated PostScript rəsmi"@az ;
+  skos:prefLabel "Encapsulated PostScript-bilete"@nn ;
+  skos:prefLabel "Encapsulated PostScript-kép"@hu ;
+  skos:prefLabel "Ingekapselde Postscript afbeelding"@nl ;
+  skos:prefLabel "Inkapslad PostScript-bild"@sv ;
+  skos:prefLabel "Obrázek v zapouzdřeném Postscriptu"@cs ;
+  skos:prefLabel "image encapsulé PostScript"@fr ;
+  skos:prefLabel "kapsuloitu PostScript-kuva"@fi ;
+  skos:prefLabel "Εικόνα Encapsulated PostScript"@el ;
+  skos:prefLabel "Угњеждена ПостСкрипт слика (EPS)"@sr ;
+  skos:prefLabel "캡슐화된 포스트스크립트 이미지"@ko .
+
+media-type:image_x-fits a skos:Concept ;
+  media-type:hasMediaType "image/x-fits" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "FITS-Dokument"@de ;
+  skos:prefLabel "Fleksibelt bildetransportsystem"@no ;
+  skos:prefLabel "Flexibel afbeeldingstransportsysteem"@nl ;
+  skos:prefLabel "Flexibelt bildtransportssystem"@sv ;
+  skos:prefLabel "Flexible Image Transport System"@cs ;
+  skos:prefLabel "Flexible Image Transport System"@en ;
+  skos:prefLabel "Flexible Image Transport System"@fi ;
+  skos:prefLabel "Flexible Image Transport System"@hu ;
+  skos:prefLabel "Flexible Image Transport System"@ko ;
+  skos:prefLabel "Flexible Image Transport System"@nn ;
+  skos:prefLabel "Flexible Rəsm Transport Sistemi"@az ;
+  skos:prefLabel "System Trosgludo Delweddau Hyblyg"@cy ;
+  skos:prefLabel "système de transport « Flexible Image »"@fr ;
+  skos:prefLabel "Флексибилни транспортни систем слика"@sr .
+
+media-type:image_x-fpx a skos:Concept ;
+  media-type:hasMediaType "image/x-fpx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "FlashPix image"@en ;
+  skos:prefLabel "FlashPix-Bild"@de ;
+  skos:prefLabel "FlashPix-bilde"@no ;
+  skos:prefLabel "FlashPix-kuva"@fi ;
+  skos:prefLabel "Εικόνα FlashPix"@el .
+
+media-type:image_x-icb a skos:Concept ;
+  media-type:hasMediaType "image/x-icb" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd Targa Truevision"@cy ;
+  skos:prefLabel "Obrázek Truevision Targa"@cs ;
+  skos:prefLabel "Truevision Targa -kuva"@fi ;
+  skos:prefLabel "Truevision Targa afbeelding"@nl ;
+  skos:prefLabel "Truevision Targa image"@en ;
+  skos:prefLabel "Truevision Targa rəsmi"@az ;
+  skos:prefLabel "Truevision Targa слика"@sr ;
+  skos:prefLabel "Truevision Targa 이미지"@ko ;
+  skos:prefLabel "Truevision Targa-bild"@sv ;
+  skos:prefLabel "Truevision Targa-bilde"@no ;
+  skos:prefLabel "Truevision Targa-bilete"@nn ;
+  skos:prefLabel "Truevision Targa-kép"@hu ;
+  skos:prefLabel "Truevision-Targa-Bild"@de ;
+  skos:prefLabel "image Truevision Targa"@fr ;
+  skos:prefLabel "Εικόνα Truevision Targa"@el .
+
+media-type:image_x-ico a skos:Concept ;
+  media-type:hasMediaType "image/x-ico" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft Windows -kuvake"@fi ;
+  skos:prefLabel "Microsoft Windows icon"@en ;
+  skos:prefLabel "Microsoft Windows-Symbol"@de ;
+  skos:prefLabel "Microsoft Windows-ikon"@no ;
+  skos:prefLabel "Εικονίδιο Microsoft Windows"@el .
+
+media-type:image_x-iff a skos:Concept ;
+  media-type:hasMediaType "image/x-iff" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd IFF"@cy ;
+  skos:prefLabel "IFF afbeelding"@nl ;
+  skos:prefLabel "IFF image"@en ;
+  skos:prefLabel "IFF rəsmi"@az ;
+  skos:prefLabel "IFF слика"@sr ;
+  skos:prefLabel "IFF 이미지"@ko ;
+  skos:prefLabel "IFF-Bild"@de ;
+  skos:prefLabel "IFF-bild"@sv ;
+  skos:prefLabel "IFF-bilde"@no ;
+  skos:prefLabel "IFF-bilete"@nn ;
+  skos:prefLabel "IFF-kuva"@fi ;
+  skos:prefLabel "IFF-kép"@hu ;
+  skos:prefLabel "Obrázek IFF"@cs ;
+  skos:prefLabel "image IFF"@fr ;
+  skos:prefLabel "Εικόνα IFF"@el .
+
+media-type:image_x-ilbm a skos:Concept ;
+  media-type:hasMediaType "image/x-ilbm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd ILBM"@cy ;
+  skos:prefLabel "ILBM afbeelding"@nl ;
+  skos:prefLabel "ILBM image"@en ;
+  skos:prefLabel "ILBM rəsmi"@az ;
+  skos:prefLabel "ILBM слика"@sr ;
+  skos:prefLabel "ILBM 이미지"@ko ;
+  skos:prefLabel "ILBM-Bild"@de ;
+  skos:prefLabel "ILBM-bild"@sv ;
+  skos:prefLabel "ILBM-bilde"@no ;
+  skos:prefLabel "ILBM-kuva"@fi ;
+  skos:prefLabel "ILBM-kép"@hu ;
+  skos:prefLabel "ILMB-bilete"@nn ;
+  skos:prefLabel "Obrázek ILMB"@cs ;
+  skos:prefLabel "image ILBM"@fr ;
+  skos:prefLabel "Εικόνα ILBM"@el .
+
+media-type:image_x-jng a skos:Concept ;
+  media-type:hasMediaType "image/x-jng" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd JNG"@cy ;
+  skos:prefLabel "JNG afbeelding"@nl ;
+  skos:prefLabel "JNG image"@en ;
+  skos:prefLabel "JNG rəsmi"@az ;
+  skos:prefLabel "JNG слика"@sr ;
+  skos:prefLabel "JNG 이미지"@ko ;
+  skos:prefLabel "JNG-Bild"@de ;
+  skos:prefLabel "JNG-bild"@sv ;
+  skos:prefLabel "JNG-bilde"@no ;
+  skos:prefLabel "JNG-bilete"@nn ;
+  skos:prefLabel "JNG-kuva"@fi ;
+  skos:prefLabel "JNG-kép"@hu ;
+  skos:prefLabel "Obrázek JNG"@cs ;
+  skos:prefLabel "image JNG"@fr ;
+  skos:prefLabel "Εικόνα JNG"@el .
+
+media-type:image_x-lwo a skos:Concept ;
+  media-type:hasMediaType "image/x-lwo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Gwrthrych LightWave"@cy ;
+  skos:prefLabel "LightWave cismi"@az ;
+  skos:prefLabel "LightWave object"@en ;
+  skos:prefLabel "LightWave object"@nl ;
+  skos:prefLabel "LightWave објекат"@sr ;
+  skos:prefLabel "LightWave 개체"@ko ;
+  skos:prefLabel "LightWave-Objekt"@de ;
+  skos:prefLabel "LightWave-esine"@fi ;
+  skos:prefLabel "LightWave-objekt"@nn ;
+  skos:prefLabel "LightWave-objekt"@no ;
+  skos:prefLabel "LightWave-objekt"@sv ;
+  skos:prefLabel "LightWave-objektum"@hu ;
+  skos:prefLabel "Objekt LightWave"@cs ;
+  skos:prefLabel "objet LightWave"@fr ;
+  skos:prefLabel "Αντικείμενο LightWave"@el .
+
+media-type:image_x-lws a skos:Concept ;
+  media-type:hasMediaType "image/x-lws" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Golygfa LightWave"@cy ;
+  skos:prefLabel "LightWave scene"@en ;
+  skos:prefLabel "LightWave scêne"@nl ;
+  skos:prefLabel "LightWave səhnəsi"@az ;
+  skos:prefLabel "LightWave сцена"@sr ;
+  skos:prefLabel "LightWave 장면"@ko ;
+  skos:prefLabel "LightWave-Szene"@de ;
+  skos:prefLabel "LightWave-jelenet"@hu ;
+  skos:prefLabel "LightWave-maisema"@fi ;
+  skos:prefLabel "LightWave-scen"@sv ;
+  skos:prefLabel "LightWave-scene"@nn ;
+  skos:prefLabel "LightWave-scene"@no ;
+  skos:prefLabel "Scéna LightWave"@cs ;
+  skos:prefLabel "scène LightWave"@fr ;
+  skos:prefLabel "Σκηνή LightWave"@el .
+
+media-type:image_x-msod a skos:Concept ;
+  media-type:hasMediaType "image/x-msod" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft Office -piirros"@fi ;
+  skos:prefLabel "Microsoft Office drawing"@en ;
+  skos:prefLabel "Microsoft Office-Zeichnung"@de ;
+  skos:prefLabel "Microsoft Office-tegning"@no .
+
+media-type:image_x-niff a skos:Concept ;
+  media-type:hasMediaType "image/x-niff" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:image_x-pcx a skos:Concept ;
+  media-type:hasMediaType "image/x-pcx" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:image_x-photo-cd a skos:Concept ;
+  media-type:hasMediaType "image/x-photo-cd" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd PhotoCD"@cy ;
+  skos:prefLabel "Obrázek PhotoCD"@cs ;
+  skos:prefLabel "Photo CD-bilete"@nn ;
+  skos:prefLabel "PhotoCD afbeelding"@nl ;
+  skos:prefLabel "PhotoCD image"@en ;
+  skos:prefLabel "PhotoCD rəsmi"@az ;
+  skos:prefLabel "PhotoCD 이미지"@ko ;
+  skos:prefLabel "PhotoCD-Bild"@de ;
+  skos:prefLabel "PhotoCD-bild"@sv ;
+  skos:prefLabel "PhotoCD-bilde"@no ;
+  skos:prefLabel "PhotoCD-kuva"@fi ;
+  skos:prefLabel "PhotoCD-kép"@hu ;
+  skos:prefLabel "image PhotoCD"@fr ;
+  skos:prefLabel "Εικόνα PhotoCD"@el ;
+  skos:prefLabel "Фото Це-Де слика"@sr .
+
+media-type:image_x-pict a skos:Concept ;
+  media-type:hasMediaType "image/x-pict" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Macintosh Quickdraw/PICT -piirros"@fi ;
+  skos:prefLabel "Macintosh Quickdraw/PICT drawing"@en ;
+  skos:prefLabel "Macintosh Quickdraw/PICT-Zeichnung"@de .
+
+media-type:image_x-portable-anymap a skos:Concept ;
+  media-type:hasMediaType "image/x-portable-anymap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd PNM"@cy ;
+  skos:prefLabel "Obrázek PNM"@cs ;
+  skos:prefLabel "PNM afbeelding"@nl ;
+  skos:prefLabel "PNM image"@en ;
+  skos:prefLabel "PNM rəsmi"@az ;
+  skos:prefLabel "PNM слика"@sr ;
+  skos:prefLabel "PNM 이미지"@ko ;
+  skos:prefLabel "PNM-Bild"@de ;
+  skos:prefLabel "PNM-bild"@sv ;
+  skos:prefLabel "PNM-bilde"@no ;
+  skos:prefLabel "PNM-bilete"@nn ;
+  skos:prefLabel "PNM-kuva"@fi ;
+  skos:prefLabel "PNM-kép"@hu ;
+  skos:prefLabel "image PNM"@fr ;
+  skos:prefLabel "Εικόνα PNM"@el .
+
+media-type:image_x-portable-bitmap a skos:Concept ;
+  media-type:hasMediaType "image/x-portable-bitmap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeiliau Fformat Pixfap Cludadwy"@cy ;
+  skos:prefLabel "Formát souborů Portable Bitmap"@cs ;
+  skos:prefLabel "Portabelt bitmapp-filformat"@sv ;
+  skos:prefLabel "Portable Bitmap Fayl Formatı"@az ;
+  skos:prefLabel "Portable Bitmap File Format"@en ;
+  skos:prefLabel "Portable Bitmap File-format"@nn ;
+  skos:prefLabel "Portable Bitmap bestandsformaat"@nl ;
+  skos:prefLabel "Portables Bitmap-Dateiformat"@de ;
+  skos:prefLabel "format de fichier Portable Bitmap"@fr ;
+  skos:prefLabel "siirrettävä bittikarttatiedostomuoto"@fi ;
+  skos:prefLabel "Портабилни запис битмапираних датотека"@sr ;
+  skos:prefLabel "이식 가능한 비트맵 파일 형식"@ko .
+
+media-type:image_x-portable-graymap a skos:Concept ;
+  media-type:hasMediaType "image/x-portable-graymap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeiliau Fformat Llwydfap Cludadwy"@cy ;
+  skos:prefLabel "Formát souborů Portable Graymap"@cs ;
+  skos:prefLabel "Portabelt gråskale-filformat"@sv ;
+  skos:prefLabel "Portable Graymap Fayl Formatı"@az ;
+  skos:prefLabel "Portable Graymap File Format"@en ;
+  skos:prefLabel "Portable Graymap File-format"@nn ;
+  skos:prefLabel "Portable Graymap bestandsformaat"@nl ;
+  skos:prefLabel "Portables Greymap-Dateiformat"@de ;
+  skos:prefLabel "format de fichier Portable Graymap"@fr ;
+  skos:prefLabel "siirrettävä harmaasävytiedostomuoto"@fi ;
+  skos:prefLabel "Портабилни запис слика у сивим нијансама"@sr ;
+  skos:prefLabel "이식 가능한 그레이맵 파일 형식"@ko .
+
+media-type:image_x-portable-pixmap a skos:Concept ;
+  media-type:hasMediaType "image/x-portable-pixmap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd Pixmap Cludadwy"@cy ;
+  skos:prefLabel "Formát souboru Portable Pixmap"@cs ;
+  skos:prefLabel "Portabelt Pixmap-filformat"@no ;
+  skos:prefLabel "Portabelt pixmap-filformat"@sv ;
+  skos:prefLabel "Portable Pixmap Fayl Formatı"@az ;
+  skos:prefLabel "Portable Pixmap File Format"@en ;
+  skos:prefLabel "Portable Pixmap File-format"@nn ;
+  skos:prefLabel "Portable Pixmap bestandsformaat"@nl ;
+  skos:prefLabel "Portables Pixmap-Dateiformat"@de ;
+  skos:prefLabel "format de fichier Portable Pixmap"@fr ;
+  skos:prefLabel "siirrettävä pikselikarttatiedostomuoto"@fi ;
+  skos:prefLabel "Портабилни запис пиксмапа"@sr ;
+  skos:prefLabel "이식 가능한 픽스맵 파일 형식"@ko .
+
+media-type:image_x-psd a skos:Concept ;
+  media-type:hasMediaType "image/x-psd" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Photoshop image"@en ;
+  skos:prefLabel "Photoshop-Bild"@de ;
+  skos:prefLabel "Photoshop-bilde"@no ;
+  skos:prefLabel "Photoshop-kuva"@fi ;
+  skos:prefLabel "Εικόνα Photoshop"@el .
+
+media-type:image_x-rgb a skos:Concept ;
+  media-type:hasMediaType "image/x-rgb" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd RGB"@cy ;
+  skos:prefLabel "Obrázek RGB"@cs ;
+  skos:prefLabel "RGB afbeelding"@nl ;
+  skos:prefLabel "RGB image"@en ;
+  skos:prefLabel "RGB rəsmi"@az ;
+  skos:prefLabel "RGB слика"@sr ;
+  skos:prefLabel "RGB 이미지"@ko ;
+  skos:prefLabel "RGB-Bild"@de ;
+  skos:prefLabel "RGB-bild"@sv ;
+  skos:prefLabel "RGB-bilde"@no ;
+  skos:prefLabel "RGB-bilete"@nn ;
+  skos:prefLabel "RGB-kuva"@fi ;
+  skos:prefLabel "RGB-kép"@hu ;
+  skos:prefLabel "image RGB"@fr ;
+  skos:prefLabel "Εικόνα RGB"@el .
+
+media-type:image_x-sgi a skos:Concept ;
+  media-type:hasMediaType "image/x-sgi" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Silicon Graphics IRIS -kuva"@fi ;
+  skos:prefLabel "Silicon Graphics IRIS image"@en ;
+  skos:prefLabel "Silicon Graphics-IRIS-Bild"@de .
+
+media-type:image_x-sun-raster a skos:Concept ;
+  media-type:hasMediaType "image/x-sun-raster" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "SUN Rasterfile image"@en ;
+  skos:prefLabel "SUN rasterfil-bilde"@no ;
+  skos:prefLabel "SUN-Rasterfile-Bild"@de ;
+  skos:prefLabel "SUN-rasterikuva"@fi .
+
+media-type:image_x-tga a skos:Concept ;
+  media-type:hasMediaType "image/x-tga" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd TarGA"@cy ;
+  skos:prefLabel "Obrázek TarGA"@cs ;
+  skos:prefLabel "TarGA afbeelding"@nl ;
+  skos:prefLabel "TarGA image"@en ;
+  skos:prefLabel "TarGA rəsmi"@az ;
+  skos:prefLabel "TarGA слика"@sr ;
+  skos:prefLabel "TarGA 이미지"@ko ;
+  skos:prefLabel "TarGA-Bild"@de ;
+  skos:prefLabel "TarGA-bild"@sv ;
+  skos:prefLabel "TarGA-bilde"@no ;
+  skos:prefLabel "TarGA-bilete"@nn ;
+  skos:prefLabel "TarGA-kuva"@fi ;
+  skos:prefLabel "TarGA-kép"@hu ;
+  skos:prefLabel "image TarGA"@fr ;
+  skos:prefLabel "Εικόνα TarGA"@el .
+
+media-type:image_x-win-bitmap a skos:Concept ;
+  media-type:hasMediaType "image/x-win-bitmap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Windows cursor"@en ;
+  skos:prefLabel "Windows-Cursor"@de ;
+  skos:prefLabel "Windows-kursori"@fi .
+
+media-type:image_x-wmf a skos:Concept ;
+  media-type:hasMediaType "image/x-wmf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft WMF -tiedosto"@fi ;
+  skos:prefLabel "Microsoft WMF file"@en ;
+  skos:prefLabel "Microsoft WMF-fil"@no ;
+  skos:prefLabel "Microsoft-WMF-Datei"@de ;
+  skos:prefLabel "Αρχείο Microsoft WMF"@el .
+
+media-type:image_x-xbitmap a skos:Concept ;
+  media-type:hasMediaType "image/x-xbitmap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bilete i X Bitmap-format"@nn ;
+  skos:prefLabel "Delwedd didfap X"@cy ;
+  skos:prefLabel "Obrázek X BitMap"@cs ;
+  skos:prefLabel "X BitMap -kuva"@fi ;
+  skos:prefLabel "X BitMap afbeelding"@nl ;
+  skos:prefLabel "X BitMap image"@en ;
+  skos:prefLabel "X BitMap kép"@hu ;
+  skos:prefLabel "X BitMap rəsmi"@az ;
+  skos:prefLabel "X битмапирана слика"@sr ;
+  skos:prefLabel "X 비트맵 이미지"@ko ;
+  skos:prefLabel "X-BitMap-Bild"@de ;
+  skos:prefLabel "X-bitmapbilde"@no ;
+  skos:prefLabel "X-bitmappbild"@sv ;
+  skos:prefLabel "image X BitMap"@fr .
+
+media-type:image_x-xcf a skos:Concept ;
+  media-type:hasMediaType "image/x-xcf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GIF-kuva"@fi ;
+  skos:prefLabel "GIMP image"@en ;
+  skos:prefLabel "GIMP-Bild"@de ;
+  skos:prefLabel "GIMP-bild"@sv ;
+  skos:prefLabel "GIMP-bilde"@no ;
+  skos:prefLabel "Εικόνα GIMP"@el .
+
+media-type:image_x-xfig a skos:Concept ;
+  media-type:hasMediaType "image/x-xfig" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "XFig image"@en ;
+  skos:prefLabel "XFig-Bild"@de ;
+  skos:prefLabel "XFig-bilde"@no ;
+  skos:prefLabel "XFig-tiedosto"@fi ;
+  skos:prefLabel "Εικόνα XFig"@el .
+
+media-type:image_x-xpixmap a skos:Concept ;
+  media-type:hasMediaType "image/x-xpixmap" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bilete i X Bitmap-format"@nn ;
+  skos:prefLabel "Delwedd picsfap X"@cy ;
+  skos:prefLabel "Obrázek X PixMap"@cs ;
+  skos:prefLabel "X PixMap -kuva"@fi ;
+  skos:prefLabel "X PixMap afbeelding"@nl ;
+  skos:prefLabel "X PixMap image"@en ;
+  skos:prefLabel "X PixMap kép"@hu ;
+  skos:prefLabel "X PixMap rəsmi"@az ;
+  skos:prefLabel "X пискмапа"@sr ;
+  skos:prefLabel "X 픽스맵 이미지"@ko ;
+  skos:prefLabel "X-PixMap-Bild"@de ;
+  skos:prefLabel "X-pixmapbild"@sv ;
+  skos:prefLabel "X-pixmapbilde"@no ;
+  skos:prefLabel "image X PixMap"@fr .
+
+media-type:image_x-xwindowdump a skos:Concept ;
+  media-type:hasMediaType "image/x-xwindowdump" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Delwedd ffenest X"@cy ;
+  skos:prefLabel "Obrázek X window"@cs ;
+  skos:prefLabel "X Window afbeelding"@nl ;
+  skos:prefLabel "X window bilete"@nn ;
+  skos:prefLabel "X window image"@en ;
+  skos:prefLabel "X window rəsmi"@az ;
+  skos:prefLabel "X window-kép"@hu ;
+  skos:prefLabel "X прозор слика"@sr ;
+  skos:prefLabel "X 윈도우 이미지"@ko ;
+  skos:prefLabel "X-Window-Bild"@de ;
+  skos:prefLabel "X-Windows skjermbilde"@no ;
+  skos:prefLabel "X-fönsterbild"@sv ;
+  skos:prefLabel "X-ikkunakuva"@fi ;
+  skos:prefLabel "image X window"@fr .
+
+media-type:inode skos:member media-type:inode_blockdevice ;
+  skos:member media-type:inode_chardevice ;
+  skos:member media-type:inode_directory ;
+  skos:member media-type:inode_fifo ;
+  skos:member media-type:inode_mount-point ;
+  skos:member media-type:inode_socket ;
+  skos:member media-type:inode_symlink .
+
+media-type:inode_blockdevice a skos:Concept ;
+  media-type:hasMediaType "inode/blockdevice" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Blockgerät"@de ;
+  skos:prefLabel "block device"@en ;
+  skos:prefLabel "blokkenhet"@no ;
+  skos:prefLabel "laitetiedosto"@fi .
+
+media-type:inode_chardevice a skos:Concept ;
+  media-type:hasMediaType "inode/chardevice" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Character-Device"@de ;
+  skos:prefLabel "character device"@en ;
+  skos:prefLabel "merkkilaite"@fi ;
+  skos:prefLabel "tegnenhet"@no .
+
+media-type:inode_directory a skos:Concept ;
+  media-type:hasMediaType "inode/directory" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:narrower media-type:inode_mount-point ;
+  skos:prefLabel "Ordner"@de ;
+  skos:prefLabel "folder"@en ;
+  skos:prefLabel "kansio"@fi ;
+  skos:prefLabel "mapp"@sv ;
+  skos:prefLabel "mappe"@no ;
+  skos:prefLabel "φάκελος"@el .
+
+media-type:inode_fifo a skos:Concept ;
+  media-type:hasMediaType "inode/fifo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Pipe"@de ;
+  skos:prefLabel "pipe"@en ;
+  skos:prefLabel "putki"@fi ;
+  skos:prefLabel "rör"@sv ;
+  skos:prefLabel "rør"@no .
+
+media-type:inode_mount-point a skos:Concept ;
+  media-type:hasMediaType "inode/mount-point" ;
+  skos:broader media-type:inode_directory ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Einbindepunkt"@de ;
+  skos:prefLabel "liitospiste"@fi ;
+  skos:prefLabel "monteringspunkt"@no ;
+  skos:prefLabel "mount point"@en ;
+  skos:prefLabel "σημείο προσάρτησης"@el .
+
+media-type:inode_socket a skos:Concept ;
+  media-type:hasMediaType "inode/socket" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Socket"@de ;
+  skos:prefLabel "pistoke"@fi ;
+  skos:prefLabel "plugg"@no ;
+  skos:prefLabel "socket"@en .
+
+media-type:inode_symlink a skos:Concept ;
+  media-type:hasMediaType "inode/symlink" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Symbolický odkaz"@cs ;
+  skos:prefLabel "Symbolischer Link"@de ;
+  skos:prefLabel "cyswllt symbolaidd"@cy ;
+  skos:prefLabel "lien symbolique"@fr ;
+  skos:prefLabel "simvolik körpü"@az ;
+  skos:prefLabel "symbolic link"@en ;
+  skos:prefLabel "symbolinen linkki"@fi ;
+  skos:prefLabel "symbolische koppeling"@nl ;
+  skos:prefLabel "symbolisk länk"@sv ;
+  skos:prefLabel "symbolsk lenke"@no ;
+  skos:prefLabel "symbolsk lenkje"@nn ;
+  skos:prefLabel "szimbolikus link"@hu ;
+  skos:prefLabel "συμβολικός σύνδεσμος"@el ;
+  skos:prefLabel "симболичка веза"@sr ;
+  skos:prefLabel "심볼릭 링크"@ko .
+
+media-type:message a skos:Collection ;
+  rdfs:label "Message types"@en ;
+  dct:description "The collection of message types"@en ;
+  dct:title "Message types"@en ;
+  skos:member media-type:message_delivery-status ;
+  skos:member media-type:message_disposition-notification ;
+  skos:member media-type:message_external-body ;
+  skos:member media-type:message_news ;
+  skos:member media-type:message_partial ;
+  skos:member media-type:message_rfc822 ;
+  skos:member media-type:message_x-gnu-rmail .
+
+media-type:message_delivery-status a skos:Concept ;
+  media-type:hasMediaType "message/delivery-status" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Adroddiad trosgludo post"@cy ;
+  skos:prefLabel "E-Mail-Zustellungsbericht"@de ;
+  skos:prefLabel "Zpráva o doručení pošty"@cs ;
+  skos:prefLabel "e-mail bezorgingsbericht"@nl ;
+  skos:prefLabel "e-post-leveringsrapport"@nn ;
+  skos:prefLabel "e-postleveranserapport"@no ;
+  skos:prefLabel "e-postleveransrapport"@sv ;
+  skos:prefLabel "jelentés levélkézbesítésről"@hu ;
+  skos:prefLabel "mail delivery report"@en ;
+  skos:prefLabel "poçt yollama raportu"@az ;
+  skos:prefLabel "rapport de livraison de courriels"@fr ;
+  skos:prefLabel "viestin jakeluilmoitus"@fi ;
+  skos:prefLabel "извештај доставе поруке"@sr ;
+  skos:prefLabel "메일 배달 보고서"@ko .
+
+media-type:message_disposition-notification a skos:Concept ;
+  media-type:hasMediaType "message/disposition-notification" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-Mail-Übertragungsbericht"@de ;
+  skos:prefLabel "Zpráva o předání pošty"@cs ;
+  skos:prefLabel "adroddiad ffurf post"@cy ;
+  skos:prefLabel "e-mail plaatsingsbericht"@nl ;
+  skos:prefLabel "e-post-disposisjonsrapport"@nn ;
+  skos:prefLabel "e-postdispositionsrapport"@no ;
+  skos:prefLabel "e-postdispositionsrapport"@sv ;
+  skos:prefLabel "jelentés levélkidobásról"@hu ;
+  skos:prefLabel "mail disposition report"@en ;
+  skos:prefLabel "poçt qayıtma raportu"@az ;
+  skos:prefLabel "rapport de disposition de courriels"@fr ;
+  skos:prefLabel "viestin kuittausilmoitus"@fi ;
+  skos:prefLabel "извештај слања поруке"@sr ;
+  skos:prefLabel "메일 처리 보고서"@ko .
+
+media-type:message_external-body a skos:Concept ;
+  media-type:hasMediaType "message/external-body" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Odkaz na vzdálený soubor"@cs ;
+  skos:prefLabel "Verweis auf entfernte Datei"@de ;
+  skos:prefLabel "cyfeiriad at ffeil bell"@cy ;
+  skos:prefLabel "hivatkozás távoli fájlra"@hu ;
+  skos:prefLabel "referanse til ekstern fil"@no ;
+  skos:prefLabel "referanse til fil over nettverk"@nn ;
+  skos:prefLabel "reference to remote file"@en ;
+  skos:prefLabel "referens till fjärrfil"@sv ;
+  skos:prefLabel "référence au fichier distant"@fr ;
+  skos:prefLabel "uzaq fayla göstəriş"@az ;
+  skos:prefLabel "verwijzing naar bestand op afstand"@nl ;
+  skos:prefLabel "viittaus etätiedostoon"@fi ;
+  skos:prefLabel "референца на удаљену датотеку"@sr ;
+  skos:prefLabel "원격 파일 참조"@ko .
+
+media-type:message_news a skos:Concept ;
+  media-type:hasMediaType "message/news" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Neges newyddion Usenet"@cy ;
+  skos:prefLabel "Příspěvek do diskusních skupin Usenet"@cs ;
+  skos:prefLabel "USENET diskusjonsmelding"@nn ;
+  skos:prefLabel "USENET-hírcsoportüzenet"@hu ;
+  skos:prefLabel "Usenet news message"@en ;
+  skos:prefLabel "Usenet nieuwsbericht"@nl ;
+  skos:prefLabel "Usenet nyhetsmelding"@no ;
+  skos:prefLabel "Usenet xəbərlər ismarışı"@az ;
+  skos:prefLabel "Usenet-News-Nachricht"@de ;
+  skos:prefLabel "Usenet-diskussionsgruppsmeddelande"@sv ;
+  skos:prefLabel "message des nouvelles « news » Usenet"@fr ;
+  skos:prefLabel "nyyssiviesti"@fi ;
+  skos:prefLabel "Порука са дискусионе групе"@sr ;
+  skos:prefLabel "유즈넷 새소식 메세지"@ko .
+
+media-type:message_partial a skos:Concept ;
+  media-type:hasMediaType "message/partial" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-Mail-Nachrichtenfragment"@de ;
+  skos:prefLabel "darn o neges e-bost"@cy ;
+  skos:prefLabel "del av e-post-melding"@nn ;
+  skos:prefLabel "del av e-postmeddelande"@sv ;
+  skos:prefLabel "del av e-postmelding"@no ;
+  skos:prefLabel "gedeeltelijk e-mail bericht"@nl ;
+  skos:prefLabel "message partiel de courriel"@fr ;
+  skos:prefLabel "osittainen sähköpostiviesti"@fi ;
+  skos:prefLabel "partial email message"@en ;
+  skos:prefLabel "qismi poçt ismarışı"@az ;
+  skos:prefLabel "részleges elektronikus levél"@hu ;
+  skos:prefLabel "Částečná e-mailová zpráva"@cs ;
+  skos:prefLabel "делимична е-порука"@sr ;
+  skos:prefLabel "부분적인 이메일 메세지"@ko .
+
+media-type:message_rfc822 a skos:Concept ;
+  media-type:hasMediaType "message/rfc822" ;
+  skos:broader media-type:text_plain ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-Mail-Nachricht"@de ;
+  skos:prefLabel "e-postmeddelande"@sv ;
+  skos:prefLabel "e-postmelding"@no ;
+  skos:prefLabel "email message"@en ;
+  skos:prefLabel "sähköpostiviesti"@fi ;
+  skos:prefLabel "μήνυμα email"@el .
+
+media-type:message_x-gnu-rmail a skos:Concept ;
+  media-type:hasMediaType "message/x-gnu-rmail" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-mailová zpráva GNU"@cs ;
+  skos:prefLabel "GNU e-mail bericht"@nl ;
+  skos:prefLabel "GNU e-postmelding"@nn ;
+  skos:prefLabel "GNU e-postmelding"@no ;
+  skos:prefLabel "GNU elektronikus levél"@hu ;
+  skos:prefLabel "GNU mail message"@en ;
+  skos:prefLabel "GNU poçt ismarışı"@az ;
+  skos:prefLabel "GNU 메일 메세지"@ko ;
+  skos:prefLabel "GNU-Mail-Nachricht"@de ;
+  skos:prefLabel "GNU-epostmeddelande"@sv ;
+  skos:prefLabel "GNU-postiviesti"@fi ;
+  skos:prefLabel "Neges E-Bost GNU"@cy ;
+  skos:prefLabel "message de courriel GNU"@fr ;
+  skos:prefLabel "Μήνυμα αλληλογραφίας GNU"@el ;
+  skos:prefLabel "ГНУ е-писмо"@sr .
+
+media-type:model a skos:Collection ;
+  rdfs:label "Model types"@en ;
+  dct:description "The collection of model types"@en ;
+  dct:title "Model types"@en ;
+  skos:member media-type:model_vrml .
+
+media-type:model_vrml a skos:Concept ;
+  media-type:hasMediaType "model/vrml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen VRML"@cy ;
+  skos:prefLabel "Dokument VRML"@cs ;
+  skos:prefLabel "VRML document"@en ;
+  skos:prefLabel "VRML document"@nl ;
+  skos:prefLabel "VRML sənədi"@az ;
+  skos:prefLabel "VRML документ"@sr ;
+  skos:prefLabel "VRML 문서"@ko ;
+  skos:prefLabel "VRML-Dokument"@de ;
+  skos:prefLabel "VRML-asiakirja"@fi ;
+  skos:prefLabel "VRML-dokument"@nn ;
+  skos:prefLabel "VRML-dokument"@no ;
+  skos:prefLabel "VRML-dokument"@sv ;
+  skos:prefLabel "VRML-dokumentum"@hu ;
+  skos:prefLabel "document VRML"@fr ;
+  skos:prefLabel "Έγγραφο VRML"@el .
+
+media-type:multipart a skos:Collection ;
+  rdfs:label "Multipart types"@en ;
+  dct:description "The collection of multipart types"@en ;
+  dct:title "Multipart types"@en ;
+  skos:member media-type:multipart_alternative ;
+  skos:member media-type:multipart_appledouble ;
+  skos:member media-type:multipart_digest ;
+  skos:member media-type:multipart_encrypted ;
+  skos:member media-type:multipart_mixed ;
+  skos:member media-type:multipart_related ;
+  skos:member media-type:multipart_report ;
+  skos:member media-type:multipart_signed ;
+  skos:member media-type:multipart_x-mixed-replace .
+
+media-type:multipart_alternative a skos:Concept ;
+  media-type:hasMediaType "multipart/alternative" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Nachricht in mehreren Formaten"@de ;
+  skos:prefLabel "Zpráva v několika formátech"@cs ;
+  skos:prefLabel "bericht in verschillende formaten"@nl ;
+  skos:prefLabel "meddelande i flera format"@sv ;
+  skos:prefLabel "melding i fleire format"@nn ;
+  skos:prefLabel "melding i flere formater"@no ;
+  skos:prefLabel "message en format divers"@fr ;
+  skos:prefLabel "message in several formats"@en ;
+  skos:prefLabel "neges mewn sawl fformat"@cy ;
+  skos:prefLabel "többféle formátumú üzenet"@hu ;
+  skos:prefLabel "verici formatlarında ismarış"@az ;
+  skos:prefLabel "viesti useissa muodoissa"@fi ;
+  skos:prefLabel "поруке у више записа"@sr ;
+  skos:prefLabel "몇몇형식의 메세지"@ko .
+
+media-type:multipart_appledouble a skos:Concept ;
+  media-type:hasMediaType "multipart/appledouble" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil AppleDouble-amgodedig Macintosh"@cy ;
+  skos:prefLabel "Macintosh AppleDouble -koodattu tiedosto"@fi ;
+  skos:prefLabel "Macintosh AppleDouble kódolású fájl"@hu ;
+  skos:prefLabel "Macintosh AppleDouble-encoded file"@en ;
+  skos:prefLabel "Macintosh AppleDouble-gecodeerd bestand"@nl ;
+  skos:prefLabel "Macintosh AppleDouble-koda fil"@nn ;
+  skos:prefLabel "Macintosh AppleDouble-kodad fil"@sv ;
+  skos:prefLabel "Macintosh AppleDouble-kodlanmış fayl"@az ;
+  skos:prefLabel "Macintosh-Datei (AppleDouble-kodiert)"@de ;
+  skos:prefLabel "Soubor kódovaný Macintosh AppleDouble"@cs ;
+  skos:prefLabel "dokument kodet med Macintosh AppleDouble"@no ;
+  skos:prefLabel "fichier encodé Macintosh AppleDouble"@fr ;
+  skos:prefLabel "Αρχείο Macintosh κωδικοποίησης AppleDouble"@el ;
+  skos:prefLabel "Мекинтош AppleDouble-encoded датотека"@sr ;
+  skos:prefLabel "맥킨토시 AppleDouble-encoded 파일"@ko .
+
+media-type:multipart_digest a skos:Concept ;
+  media-type:hasMediaType "multipart/digest" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Digest zpráv"@cs ;
+  skos:prefLabel "Nachrichtensammlung"@de ;
+  skos:prefLabel "berichtsamenvatting"@nl ;
+  skos:prefLabel "crynodeb negeseuon"@cy ;
+  skos:prefLabel "digesteur de messages"@fr ;
+  skos:prefLabel "ismarış daycesti"@az ;
+  skos:prefLabel "meddelandesamling"@sv ;
+  skos:prefLabel "medldingssamling"@no ;
+  skos:prefLabel "meldingsamandrag"@nn ;
+  skos:prefLabel "message digest"@en ;
+  skos:prefLabel "viestikokoelma"@fi ;
+  skos:prefLabel "ömlesztett üzenet"@hu ;
+  skos:prefLabel "гомила порука"@sr ;
+  skos:prefLabel "메세지 묶음"@ko .
+
+media-type:multipart_encrypted a skos:Concept ;
+  media-type:hasMediaType "multipart/encrypted" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Neges wedi ei hamgryptio"@cy ;
+  skos:prefLabel "Zašifrovaná zpráva"@cs ;
+  skos:prefLabel "encrypted message"@en ;
+  skos:prefLabel "gecodeerd bericht"@nl ;
+  skos:prefLabel "krypterat meddelande"@sv ;
+  skos:prefLabel "kryptert melding"@nn ;
+  skos:prefLabel "kryptert melding"@no ;
+  skos:prefLabel "message encrypté"@fr ;
+  skos:prefLabel "salattu viesti"@fi ;
+  skos:prefLabel "titkosított üzenet"@hu ;
+  skos:prefLabel "verschlüsselte Nachricht"@de ;
+  skos:prefLabel "şifrələnmiş ismarış"@az ;
+  skos:prefLabel "κρυπτογραφημένο μήνυμα"@el ;
+  skos:prefLabel "шифрована порука"@sr ;
+  skos:prefLabel "암호화된 메세지"@ko .
+
+media-type:multipart_mixed a skos:Concept ;
+  media-type:hasMediaType "multipart/mixed" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Verbunddokumente"@de ;
+  skos:prefLabel "compound documents"@en ;
+  skos:prefLabel "sammensatte dokumenter"@no ;
+  skos:prefLabel "yhdisteasiakirja"@fi .
+
+media-type:multipart_related a skos:Concept ;
+  media-type:hasMediaType "multipart/related" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Složený dokument"@cs ;
+  skos:prefLabel "Verbunddokument"@de ;
+  skos:prefLabel "birləşik sənəd"@az ;
+  skos:prefLabel "compound document"@en ;
+  skos:prefLabel "document lié « compound »"@fr ;
+  skos:prefLabel "dogfen gyfansawdd"@cy ;
+  skos:prefLabel "samansett dokument"@nn ;
+  skos:prefLabel "samengesteld document"@nl ;
+  skos:prefLabel "sammansatt dokument"@sv ;
+  skos:prefLabel "sammensatt dokument"@no ;
+  skos:prefLabel "yhdisteasiakirja"@fi ;
+  skos:prefLabel "összetett dokumentum"@hu ;
+  skos:prefLabel "сједињени документ"@sr ;
+  skos:prefLabel "복합 문서"@ko .
+
+media-type:multipart_report a skos:Concept ;
+  media-type:hasMediaType "multipart/report" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-Mail-Systembericht"@de ;
+  skos:prefLabel "Zpráva poštovního systému"@cs ;
+  skos:prefLabel "adroddiad system bost"@cy ;
+  skos:prefLabel "e-mail systeembericht"@nl ;
+  skos:prefLabel "e-post-systemrapport"@nn ;
+  skos:prefLabel "e-postsystemrapport"@no ;
+  skos:prefLabel "e-postsystemrapport"@sv ;
+  skos:prefLabel "levelezőrendszer jelentése"@hu ;
+  skos:prefLabel "mail system report"@en ;
+  skos:prefLabel "poçt sistemi raportu"@az ;
+  skos:prefLabel "rapport système de courriels"@fr ;
+  skos:prefLabel "viestijärjestelmän ilmoitus"@fi ;
+  skos:prefLabel "извештај поштанског система"@sr ;
+  skos:prefLabel "메일 시스템 보고서"@ko .
+
+media-type:multipart_signed a skos:Concept ;
+  media-type:hasMediaType "multipart/signed" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Podepsaná zpráva"@cs ;
+  skos:prefLabel "allekirjoitettu viesti"@fi ;
+  skos:prefLabel "aláírt üzenet"@hu ;
+  skos:prefLabel "imzalanmış ismarış"@az ;
+  skos:prefLabel "message signé"@fr ;
+  skos:prefLabel "neges lofnodwyd"@cy ;
+  skos:prefLabel "ondertekend bericht"@nl ;
+  skos:prefLabel "signed message"@en ;
+  skos:prefLabel "signerat meddelande"@sv ;
+  skos:prefLabel "signert melding"@nn ;
+  skos:prefLabel "signert melding"@no ;
+  skos:prefLabel "signierte Nachricht"@de ;
+  skos:prefLabel "потписана порука"@sr ;
+  skos:prefLabel "서명된 메세지"@ko .
+
+media-type:multipart_x-mixed-replace a skos:Concept ;
+  media-type:hasMediaType "multipart/x-mixed-replace" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Datenstrom (Server-Push)"@de ;
+  skos:prefLabel "datastrøm (server push)"@no ;
+  skos:prefLabel "stream of data (server push)"@en ;
+  skos:prefLabel "tietovirta (palvelin työntää)"@fi .
+
+media-type:text a skos:Collection ;
+  rdfs:label "Text types"@en ;
+  dct:description "The collection of text types"@en ;
+  dct:title "Text types"@en ;
+  skos:member media-type:text_calendar ;
+  skos:member media-type:text_css ;
+  skos:member media-type:text_directory ;
+  skos:member media-type:text_enriched ;
+  skos:member media-type:text_html ;
+  skos:member media-type:text_htmlh ;
+  skos:member media-type:text_mathml ;
+  skos:member media-type:text_plain ;
+  skos:member media-type:text_rdf ;
+  skos:member media-type:text_rfc822-headers ;
+  skos:member media-type:text_richtext ;
+  skos:member media-type:text_rss ;
+  skos:member media-type:text_sgml ;
+  skos:member media-type:text_spreadsheet ;
+  skos:member media-type:text_tab-separated-values ;
+  skos:member media-type:text_vndwapwml ;
+  skos:member media-type:text_x-adasrc ;
+  skos:member media-type:text_x-authors ;
+  skos:member media-type:text_x-bibtex ;
+  skos:member media-type:text_x-chdr ;
+  skos:member media-type:text_x-comma-separated-values ;
+  skos:member media-type:text_x-copying ;
+  skos:member media-type:text_x-credits ;
+  skos:member media-type:text_x-csharp ;
+  skos:member media-type:text_x-csrc ;
+  skos:member media-type:text_x-dcl ;
+  skos:member media-type:text_x-dsl ;
+  skos:member media-type:text_x-dtd ;
+  skos:member media-type:text_x-emacs-lisp ;
+  skos:member media-type:text_x-fortran ;
+  skos:member media-type:text_x-gettext-translation ;
+  skos:member media-type:text_x-gettext-translation-template ;
+  skos:member media-type:text_x-gtkrc ;
+  skos:member media-type:text_x-haskell ;
+  skos:member media-type:text_x-idl ;
+  skos:member media-type:text_x-install ;
+  skos:member media-type:text_x-java ;
+  skos:member media-type:text_x-ksh ;
+  skos:member media-type:text_x-ksysv-log ;
+  skos:member media-type:text_x-literate-haskell ;
+  skos:member media-type:text_x-log ;
+  skos:member media-type:text_x-makefile ;
+  skos:member media-type:text_x-moc ;
+  skos:member media-type:text_x-objcsrc ;
+  skos:member media-type:text_x-pascal ;
+  skos:member media-type:text_x-patch ;
+  skos:member media-type:text_x-readme ;
+  skos:member media-type:text_x-scheme ;
+  skos:member media-type:text_x-setext ;
+  skos:member media-type:text_x-speech ;
+  skos:member media-type:text_x-sql ;
+  skos:member media-type:text_x-tcl ;
+  skos:member media-type:text_x-tex ;
+  skos:member media-type:text_x-texinfo ;
+  skos:member media-type:text_x-troff-me ;
+  skos:member media-type:text_x-troff-mm ;
+  skos:member media-type:text_x-troff-ms ;
+  skos:member media-type:text_x-uil ;
+  skos:member media-type:text_x-uri ;
+  skos:member media-type:text_x-vcalendar ;
+  skos:member media-type:text_x-vcard ;
+  skos:member media-type:text_x-xmi ;
+  skos:member media-type:text_x-xslfo ;
+  skos:member media-type:text_x-xslt ;
+  skos:member media-type:text_xmcd ;
+  skos:member media-type:text_xml .
+
+media-type:text_calendar a skos:Concept ;
+  media-type:hasMediaType "text/calendar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil iCalendar"@cy ;
+  skos:prefLabel "Soubor iCalendar"@cs ;
+  skos:prefLabel "fichier iCalendar"@fr ;
+  skos:prefLabel "iCalendar bestand"@nl ;
+  skos:prefLabel "iCalendar faylı"@az ;
+  skos:prefLabel "iCalendar file"@en ;
+  skos:prefLabel "iCalendar датотека"@sr ;
+  skos:prefLabel "iCalendar 파일"@ko ;
+  skos:prefLabel "iCalendar-Datei"@de ;
+  skos:prefLabel "iCalendar-fil"@nn ;
+  skos:prefLabel "iCalendar-fil"@sv ;
+  skos:prefLabel "iCalendar-file"@hu ;
+  skos:prefLabel "iCalendar-tiedosto"@fi ;
+  skos:prefLabel "iCalender-fil"@no ;
+  skos:prefLabel "Αρχείο iCalendar"@el .
+
+media-type:text_css a skos:Concept ;
+  media-type:hasMediaType "text/css" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "CSS-Stylesheet"@de ;
+  skos:prefLabel "CSS-stíluslap"@hu ;
+  skos:prefLabel "CSS-tyylisäännöstö"@fi ;
+  skos:prefLabel "Cascading Style Sheet"@cs ;
+  skos:prefLabel "Cascading Style Sheet"@en ;
+  skos:prefLabel "Cascading Style Sheet"@fr ;
+  skos:prefLabel "Cascading Style Sheet"@nl ;
+  skos:prefLabel "Cascading style sheet"@no ;
+  skos:prefLabel "Kaskadstilmall"@sv ;
+  skos:prefLabel "Overlappande stilark (CSS)"@nn ;
+  skos:prefLabel "Stil Layları (CSS)"@az ;
+  skos:prefLabel "Taflen Arddull Rhaeadrol"@cy ;
+  skos:prefLabel "Каскадна стилска страна (CSS)"@sr ;
+  skos:prefLabel "다단 스타일시트"@ko .
+
+media-type:text_directory a skos:Concept ;
+  media-type:hasMediaType "text/directory" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil gwybodaeth cyfeiriadur"@cy ;
+  skos:prefLabel "Soubor informací o adresáři"@cs ;
+  skos:prefLabel "Verzeichnisinformationsdatei"@de ;
+  skos:prefLabel "cərgə mə'lumat faylı"@az ;
+  skos:prefLabel "directory information file"@en ;
+  skos:prefLabel "fichier d'information répertoire"@fr ;
+  skos:prefLabel "hakemistoinfotiedosto"@fi ;
+  skos:prefLabel "katalog-informasjonsfil"@nn ;
+  skos:prefLabel "kataloginformasjonsfil"@no ;
+  skos:prefLabel "kataloginformationsfil"@sv ;
+  skos:prefLabel "könyvtár-információs fájl"@hu ;
+  skos:prefLabel "mapinformatie bestand"@nl ;
+  skos:prefLabel "датотека са подацима о директоријуму"@sr ;
+  skos:prefLabel "디렉토리 정보 파일"@ko .
+
+media-type:text_enriched a skos:Concept ;
+  media-type:hasMediaType "text/enriched" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen testun wedi ei gyfoethogi"@cy ;
+  skos:prefLabel "Rozšířený textový dokument"@cs ;
+  skos:prefLabel "angereichertes Textdokument"@de ;
+  skos:prefLabel "berikat textdokument"@sv ;
+  skos:prefLabel "document  « enriched text »"@fr ;
+  skos:prefLabel "enriched text document"@en ;
+  skos:prefLabel "enriched text dokumentum"@hu ;
+  skos:prefLabel "enriched text 문서"@ko ;
+  skos:prefLabel "rik tekst tekstdokument"@nn ;
+  skos:prefLabel "rikastettu tekstiasiakirja"@fi ;
+  skos:prefLabel "riktekst-dokument"@no ;
+  skos:prefLabel "verrijkt tekstdocument"@nl ;
+  skos:prefLabel "zəngin mətn sənədi"@az ;
+  skos:prefLabel "обогаћени текстуални документ"@sr .
+
+media-type:text_html a skos:Concept ;
+  media-type:hasMediaType "text/html" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "HTML page"@en ;
+  skos:prefLabel "HTML-Seite"@de ;
+  skos:prefLabel "HTML-sida"@sv ;
+  skos:prefLabel "HTML-side"@no ;
+  skos:prefLabel "HTML-sivu"@fi ;
+  skos:prefLabel "Σελίδα HTML"@el .
+
+media-type:text_htmlh a skos:Concept ;
+  media-type:hasMediaType "text/htmlh" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Hilfeseite"@de ;
+  skos:prefLabel "Stránka nápovědy"@cs ;
+  skos:prefLabel "help page"@en ;
+  skos:prefLabel "hjelpeside"@nn ;
+  skos:prefLabel "hjelpside"@no ;
+  skos:prefLabel "hjälpsida"@sv ;
+  skos:prefLabel "hulppagina"@nl ;
+  skos:prefLabel "ohjesivu"@fi ;
+  skos:prefLabel "page d'aide"@fr ;
+  skos:prefLabel "súgóoldal"@hu ;
+  skos:prefLabel "tudalen gymorth"@cy ;
+  skos:prefLabel "yardım səhifəsi"@az ;
+  skos:prefLabel "σελίδα βοήθειας"@el ;
+  skos:prefLabel "страна помоћи"@sr ;
+  skos:prefLabel "도움말 페이지"@ko .
+
+media-type:text_mathml a skos:Concept ;
+  media-type:hasMediaType "text/mathml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen MathML"@cy ;
+  skos:prefLabel "Dokument MathML"@cs ;
+  skos:prefLabel "MathML document"@en ;
+  skos:prefLabel "MathML document"@nl ;
+  skos:prefLabel "MathML sənədi"@az ;
+  skos:prefLabel "MathML документ"@sr ;
+  skos:prefLabel "MathML 문서"@ko ;
+  skos:prefLabel "MathML-Dokument"@de ;
+  skos:prefLabel "MathML-asiakirja"@fi ;
+  skos:prefLabel "MathML-dokument"@nn ;
+  skos:prefLabel "MathML-dokument"@no ;
+  skos:prefLabel "MathML-dokument"@sv ;
+  skos:prefLabel "MathML-dokumentum"@hu ;
+  skos:prefLabel "document MathML"@fr ;
+  skos:prefLabel "Έγγραφο MathML"@el .
+
+media-type:text_plain a skos:Concept ;
+  media-type:hasMediaType "text/plain" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:narrower media-type:application_rtf ;
+  skos:narrower media-type:application_smil ;
+  skos:narrower media-type:application_x-asp ;
+  skos:narrower media-type:application_x-awk ;
+  skos:narrower media-type:application_x-cgi ;
+  skos:narrower media-type:application_x-csh ;
+  skos:narrower media-type:application_x-desktop ;
+  skos:narrower media-type:application_x-glade ;
+  skos:narrower media-type:application_x-javascript ;
+  skos:narrower media-type:application_x-magicpoint ;
+  skos:narrower media-type:application_x-nautilus-link ;
+  skos:narrower media-type:application_x-netscape-bookmarks ;
+  skos:narrower media-type:application_x-perl ;
+  skos:narrower media-type:application_x-php ;
+  skos:narrower media-type:application_x-profile ;
+  skos:narrower media-type:application_x-python ;
+  skos:narrower media-type:application_x-reject ;
+  skos:narrower media-type:application_x-ruby ;
+  skos:narrower media-type:application_x-shar ;
+  skos:narrower media-type:application_x-shellscript ;
+  skos:narrower media-type:application_x-theme ;
+  skos:narrower media-type:application_x-troff ;
+  skos:narrower media-type:application_x-troff-man ;
+  skos:narrower media-type:application_x-xbel ;
+  skos:narrower media-type:application_xhtmlxml ;
+  skos:narrower media-type:message_delivery-status ;
+  skos:narrower media-type:message_news ;
+  skos:narrower media-type:message_partial ;
+  skos:narrower media-type:message_rfc822 ;
+  skos:prefLabel "einfaches Textdokument"@de ;
+  skos:prefLabel "plain text document"@en ;
+  skos:prefLabel "tekstitiedosto"@fi ;
+  skos:prefLabel "vanlig tekstdokument"@no ;
+  skos:prefLabel "έγγραφο απλού κειμένου"@el .
+
+media-type:text_rdf a skos:Concept ;
+  media-type:hasMediaType "text/rdf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil RDF (Resource Description Framework)"@cy ;
+  skos:prefLabel "Mənbə İzahat Çərçivəsi (RDF) faylı"@az ;
+  skos:prefLabel "RDF (erőforrásleíró) -fájl"@hu ;
+  skos:prefLabel "Resource Description Framework (RDF) -tiedosto"@fi ;
+  skos:prefLabel "Resource Description Framework (RDF) bestand"@nl ;
+  skos:prefLabel "Resource Description Framework (RDF) file"@en ;
+  skos:prefLabel "Resource Description Framework (RDF) датотека"@sr ;
+  skos:prefLabel "Resource Description Framework (RDF)-fil"@nn ;
+  skos:prefLabel "Ressourcenbeschreibungs-Framework (RDF)-Datei"@de ;
+  skos:prefLabel "Resursbeskrivningsfil"@sv ;
+  skos:prefLabel "Soubor Resource Description Framework (RDF)"@cs ;
+  skos:prefLabel "fichier Resource Description Framework (RDF)"@fr ;
+  skos:prefLabel "자원 기술 프레임워크 (RDF) 파일"@ko .
+
+media-type:text_rfc822-headers a skos:Concept ;
+  media-type:hasMediaType "text/rfc822-headers" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "E-Mail-Kopfzeilen"@de ;
+  skos:prefLabel "Hlavičky E-mailu"@cs ;
+  skos:prefLabel "e-mail koppen"@nl ;
+  skos:prefLabel "e-post-hovud"@nn ;
+  skos:prefLabel "e-posthode"@no ;
+  skos:prefLabel "e-posthuvuden"@sv ;
+  skos:prefLabel "email headers"@en ;
+  skos:prefLabel "en-tête de courriel"@fr ;
+  skos:prefLabel "epoçt başlıqları"@az ;
+  skos:prefLabel "levélfejléc"@hu ;
+  skos:prefLabel "penawdau e-bost"@cy ;
+  skos:prefLabel "sähköpostiotsakkeet"@fi ;
+  skos:prefLabel "заглавља е-порука"@sr ;
+  skos:prefLabel "이메일 헤더"@ko .
+
+media-type:text_richtext a skos:Concept ;
+  media-type:hasMediaType "text/richtext" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bohatý textový dokument"@cs ;
+  skos:prefLabel "RTF-Textdokument"@de ;
+  skos:prefLabel "RTF-asiakirja"@fi ;
+  skos:prefLabel "document « rich text »"@fr ;
+  skos:prefLabel "dogfen testun gyfoethog (rtf)"@cy ;
+  skos:prefLabel "opgemaakt tekstdocument"@nl ;
+  skos:prefLabel "rich text document"@en ;
+  skos:prefLabel "rich text 문서"@ko ;
+  skos:prefLabel "rich text-dokumentum"@hu ;
+  skos:prefLabel "rik tekst-dokument"@nn ;
+  skos:prefLabel "rik tekst-dokument"@no ;
+  skos:prefLabel "rikt textdokument"@sv ;
+  skos:prefLabel "zəngin mətn sənədi"@az ;
+  skos:prefLabel "обогаћени текстуални документ"@sr .
+
+media-type:text_rss a skos:Concept ;
+  media-type:hasMediaType "text/rss" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Crynodeb Safle RDF"@cy ;
+  skos:prefLabel "RDF Sayt İcmalı"@az ;
+  skos:prefLabel "RDF Site Summary"@en ;
+  skos:prefLabel "RDF website samenvatting"@nl ;
+  skos:prefLabel "RDF сажетак странице (RSS)"@sr ;
+  skos:prefLabel "RDF 사이트 요약"@ko ;
+  skos:prefLabel "RDF-Seitenzusammenfassung"@de ;
+  skos:prefLabel "RDF-sidesamandrag"@nn ;
+  skos:prefLabel "RDF-sivuston tiivistelmä"@fi ;
+  skos:prefLabel "RDF-strøm"@no ;
+  skos:prefLabel "RDF-webbplatssammanfattning"@sv ;
+  skos:prefLabel "RDF-webhelyinformáció"@hu ;
+  skos:prefLabel "Sourhn serveru RDF"@cs ;
+  skos:prefLabel "sommaire RDF Site"@fr .
+
+media-type:text_sgml a skos:Concept ;
+  media-type:hasMediaType "text/sgml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen SGML"@cy ;
+  skos:prefLabel "SGML document"@en ;
+  skos:prefLabel "SGML документ"@sr ;
+  skos:prefLabel "SGML-Dokument"@de ;
+  skos:prefLabel "SGML-asiakirja"@fi ;
+  skos:prefLabel "SGML-dokument"@nn ;
+  skos:prefLabel "SGML-dokument"@no ;
+  skos:prefLabel "SGML-dokument"@sv ;
+  skos:prefLabel "Έγγραφο SGML"@el .
+
+media-type:text_spreadsheet a skos:Concept ;
+  media-type:hasMediaType "text/spreadsheet" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dokument for regnearkutveksling"@no ;
+  skos:prefLabel "Spreadsheet interchange document"@en ;
+  skos:prefLabel "Tabellenkalkulations-Austauschdokument"@de ;
+  skos:prefLabel "taulukkovälitysasiakirja"@fi .
+
+media-type:text_tab-separated-values a skos:Concept ;
+  media-type:hasMediaType "text/tab-separated-values" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Textdokument·(Werte·durch·Tabulatorzeichen·unterteilt)"@de ;
+  skos:prefLabel "sarkaimella eroteltuja arvoja tekstitiedostossa"@fi ;
+  skos:prefLabel "tekstdokument (med tabulatorseparerte verdier)"@no ;
+  skos:prefLabel "text document (with tab-separated values)"@en .
+
+media-type:text_vndwapwml a skos:Concept ;
+  media-type:hasMediaType "text/vnd.wap.wml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen WML"@cy ;
+  skos:prefLabel "Dokument WML"@cs ;
+  skos:prefLabel "WML document"@en ;
+  skos:prefLabel "WML document"@nl ;
+  skos:prefLabel "WML sənədi"@az ;
+  skos:prefLabel "WML документ"@sr ;
+  skos:prefLabel "WML 문서"@ko ;
+  skos:prefLabel "WML-Dokument"@de ;
+  skos:prefLabel "WML-asiakirja"@fi ;
+  skos:prefLabel "WML-dokument"@nn ;
+  skos:prefLabel "WML-dokument"@no ;
+  skos:prefLabel "WML-dokument"@sv ;
+  skos:prefLabel "WML-dokumentum"@hu ;
+  skos:prefLabel "document WML"@fr ;
+  skos:prefLabel "Έγγραφο WML"@el .
+
+media-type:text_x-adasrc a skos:Concept ;
+  media-type:hasMediaType "text/x-adasrc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ada source code"@en ;
+  skos:prefLabel "Ada-Quelltext"@de ;
+  skos:prefLabel "Ada-kildekode"@no ;
+  skos:prefLabel "Ada-lähdekoodi"@fi ;
+  skos:prefLabel "Πηγαίος κώδικας Ada"@el .
+
+media-type:text_x-authors a skos:Concept ;
+  media-type:hasMediaType "text/x-authors" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Autorenliste"@de ;
+  skos:prefLabel "author list"@en ;
+  skos:prefLabel "forfatterliste"@no ;
+  skos:prefLabel "tekijäluettelo"@fi .
+
+media-type:text_x-bibtex a skos:Concept ;
+  media-type:hasMediaType "text/x-bibtex" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Bibtex bibliografiske data"@no ;
+  skos:prefLabel "Bibtex bibliographic data"@en ;
+  skos:prefLabel "bibliographische Bibitex-Daten"@de ;
+  skos:prefLabel "kirjallisuusviittaustiedot (bibtex)"@fi .
+
+media-type:text_x-chdr a skos:Concept ;
+  media-type:hasMediaType "text/x-c++hdr" ;
+  media-type:hasMediaType "text/x-chdr" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "C source code header"@en ;
+  skos:prefLabel "C заглавља изворног кôда"@sr ;
+  skos:prefLabel "C++ source code header"@en ;
+  skos:prefLabel "C++-Quelltext-Header"@de ;
+  skos:prefLabel "C++-kildekodeheader"@no ;
+  skos:prefLabel "C-Quelltext-Header"@de ;
+  skos:prefLabel "C-kildekodeheader"@no ;
+  skos:prefLabel "C-kjeldekode-header"@nn ;
+  skos:prefLabel "C-källkodshuvud"@sv ;
+  skos:prefLabel "Penawd Rhaglen C"@cy .
+
+media-type:text_x-comma-separated-values a skos:Concept ;
+  media-type:hasMediaType "text/x-comma-separated-values" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Textdokument (Werte durch Kommata unterteilt)"@de ;
+  skos:prefLabel "pilkulla eroteltuja arvoja tekstitiedostossa"@fi ;
+  skos:prefLabel "tekstdokument (med kommaseparerte verdier)"@no ;
+  skos:prefLabel "text document (with comma-separated values)"@en .
+
+media-type:text_x-copying a skos:Concept ;
+  media-type:hasMediaType "text/x-copying" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Podmínky licence na software"@cs ;
+  skos:prefLabel "Software-Lizenzbedingungen"@de ;
+  skos:prefLabel "lisensbestemmelser for programvare"@no ;
+  skos:prefLabel "lisensvilkår for programvare"@nn ;
+  skos:prefLabel "ohjelmiston lisenssiehdot"@fi ;
+  skos:prefLabel "programlicensavtal"@sv ;
+  skos:prefLabel "proqram tə'minatını lisenziya qaydaları"@az ;
+  skos:prefLabel "software license terms"@en ;
+  skos:prefLabel "software licentievoorwaarden"@nl ;
+  skos:prefLabel "szoftver felhasználási szerződése"@hu ;
+  skos:prefLabel "termau trwydded meddalwedd"@cy ;
+  skos:prefLabel "termes de la license du logiciel"@fr ;
+  skos:prefLabel "лиценца за програм"@sr ;
+  skos:prefLabel "소프트웨어 라이센스 조항"@ko .
+
+media-type:text_x-credits a skos:Concept ;
+  media-type:hasMediaType "text/x-credits" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Informace o autorovi software"@cs ;
+  skos:prefLabel "Software-Impressum"@de ;
+  skos:prefLabel "clodau awduron meddalwedd"@cy ;
+  skos:prefLabel "crédits des auteurs pour le logiciel"@fr ;
+  skos:prefLabel "forfattarliste for programvare"@nn ;
+  skos:prefLabel "forfatterliste for programvare"@no ;
+  skos:prefLabel "informatie over auteur"@nl ;
+  skos:prefLabel "ohjelmiston tekijäluettelo"@fi ;
+  skos:prefLabel "programförfattarlista"@sv ;
+  skos:prefLabel "proqram müəllifləri sənədi"@az ;
+  skos:prefLabel "software author credits"@en ;
+  skos:prefLabel "szoftver szerzőinek felsorolása"@hu ;
+  skos:prefLabel "заслуге аутора програма"@sr ;
+  skos:prefLabel "소프트웨어 저작자 크레디트"@ko .
+
+media-type:text_x-csharp a skos:Concept ;
+  media-type:hasMediaType "text/x-csharp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "C# source code"@en ;
+  skos:prefLabel "C#-Quelltext"@de ;
+  skos:prefLabel "C#-lähdekoodi"@fi ;
+  skos:prefLabel "Πηγαίος κώδικας C#"@el .
+
+media-type:text_x-csrc a skos:Concept ;
+  media-type:hasMediaType "text/x-c++src" ;
+  media-type:hasMediaType "text/x-csrc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "C source code"@en ;
+  skos:prefLabel "C++ source code"@en ;
+  skos:prefLabel "C++-Quelltext"@de ;
+  skos:prefLabel "C++-kildekode"@no ;
+  skos:prefLabel "C++-lähdekoodi"@fi ;
+  skos:prefLabel "C-Quelltext"@de ;
+  skos:prefLabel "C-kildekode"@no ;
+  skos:prefLabel "C-lähdekoodi"@fi ;
+  skos:prefLabel "Πηγαίος κώδικας C++"@el ;
+  skos:prefLabel "Πηγαίος κώδικας C"@el .
+
+media-type:text_x-dcl a skos:Concept ;
+  media-type:hasMediaType "text/x-dcl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DCL script"@en ;
+  skos:prefLabel "DCL script"@nl ;
+  skos:prefLabel "DCL skripti"@az ;
+  skos:prefLabel "DCL скрипта"@sr ;
+  skos:prefLabel "DCL 스크립트"@ko ;
+  skos:prefLabel "DCL-Skript"@de ;
+  skos:prefLabel "DCL-komentotiedosto"@fi ;
+  skos:prefLabel "DCL-parancsfájl"@hu ;
+  skos:prefLabel "DCL-skript"@nn ;
+  skos:prefLabel "DCL-skript"@no ;
+  skos:prefLabel "DCL-skript"@sv ;
+  skos:prefLabel "Sgript DCL"@cy ;
+  skos:prefLabel "Skript DCL"@cs ;
+  skos:prefLabel "script DCL"@fr ;
+  skos:prefLabel "Πρόγραμμα εντολών DCL"@el .
+
+media-type:text_x-dsl a skos:Concept ;
+  media-type:hasMediaType "text/x-dsl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "DSSSL document"@en ;
+  skos:prefLabel "DSSSL document"@nl ;
+  skos:prefLabel "DSSSL sənədi"@az ;
+  skos:prefLabel "DSSSL документ"@sr ;
+  skos:prefLabel "DSSSL 문서"@ko ;
+  skos:prefLabel "DSSSL-Dokument"@de ;
+  skos:prefLabel "DSSSL-asiakirja"@fi ;
+  skos:prefLabel "DSSSL-dokument"@nn ;
+  skos:prefLabel "DSSSL-dokument"@no ;
+  skos:prefLabel "DSSSL-dokument"@sv ;
+  skos:prefLabel "DSSSL-dokumentum"@hu ;
+  skos:prefLabel "Dogfen DSSSL"@cy ;
+  skos:prefLabel "Dokument DSSSL"@cs ;
+  skos:prefLabel "document DSSSL"@fr ;
+  skos:prefLabel "Έγγραφο DSSSL"@el .
+
+media-type:text_x-dtd a skos:Concept ;
+  media-type:hasMediaType "text/x-dtd" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Definice typu dokumentu"@cs ;
+  skos:prefLabel "Diffiniad math dogfen"@cy ;
+  skos:prefLabel "Dokumenttypenbeschreibung (DTD)"@de ;
+  skos:prefLabel "asiakirjatyypin määritelmä"@fi ;
+  skos:prefLabel "document type definition"@en ;
+  skos:prefLabel "documentsoort definitie"@nl ;
+  skos:prefLabel "dokumenttypdefinisjon"@no ;
+  skos:prefLabel "dokumenttypdefinition"@sv ;
+  skos:prefLabel "dokumenttypedefinisjon"@nn ;
+  skos:prefLabel "dokumentumtípus definíciója"@hu ;
+  skos:prefLabel "définition des types de document"@fr ;
+  skos:prefLabel "sənəd növü tə'yini"@az ;
+  skos:prefLabel "дефиниција типа датотеке"@sr ;
+  skos:prefLabel "문서 형식 정의"@ko .
+
+media-type:text_x-emacs-lisp a skos:Concept ;
+  media-type:hasMediaType "text/x-emacs-lisp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Emacs Lisp -lähdekoodi"@fi ;
+  skos:prefLabel "Emacs Lisp broncode"@nl ;
+  skos:prefLabel "Emacs Lisp kjeldekode"@nn ;
+  skos:prefLabel "Emacs Lisp mənbə kodu"@az ;
+  skos:prefLabel "Emacs Lisp source code"@en ;
+  skos:prefLabel "Emacs Lisp 소스 코드"@ko ;
+  skos:prefLabel "Emacs Lisp-forráskód"@hu ;
+  skos:prefLabel "Emacs Lisp-kildekode"@no ;
+  skos:prefLabel "Emacs Lisp-källkod"@sv ;
+  skos:prefLabel "Emacs-Lisp-Quelltext"@de ;
+  skos:prefLabel "Ffynhonnell rhaglen EMACS LISP"@cy ;
+  skos:prefLabel "Zdrojový kód Emacs Lisp"@cs ;
+  skos:prefLabel "code source Emacs Lisp"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας Emacs Lisp"@el ;
+  skos:prefLabel "Емакс Лисп изворни кôд"@sr .
+
+media-type:text_x-fortran a skos:Concept ;
+  media-type:hasMediaType "text/x-fortran" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffynhonnell rhaglen FORTRAN"@cy ;
+  skos:prefLabel "Fortran broncode"@nl ;
+  skos:prefLabel "Fortran mənbə kodu"@az ;
+  skos:prefLabel "Fortran source code"@en ;
+  skos:prefLabel "Fortran-Quelltext"@de ;
+  skos:prefLabel "Fortran-forráskód"@hu ;
+  skos:prefLabel "Fortran-kildekode"@no ;
+  skos:prefLabel "Fortran-kjeldekode"@nn ;
+  skos:prefLabel "Fortran-källkod"@sv ;
+  skos:prefLabel "Fortran-lähdekoodi"@fi ;
+  skos:prefLabel "Zdrojový kód Fortran"@cs ;
+  skos:prefLabel "code source Fortran"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας Fortran"@el ;
+  skos:prefLabel "Фортран изворни кôд"@sr ;
+  skos:prefLabel "포트란 소스 코드"@ko .
+
+media-type:text_x-gettext-translation a skos:Concept ;
+  media-type:hasMediaType "text/x-gettext-translation" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "käännettyjä viestejä"@fi ;
+  skos:prefLabel "oversatte meldinger"@no ;
+  skos:prefLabel "translated messages"@en ;
+  skos:prefLabel "übersetzte Meldungen"@de ;
+  skos:prefLabel "μεταφρασμένα μηνύματα"@el .
+
+media-type:text_x-gettext-translation-template a skos:Concept ;
+  media-type:hasMediaType "text/x-gettext-translation-template" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Vorlage zur Nachrichtenübersetzung"@de ;
+  skos:prefLabel "message translation template"@en .
+
+media-type:text_x-gtkrc a skos:Concept ;
+  media-type:hasMediaType "text/x-gtkrc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffurfosodiad GTK"@cy ;
+  skos:prefLabel "GTK configuratie"@nl ;
+  skos:prefLabel "GTK configuration"@en ;
+  skos:prefLabel "GTK qurğusu"@az ;
+  skos:prefLabel "GTK 설정"@ko ;
+  skos:prefLabel "GTK-Konfiguration"@de ;
+  skos:prefLabel "GTK-asetukset"@fi ;
+  skos:prefLabel "GTK-beállítások"@hu ;
+  skos:prefLabel "GTK-konfigurasjon"@no ;
+  skos:prefLabel "GTK-konfiguration"@sv ;
+  skos:prefLabel "GTK-oppsett"@nn ;
+  skos:prefLabel "Nastavení GTK"@cs ;
+  skos:prefLabel "configuration GTK"@fr ;
+  skos:prefLabel "Ρυθμίσεις GTK"@el ;
+  skos:prefLabel "Гтк подешавања"@sr .
+
+media-type:text_x-haskell a skos:Concept ;
+  media-type:hasMediaType "text/x-haskell" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffynhonnell rhaglen Haskell"@cy ;
+  skos:prefLabel "Haskell broncode"@nl ;
+  skos:prefLabel "Haskell mənbə kodu"@az ;
+  skos:prefLabel "Haskell source code"@en ;
+  skos:prefLabel "Haskell изворни кôд"@sr ;
+  skos:prefLabel "Haskell 소스 코드"@ko ;
+  skos:prefLabel "Haskell-Quelltext"@de ;
+  skos:prefLabel "Haskell-forráskód"@hu ;
+  skos:prefLabel "Haskell-kildekode"@no ;
+  skos:prefLabel "Haskell-kjeldekode"@nn ;
+  skos:prefLabel "Haskell-källkod"@sv ;
+  skos:prefLabel "Haskell-lähdekoodi"@fi ;
+  skos:prefLabel "Zdrojový kód Haskell"@cs ;
+  skos:prefLabel "code source Haskell"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας Haskell"@el .
+
+media-type:text_x-idl a skos:Concept ;
+  media-type:hasMediaType "text/x-idl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen IDL"@cy ;
+  skos:prefLabel "Dokument IDL"@cs ;
+  skos:prefLabel "IDL document"@en ;
+  skos:prefLabel "IDL document"@nl ;
+  skos:prefLabel "IDL sənədi"@az ;
+  skos:prefLabel "IDL документ"@sr ;
+  skos:prefLabel "IDL 문서"@ko ;
+  skos:prefLabel "IDL-Dokument"@de ;
+  skos:prefLabel "IDL-asiakirja"@fi ;
+  skos:prefLabel "IDL-dokument"@nn ;
+  skos:prefLabel "IDL-dokument"@no ;
+  skos:prefLabel "IDL-dokument"@sv ;
+  skos:prefLabel "IDL-dokumentum"@hu ;
+  skos:prefLabel "document IDL"@fr ;
+  skos:prefLabel "Έγγραφο IDL"@el .
+
+media-type:text_x-install a skos:Concept ;
+  media-type:hasMediaType "text/x-install" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Návod k instalaci software"@cs ;
+  skos:prefLabel "Software-Installationsanleitung"@de ;
+  skos:prefLabel "cyfarwyddiadau gosod meddalwedd"@cy ;
+  skos:prefLabel "installationsinstruksjoner for programvare"@no ;
+  skos:prefLabel "instructions d'installation du logiciel"@fr ;
+  skos:prefLabel "ohjelmiston asennusohjeet"@fi ;
+  skos:prefLabel "programinstallationsinstruktioner"@sv ;
+  skos:prefLabel "proqram tə'minatını qurma tə'limatları"@az ;
+  skos:prefLabel "rettleiing i installering av programvare"@nn ;
+  skos:prefLabel "software installatie instructies"@nl ;
+  skos:prefLabel "software installation instructions"@en ;
+  skos:prefLabel "szoftvertelepítési leírás"@hu ;
+  skos:prefLabel "упутство за инсталацију програма"@sr ;
+  skos:prefLabel "소프트웨어 설치 방법"@ko .
+
+media-type:text_x-java a skos:Concept ;
+  media-type:hasMediaType "text/x-java" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Java source code"@en ;
+  skos:prefLabel "Java-Quelltext"@de ;
+  skos:prefLabel "Java-kildekode"@no ;
+  skos:prefLabel "Java-lähdekoodi"@fi ;
+  skos:prefLabel "Πηγαίος κώδικας Java"@el .
+
+media-type:text_x-ksh a skos:Concept ;
+  media-type:hasMediaType "text/x-ksh" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Korn qabıq skripti"@az ;
+  skos:prefLabel "Korn shell script"@en ;
+  skos:prefLabel "Korn shell script"@nl ;
+  skos:prefLabel "Korn shell-parancsfájl"@hu ;
+  skos:prefLabel "Korn skalskript"@nn ;
+  skos:prefLabel "Korn скрипта окружења"@sr ;
+  skos:prefLabel "Korn-Shell-Skript"@de ;
+  skos:prefLabel "Korn-skall skript"@no ;
+  skos:prefLabel "Korn-skalskript"@sv ;
+  skos:prefLabel "Ksh-komentotiedosto"@fi ;
+  skos:prefLabel "Sgript plisgyn Korn"@cy ;
+  skos:prefLabel "Skript Korn shellu"@cs ;
+  skos:prefLabel "script Korn shell"@fr ;
+  skos:prefLabel "Πρόγραμμα εντολών φλοιού Korn"@el ;
+  skos:prefLabel "콘쉘 스크립트"@ko .
+
+media-type:text_x-ksysv-log a skos:Concept ;
+  media-type:hasMediaType "text/x-ksysv-log" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:text_x-literate-haskell a skos:Concept ;
+  media-type:hasMediaType "text/x-literate-haskell" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffynhonnell Haskell llenyddol"@cy ;
+  skos:prefLabel "Literate Haskell-Quelltext"@de ;
+  skos:prefLabel "Literate Haskell-källkod"@sv ;
+  skos:prefLabel "Literate haskell -lähdekoodi"@fi ;
+  skos:prefLabel "Literate haskell mənbə kodu"@az ;
+  skos:prefLabel "Literate haskell source code"@en ;
+  skos:prefLabel "Literate haskell изворни кôд"@sr ;
+  skos:prefLabel "Literate haskell 소스 코드"@ko ;
+  skos:prefLabel "Literate haskell-kildekode"@no ;
+  skos:prefLabel "Literate haskell-kjeldekode"@nn ;
+  skos:prefLabel "Literális haskell-forráskód"@hu ;
+  skos:prefLabel "Zdrojový kód Literate haskell"@cs ;
+  skos:prefLabel "code source Literate haskell"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας Literate haskell"@el .
+
+media-type:text_x-log a skos:Concept ;
+  media-type:hasMediaType "text/x-log" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Anwendungsprotokoll"@de ;
+  skos:prefLabel "application log"@en ;
+  skos:prefLabel "applikasjonslogg"@no ;
+  skos:prefLabel "sovelluksen lokitiedosto"@fi .
+
+media-type:text_x-makefile a skos:Concept ;
+  media-type:hasMediaType "text/x-makefile" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil 'make'"@cy ;
+  skos:prefLabel "Makefil"@sv ;
+  skos:prefLabel "Makefile"@cs ;
+  skos:prefLabel "Makefile"@de ;
+  skos:prefLabel "Makefile"@el ;
+  skos:prefLabel "Makefile"@en ;
+  skos:prefLabel "Makefile"@fi ;
+  skos:prefLabel "Makefile"@hu ;
+  skos:prefLabel "Makefile"@ko ;
+  skos:prefLabel "Makefile"@nl ;
+  skos:prefLabel "Makefile"@nn ;
+  skos:prefLabel "Makefile"@no ;
+  skos:prefLabel "makefile"@fr ;
+  skos:prefLabel "İnşa faylı"@az ;
+  skos:prefLabel "Производна датотека"@sr .
+
+media-type:text_x-moc a skos:Concept ;
+  media-type:hasMediaType "text/x-moc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "QT-Meta-Objektdatei"@de ;
+  skos:prefLabel "Qt Meta Object -tiedosto"@fi ;
+  skos:prefLabel "Qt Meta Object file"@en ;
+  skos:prefLabel "Qt metaobjektfil"@no .
+
+media-type:text_x-objcsrc a skos:Concept ;
+  media-type:hasMediaType "text/x-objcsrc" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Objective-C -lähdekoodi"@fi ;
+  skos:prefLabel "Objective-C source code"@en ;
+  skos:prefLabel "Objective-C-Quelltext"@de ;
+  skos:prefLabel "Objective-C-kildekode"@no ;
+  skos:prefLabel "Πηγαίος κώδικας Objective-C"@el .
+
+media-type:text_x-pascal a skos:Concept ;
+  media-type:hasMediaType "text/x-pascal" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Pascal source code"@en ;
+  skos:prefLabel "Pascal-Quelltext"@de ;
+  skos:prefLabel "Pascal-kildekode"@no ;
+  skos:prefLabel "Pascal-lähdekoodi"@fi ;
+  skos:prefLabel "Πηγαίος κώδικας Pascal "@el .
+
+media-type:text_x-patch a skos:Concept ;
+  media-type:hasMediaType "text/x-patch" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Unterschied zwischen Dateien"@de ;
+  skos:prefLabel "differences between files"@en ;
+  skos:prefLabel "forskjeller mellom filer"@no ;
+  skos:prefLabel "tiedostojen väliset erot"@fi .
+
+media-type:text_x-readme a skos:Concept ;
+  media-type:hasMediaType "text/x-readme" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen README"@cy ;
+  skos:prefLabel "Dokument README"@cs ;
+  skos:prefLabel "LEESMIJ document"@nl ;
+  skos:prefLabel "LUEMINUT-asiakirja"@fi ;
+  skos:prefLabel "README document"@en ;
+  skos:prefLabel "README sənədi"@az ;
+  skos:prefLabel "README 문서"@ko ;
+  skos:prefLabel "README-Dokument"@de ;
+  skos:prefLabel "README-dokument"@nn ;
+  skos:prefLabel "README-dokument"@no ;
+  skos:prefLabel "README-dokument"@sv ;
+  skos:prefLabel "README-dokumentum"@hu ;
+  skos:prefLabel "document README"@fr ;
+  skos:prefLabel "Έγγραφο README"@el ;
+  skos:prefLabel "ПРОЧИТАЈМЕ документ"@sr .
+
+media-type:text_x-scheme a skos:Concept ;
+  media-type:hasMediaType "text/x-scheme" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffynhonnell Rhaglen Scheme"@cy ;
+  skos:prefLabel "Scheme broncode"@nl ;
+  skos:prefLabel "Scheme kjeldekode"@nn ;
+  skos:prefLabel "Scheme source code"@en ;
+  skos:prefLabel "Scheme изворни кôд"@sr ;
+  skos:prefLabel "Scheme 소스 코드"@ko ;
+  skos:prefLabel "Scheme-Quelltext"@de ;
+  skos:prefLabel "Scheme-forráskód"@hu ;
+  skos:prefLabel "Scheme-kildekode"@no ;
+  skos:prefLabel "Scheme-källkod"@sv ;
+  skos:prefLabel "Scheme-lähdekoodi"@fi ;
+  skos:prefLabel "Sxem mənbə kodu"@az ;
+  skos:prefLabel "Zdrojový kód Scheme"@cs ;
+  skos:prefLabel "code source Scheme"@fr ;
+  skos:prefLabel "Πηγαίος κώδικας Scheme"@el .
+
+media-type:text_x-setext a skos:Concept ;
+  media-type:hasMediaType "text/x-setext" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen Setext"@cy ;
+  skos:prefLabel "Dokument Setext"@cs ;
+  skos:prefLabel "Setext document"@en ;
+  skos:prefLabel "Setext document"@nl ;
+  skos:prefLabel "Setext sənədi"@az ;
+  skos:prefLabel "Setext документ"@sr ;
+  skos:prefLabel "Setext 문서"@ko ;
+  skos:prefLabel "Setext-Dokument"@de ;
+  skos:prefLabel "Setext-asiakirja"@fi ;
+  skos:prefLabel "Setext-dokument"@nn ;
+  skos:prefLabel "Setext-dokument"@no ;
+  skos:prefLabel "Setext-dokument"@sv ;
+  skos:prefLabel "Setext-dokumentum"@hu ;
+  skos:prefLabel "document Setext"@fr ;
+  skos:prefLabel "Έγγραφο Setext"@el .
+
+media-type:text_x-speech a skos:Concept ;
+  media-type:hasMediaType "text/x-speech" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Danışıq sənədi"@az ;
+  skos:prefLabel "Dogfen leferydd"@cy ;
+  skos:prefLabel "Dokument Speech"@cs ;
+  skos:prefLabel "Speech document"@en ;
+  skos:prefLabel "Speech document"@nl ;
+  skos:prefLabel "Speech документ"@sr ;
+  skos:prefLabel "Speech 문서"@ko ;
+  skos:prefLabel "Speech-dokument"@no ;
+  skos:prefLabel "Speech-dokument"@sv ;
+  skos:prefLabel "Speech-dokumentum"@hu ;
+  skos:prefLabel "Sprachdokument"@de ;
+  skos:prefLabel "Syntetisk tale"@nn ;
+  skos:prefLabel "document Speech"@fr ;
+  skos:prefLabel "puheasiakirja"@fi ;
+  skos:prefLabel "Έγγραφο ομιλίας"@el .
+
+media-type:text_x-sql a skos:Concept ;
+  media-type:hasMediaType "text/x-sql" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Côd SQL"@cy ;
+  skos:prefLabel "Kód SQL"@cs ;
+  skos:prefLabel "SQL code"@en ;
+  skos:prefLabel "SQL code"@nl ;
+  skos:prefLabel "SQL kodu"@az ;
+  skos:prefLabel "SQL кôд"@sr ;
+  skos:prefLabel "SQL 코드"@ko ;
+  skos:prefLabel "SQL-Befehle"@de ;
+  skos:prefLabel "SQL-kildekode"@no ;
+  skos:prefLabel "SQL-kod"@sv ;
+  skos:prefLabel "SQL-kode"@nn ;
+  skos:prefLabel "SQL-koodi"@fi ;
+  skos:prefLabel "SQL-kód"@hu ;
+  skos:prefLabel "code SQL"@fr ;
+  skos:prefLabel "Κώδικας SQL"@el .
+
+media-type:text_x-tcl a skos:Concept ;
+  media-type:hasMediaType "text/x-tcl" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Tcl script"@en ;
+  skos:prefLabel "Tcl-Skript"@de ;
+  skos:prefLabel "Tcl-skript"@no ;
+  skos:prefLabel "Tcl-skript"@sv ;
+  skos:prefLabel "Tcl-skripti"@fi ;
+  skos:prefLabel "Πρόγραμμα εντολών Tcl"@el .
+
+media-type:text_x-tex a skos:Concept ;
+  media-type:hasMediaType "text/x-tex" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen TeX "@cy ;
+  skos:prefLabel "TeX document"@en ;
+  skos:prefLabel "TeX документ"@sr ;
+  skos:prefLabel "TeX-Dokument"@de ;
+  skos:prefLabel "TeX-asiakirja"@fi ;
+  skos:prefLabel "TeX-dokument"@nn ;
+  skos:prefLabel "TeX-dokument"@no ;
+  skos:prefLabel "TeX-dokument"@sv ;
+  skos:prefLabel "Έγγραφο TeX"@el .
+
+media-type:text_x-texinfo a skos:Concept ;
+  media-type:hasMediaType "text/x-texinfo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen TeXInfo"@cy ;
+  skos:prefLabel "Dokument TeXInfo"@cs ;
+  skos:prefLabel "TeXInfo document"@en ;
+  skos:prefLabel "TeXInfo document"@nl ;
+  skos:prefLabel "TeXInfo sənədi"@az ;
+  skos:prefLabel "TeXInfo 문서"@ko ;
+  skos:prefLabel "TeXInfo-Dokument"@de ;
+  skos:prefLabel "TeXInfo-asiakirja"@fi ;
+  skos:prefLabel "TeXInfo-dokument"@nn ;
+  skos:prefLabel "TeXInfo-dokument"@no ;
+  skos:prefLabel "TeXInfo-dokument"@sv ;
+  skos:prefLabel "TeXInfo-dokumentum"@hu ;
+  skos:prefLabel "document TeXInfo"@fr ;
+  skos:prefLabel "Έγγραφο TeXInfo"@el ;
+  skos:prefLabel "ТеХинфо документ"@sr .
+
+media-type:text_x-troff-me a skos:Concept ;
+  media-type:hasMediaType "text/x-troff-me" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Troff ME -syöteasiakirja"@fi ;
+  skos:prefLabel "Troff ME input document"@en ;
+  skos:prefLabel "Troff ME-inndatadokument"@no ;
+  skos:prefLabel "Troff-ME-Eingabedokument"@de .
+
+media-type:text_x-troff-mm a skos:Concept ;
+  media-type:hasMediaType "text/x-troff-mm" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Troff MM -syöteasiakirja"@fi ;
+  skos:prefLabel "Troff MM input document"@en ;
+  skos:prefLabel "Troff MM-inndatadokument"@no ;
+  skos:prefLabel "Troff-MM-Eingabedokument"@de .
+
+media-type:text_x-troff-ms a skos:Concept ;
+  media-type:hasMediaType "text/x-troff-ms" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Troff MS -syöteasiakirja"@fi ;
+  skos:prefLabel "Troff MS input document"@en ;
+  skos:prefLabel "Troff MS-inndatadokument"@no ;
+  skos:prefLabel "Troff-MS-Eingabedokument"@de .
+
+media-type:text_x-uil a skos:Concept ;
+  media-type:hasMediaType "text/x-uil" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "X-Motif UIL -taulukko"@fi ;
+  skos:prefLabel "X-Motif UIL table"@en ;
+  skos:prefLabel "X-Motif-UIL-Tabelle"@de .
+
+media-type:text_x-uri a skos:Concept ;
+  media-type:hasMediaType "text/x-uri" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ressourcenort"@de ;
+  skos:prefLabel "resource location"@en ;
+  skos:prefLabel "ressurslokasjon"@no .
+
+media-type:text_x-vcalendar a skos:Concept ;
+  media-type:hasMediaType "text/x-vcalendar" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil gyfnewid vCalendar"@cy ;
+  skos:prefLabel "Soubor výměny vCalendar"@cs ;
+  skos:prefLabel "fichier « vCalendar interchange »"@fr ;
+  skos:prefLabel "vCalendar dəyişmə faylı"@az ;
+  skos:prefLabel "vCalendar interchange file"@en ;
+  skos:prefLabel "vCalendar uitwisselingsbestand"@nl ;
+  skos:prefLabel "vCalendar 교환 파일"@ko ;
+  skos:prefLabel "vCalendar-Austauschdatei"@de ;
+  skos:prefLabel "vCalendar-utbytesfil"@sv ;
+  skos:prefLabel "vCalendar-utvekslingsfil"@nn ;
+  skos:prefLabel "vCalendar-utvekslingsfil"@no ;
+  skos:prefLabel "vCalendar-välitystiedosto"@fi ;
+  skos:prefLabel "Датотека за vCalendar размену"@sr .
+
+media-type:text_x-vcard a skos:Concept ;
+  media-type:hasMediaType "text/x-vcard" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "electronic business card"@en ;
+  skos:prefLabel "elektronische Visitenkarte"@de ;
+  skos:prefLabel "elektronisk visittkort"@no ;
+  skos:prefLabel "elektroniskt visitkort"@sv ;
+  skos:prefLabel "sähköinen käyntikortti"@fi .
+
+media-type:text_x-xmi a skos:Concept ;
+  media-type:hasMediaType "text/x-xmi" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "XML Metadata Interchange file"@en ;
+  skos:prefLabel "XML-Metadaten-Austauschdatei"@de .
+
+media-type:text_x-xslfo a skos:Concept ;
+  media-type:hasMediaType "text/x-xslfo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Ffeil gwrthrych ffurfwedd XSL"@cy ;
+  skos:prefLabel "Soubor objektu formátování XSL"@cs ;
+  skos:prefLabel "XSF:FO-fájl"@hu ;
+  skos:prefLabel "XSL Formating Object file"@en ;
+  skos:prefLabel "XSL Formatlama Cismi faylı"@az ;
+  skos:prefLabel "XSL formatterend object bestand"@nl ;
+  skos:prefLabel "XSL formatteringsobjektfil"@nn ;
+  skos:prefLabel "XSL 포매팅 개체 파일"@ko ;
+  skos:prefLabel "XSL-Formatierungsobjektdatei"@de ;
+  skos:prefLabel "XSL-formateringsobjektfil"@sv ;
+  skos:prefLabel "XSL-muotoiluobjektitiedosto"@fi ;
+  skos:prefLabel "fichier objet XSL Formating"@fr ;
+  skos:prefLabel "Датотека XSL објеката форматирања"@sr .
+
+media-type:text_x-xslt a skos:Concept ;
+  media-type:hasMediaType "text/x-xslt" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "XSLT stylesheet"@en ;
+  skos:prefLabel "XSLT-Stylesheet"@de ;
+  skos:prefLabel "XSLT-stilark"@no ;
+  skos:prefLabel "XSLT-tyylitiedosto"@fi .
+
+media-type:text_xmcd a skos:Concept ;
+  media-type:hasMediaType "text/xmcd" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+
+media-type:text_xml a skos:Concept ;
+  media-type:hasMediaType "text/xml" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Dogfen XML (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language)"@cy ;
+  skos:prefLabel "Dokument eXtensible Markup Language"@cs ;
+  skos:prefLabel "Uitbreidbare opmaaktaal document (XML)"@nl ;
+  skos:prefLabel "XML-Dokument"@de ;
+  skos:prefLabel "XML-dokument"@sv ;
+  skos:prefLabel "XML-dokumentum"@hu ;
+  skos:prefLabel "document XML « eXtensible Markup Language »"@fr ;
+  skos:prefLabel "eXtensible Markup Language document"@en ;
+  skos:prefLabel "eXtensible Markup Language sənədi"@az ;
+  skos:prefLabel "eXtensible Markup Language-dokument"@nn ;
+  skos:prefLabel "laajennettava merkintäkielinen asiakirja (XML)"@fi ;
+  skos:prefLabel "документ проширивог језика за означавање (XML)"@sr ;
+  skos:prefLabel "확장 마크업 언어 문서"@ko .
+
+media-type:video a skos:Collection ;
+  rdfs:label "Video types"@en ;
+  dct:description "The collection of video types"@en ;
+  dct:title "Video types"@en ;
+  skos:member media-type:video_isivideo ;
+  skos:member media-type:video_mpeg ;
+  skos:member media-type:video_quicktime ;
+  skos:member media-type:video_vivo ;
+  skos:member media-type:video_wavelet ;
+  skos:member media-type:video_x-anim ;
+  skos:member media-type:video_x-avi ;
+  skos:member media-type:video_x-flic ;
+  skos:member media-type:video_x-mng ;
+  skos:member media-type:video_x-ms-asf ;
+  skos:member media-type:video_x-ms-wmv ;
+  skos:member media-type:video_x-msvideo ;
+  skos:member media-type:video_x-nsv ;
+  skos:member media-type:video_x-real-video ;
+  skos:member media-type:video_x-sgi-movie .
+
+media-type:video_isivideo a skos:Concept ;
+  media-type:hasMediaType "video/isivideo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Fideo ISI"@cy ;
+  skos:prefLabel "ISI video faylı"@az ;
+  skos:prefLabel "ISI video"@en ;
+  skos:prefLabel "ISI video"@nl ;
+  skos:prefLabel "ISI video"@nn ;
+  skos:prefLabel "ISI видео"@sr ;
+  skos:prefLabel "ISI 비디오"@ko ;
+  skos:prefLabel "ISI-Video"@de ;
+  skos:prefLabel "ISI-film"@no ;
+  skos:prefLabel "ISI-video"@fi ;
+  skos:prefLabel "ISI-video"@hu ;
+  skos:prefLabel "ISI-video"@sv ;
+  skos:prefLabel "Video ISI"@cs ;
+  skos:prefLabel "vidéo ISI"@fr ;
+  skos:prefLabel "Βίντεο ISI"@el .
+
+media-type:video_mpeg a skos:Concept ;
+  media-type:hasMediaType "video/mpeg" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MPEG video"@en ;
+  skos:prefLabel "MPEG-Video"@de ;
+  skos:prefLabel "MPEG-film"@no ;
+  skos:prefLabel "MPEG-video"@fi ;
+  skos:prefLabel "MPEG-video"@sv ;
+  skos:prefLabel "Βίντεο MPEG"@el .
+
+media-type:video_quicktime a skos:Concept ;
+  media-type:hasMediaType "video/quicktime" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "QuickTime video"@en ;
+  skos:prefLabel "QuickTime-Video"@de ;
+  skos:prefLabel "QuickTime-video"@fi ;
+  skos:prefLabel "Quicktime-film"@no ;
+  skos:prefLabel "Βίντεο QuickTime"@el .
+
+media-type:video_vivo a skos:Concept ;
+  media-type:hasMediaType "video/vivo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Fideo Vivo"@cy ;
+  skos:prefLabel "Video Vivo"@cs ;
+  skos:prefLabel "Vivo video faylı"@az ;
+  skos:prefLabel "Vivo video"@en ;
+  skos:prefLabel "Vivo video"@nl ;
+  skos:prefLabel "Vivo видео"@sr ;
+  skos:prefLabel "Vivo 비디오"@ko ;
+  skos:prefLabel "Vivo-Video"@de ;
+  skos:prefLabel "Vivo-film"@nn ;
+  skos:prefLabel "Vivo-film"@no ;
+  skos:prefLabel "Vivo-video"@fi ;
+  skos:prefLabel "Vivo-video"@hu ;
+  skos:prefLabel "Vivo-video"@sv ;
+  skos:prefLabel "vidéo Vivo"@fr ;
+  skos:prefLabel "Βίντεο Vivo"@el .
+
+media-type:video_wavelet a skos:Concept ;
+  media-type:hasMediaType "video/wavelet" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Fideo Wavelet"@cy ;
+  skos:prefLabel "Video Wavelet"@cs ;
+  skos:prefLabel "Wavelet video faylı"@az ;
+  skos:prefLabel "Wavelet video"@en ;
+  skos:prefLabel "Wavelet video"@nl ;
+  skos:prefLabel "Wavelet video"@nn ;
+  skos:prefLabel "Wavelet видео"@sr ;
+  skos:prefLabel "Wavelet 비디오"@ko ;
+  skos:prefLabel "Wavelet-Video"@de ;
+  skos:prefLabel "Wavelet-film"@no ;
+  skos:prefLabel "Wavelet-video"@fi ;
+  skos:prefLabel "Wavelet-video"@hu ;
+  skos:prefLabel "Wavelet-video"@sv ;
+  skos:prefLabel "vidéo Wavelet"@fr ;
+  skos:prefLabel "Βίντεο Wavelet"@el .
+
+media-type:video_x-anim a skos:Concept ;
+  media-type:hasMediaType "video/x-anim" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "ANIM animasiyası"@az ;
+  skos:prefLabel "ANIM animatie"@nl ;
+  skos:prefLabel "ANIM animation"@en ;
+  skos:prefLabel "ANIM анимација"@sr ;
+  skos:prefLabel "ANIM 동화상"@ko ;
+  skos:prefLabel "ANIM-Animation"@de ;
+  skos:prefLabel "ANIM-animaatio"@fi ;
+  skos:prefLabel "ANIM-animasjon"@nn ;
+  skos:prefLabel "ANIM-animasjon"@no ;
+  skos:prefLabel "ANIM-animation"@sv ;
+  skos:prefLabel "ANIM-animáció"@hu ;
+  skos:prefLabel "Animace ANIM"@cs ;
+  skos:prefLabel "Animeiddiad ANIM"@cy ;
+  skos:prefLabel "animation ANIM"@fr ;
+  skos:prefLabel "Κινούμενο σχέδιο ANIM"@el .
+
+media-type:video_x-avi a skos:Concept ;
+  media-type:hasMediaType "video/x-avi" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AVI video faylı"@az ;
+  skos:prefLabel "AVI video"@en ;
+  skos:prefLabel "AVI video"@nl ;
+  skos:prefLabel "AVI видео"@sr ;
+  skos:prefLabel "AVI 비디오"@ko ;
+  skos:prefLabel "AVI-Video"@de ;
+  skos:prefLabel "AVI-film"@no ;
+  skos:prefLabel "AVI-video"@fi ;
+  skos:prefLabel "AVI-video"@hu ;
+  skos:prefLabel "AVI-video"@nn ;
+  skos:prefLabel "AVI-video"@sv ;
+  skos:prefLabel "Fideo AVI"@cy ;
+  skos:prefLabel "Video AVI"@cs ;
+  skos:prefLabel "vidéo AVI"@fr ;
+  skos:prefLabel "Βίντεο AVI"@el .
+
+media-type:video_x-flic a skos:Concept ;
+  media-type:hasMediaType "video/x-flic" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "AutoDesk FLIC -animaatio"@fi ;
+  skos:prefLabel "AutoDesk FLIC animation"@en ;
+  skos:prefLabel "AutoDesk FLIC-animasjon"@no ;
+  skos:prefLabel "AutoDesk-FLIC-Animation"@de .
+
+media-type:video_x-mng a skos:Concept ;
+  media-type:hasMediaType "video/x-mng" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "MNG animation"@en ;
+  skos:prefLabel "MNG-Animation"@de ;
+  skos:prefLabel "MNG-animaatio"@fi ;
+  skos:prefLabel "MNG-animasjon"@no .
+
+media-type:video_x-ms-asf a skos:Concept ;
+  media-type:hasMediaType "video/x-ms-asf" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft ASF -video"@fi ;
+  skos:prefLabel "Microsoft ASF video"@en ;
+  skos:prefLabel "Microsoft ASF-film"@no ;
+  skos:prefLabel "Microsoft-ASF-Video"@de ;
+  skos:prefLabel "Βίντεο Microsoft ASF"@el .
+
+media-type:video_x-ms-wmv a skos:Concept ;
+  media-type:hasMediaType "video/x-ms-wmv" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft WMV -video"@fi ;
+  skos:prefLabel "Microsoft WMV video faylı"@az ;
+  skos:prefLabel "Microsoft WMV video"@en ;
+  skos:prefLabel "Microsoft WMV video"@nl ;
+  skos:prefLabel "Microsoft WMV-film"@nn ;
+  skos:prefLabel "Microsoft WMV-film"@no ;
+  skos:prefLabel "Microsoft WMV-video"@hu ;
+  skos:prefLabel "Microsoft WMV-video"@sv ;
+  skos:prefLabel "Microsoft-WMV-Video"@de ;
+  skos:prefLabel "Video Microsoft WMV"@cs ;
+  skos:prefLabel "Video Microsoft WMV"@cy ;
+  skos:prefLabel "vidéo Microsoft WMV"@fr ;
+  skos:prefLabel "Βίντεο Microsoft WMV"@el ;
+  skos:prefLabel "Микрософт WMV видео"@sr ;
+  skos:prefLabel "마이크로소프트 WMV 비디오"@ko .
+
+media-type:video_x-msvideo a skos:Concept ;
+  media-type:hasMediaType "video/x-msvideo" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Microsoft AVI -video"@fi ;
+  skos:prefLabel "Microsoft AVI video"@en ;
+  skos:prefLabel "Microsoft AVI-film"@no ;
+  skos:prefLabel "Microsoft AVI-video"@sv ;
+  skos:prefLabel "Microsoft-AVI-Video"@de ;
+  skos:prefLabel "Βίντεο Microsoft AVI"@el .
+
+media-type:video_x-nsv a skos:Concept ;
+  media-type:hasMediaType "video/x-nsv" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Fideo Nullsoft"@cy ;
+  skos:prefLabel "Nullsoft video faylı"@az ;
+  skos:prefLabel "Nullsoft video"@en ;
+  skos:prefLabel "Nullsoft video"@nl ;
+  skos:prefLabel "Nullsoft video"@nn ;
+  skos:prefLabel "Nullsoft video"@no ;
+  skos:prefLabel "Nullsoft видео"@sr ;
+  skos:prefLabel "Nullsoft-Video"@de ;
+  skos:prefLabel "Nullsoft-video"@fi ;
+  skos:prefLabel "Nullsoft-video"@hu ;
+  skos:prefLabel "Nullsoft-video"@sv ;
+  skos:prefLabel "Video Nullsoft"@cs ;
+  skos:prefLabel "vidéo Nullsoft"@fr ;
+  skos:prefLabel "Βίντεο Nullsoft"@el ;
+  skos:prefLabel "널소프트 비디오"@ko .
+
+media-type:video_x-real-video a skos:Concept ;
+  media-type:hasMediaType "video/x-real-video" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Fideo RealVideo"@cy ;
+  skos:prefLabel "RealVideo film"@no ;
+  skos:prefLabel "RealVideo video faylı"@az ;
+  skos:prefLabel "RealVideo video"@en ;
+  skos:prefLabel "RealVideo video"@nl ;
+  skos:prefLabel "RealVideo видео"@sr ;
+  skos:prefLabel "RealVideo-Video"@de ;
+  skos:prefLabel "RealVideo-film"@nn ;
+  skos:prefLabel "RealVideo-video"@fi ;
+  skos:prefLabel "RealVideo-video"@hu ;
+  skos:prefLabel "RealVideo-video"@sv ;
+  skos:prefLabel "Video RealVideo"@cs ;
+  skos:prefLabel "vidéo RealVideos"@fr ;
+  skos:prefLabel "Βίντεο RealVideo"@el ;
+  skos:prefLabel "리얼비디오 비디오"@ko .
+
+media-type:video_x-sgi-movie a skos:Concept ;
+  media-type:hasMediaType "video/x-sgi-movie" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "SGI video faylı"@az ;
+  skos:prefLabel "SGI video"@en ;
+  skos:prefLabel "SGI video"@nl ;
+  skos:prefLabel "SGI видео"@sr ;
+  skos:prefLabel "SGI 비디오"@ko ;
+  skos:prefLabel "SGI-Video"@de ;
+  skos:prefLabel "SGI-film"@no ;
+  skos:prefLabel "SGI-video"@fi ;
+  skos:prefLabel "SGI-video"@hu ;
+  skos:prefLabel "SGI-video"@nn ;
+  skos:prefLabel "SGI-video"@sv ;
+  skos:prefLabel "Video SGI"@cs ;
+  skos:prefLabel "Video SGI"@cy ;
+  skos:prefLabel "vidéo SGI"@fr ;
+  skos:prefLabel "Βίντεο SGI"@el .
+
+

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -12,10 +12,20 @@ media-type:hasMediaType a owl:DatatypeProperty, owl:FunctionalProperty ;
 
 <https://ontology.okp4.space/thesaurus/media-type> a skos:ConceptScheme ;
   rdfs:label "Media types Thesaurus"@en ;
-  dct:description "This thesaurus identifyies a sef of Internet media types (originally called MIME type) that are awareness and usage significant."@en ;
+  dct:description """
+    The Media Types Thesaurus is a comprehensive list of Internet media types (originally called MIME types) that are commonly used and widely recognized.
+    It serves as a standardized vocabulary to describe different types of content that can be transmitted over the Internet, including text, images, audio, and video.
+    
+    The primary purpose of this thesaurus is to enable interoperability and resource sharing within the dataverse, with a specific focus on datasets. Its design is intended
+    to promote the exchange of information and facilitate compatibility between different systems and tools used for managing and analyzing datasets.
+  """@en ;
+  dct:source <https://specifications.freedesktop.org/shared-mime-info-spec/latest/> ;
   dct:title "Media types Thesaurus"@en ;
   rdfs:seeAlso <http://en.wikipedia.org/wiki/Internet_media_type> ;
-  rdfs:seeAlso <http://standards.freedesktop.org/shared-mime-info-spec/> .
+  rdfs:seeAlso <https://www.iana.org/assignments/media-types/media-types.xhtml> ;
+  skos:note """
+    Note that this thesaurus may not be complete and all the media-type terms may not have all translations.
+  """@en .
 
 media-type:application a skos:Collection ;
   rdfs:label "Application types"@en ;


### PR DESCRIPTION
# Add the `hasFormat` property

## Description

The core ontology now includes the `hasFormat` property, enabling the designation of a resource's format as a [media type](https://en.wikipedia.org/wiki/Media_type) and linking it to the `GeneralMetadata` concept for `datasets`. The allowed format values (i.e. media types) are defined by a controlled vocabulary created with the [SKOS](https://www.w3.org/2009/08/skos-reference/skos.html) meta-model, and are based on the Freedesktop [Shared MIME-info Database](https://specifications.freedesktop.org/shared-mime-info-spec/latest/).
