### PR TITLE
refactor!: remove okp4:core subclassification of resources

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -35,8 +35,7 @@ A Data Space is highly customizable to allow its members to create a space of sh
     a owl:Restriction ;
     owl:allValuesFrom okp4core:DIDURI ;
     owl:onProperty okp4core:hasRegistrar ;
-  ] ;
-  rdfs:subClassOf okp4core:Data .
+  ] .
 
 okp4core:Dataset a owl:Class ;
   rdfs:label "Dataset"@en ;
@@ -65,8 +64,7 @@ okp4core:Dataset a owl:Class ;
     a owl:Restriction ;
     owl:allValuesFrom okp4core:Service ;
     owl:onProperty okp4core:providedBy ;
-  ] ;
-  rdfs:subClassOf okp4core:Data .
+  ] .
 
 okp4core:Metadata a owl:Class ;
   rdfs:label "Metadata"@en ;
@@ -77,8 +75,7 @@ okp4core:Metadata a owl:Class ;
     a owl:Restriction ;
     owl:allValuesFrom okp4core:Data ;
     owl:onProperty okp4core:describes ;
-  ] ;
-  rdfs:subClassOf okp4core:Data .
+  ] .
 
 okp4core:Period a owl:Class ;
   rdfs:label "Period"@en ;
@@ -134,8 +131,7 @@ okp4core:Service a owl:Class ;
     a owl:Restriction ;
     owl:allValuesFrom xsd:anyURI ;
     owl:onProperty okp4core:hasIdentifier ;
-  ] ;
-  rdfs:subClassOf okp4core:Data .
+  ] .
 
 okp4core:belongsTo a owl:ObjectProperty ;
   rdfs:label "belongs to"@en ;


### PR DESCRIPTION
# Metadata / Data refactor

## Change

This one is a little bit tricky. This PR removes the `rdfs:subClassOf okp4core:Data` statement for the classes `Dataspace`, `Dataset`, `Service` and `Metadata`. 

## Rationale

The initial version of the ontology included the `rdfs:subClassOf okp4core:Data` statement, which meant that `okp4core:Dataspace`, `okp4core:Dataset`, `okp4core:Service` and `okp4core:Metadata` were classified as subclasses of `okp4core:Data`. This classification implied that these resources were a type of `data` and could be described by `metadata`.

However, this classification is not entirely accurate from an ontological standpoint. In reality, it is because a `resource` is described by `metadata` that it becomes a type of `data` within the context of the `data` - `metadata` relation. Therefore, by removing the subclassing property, we avoid misclassifying the resources as a type of `data` and instead recognize that they are entities that can be described by metadata.