### PR TITLE
feat: add open licence v1

### DIFF
--- a/src/vocab-license.ttl
+++ b/src/vocab-license.ttl
@@ -185,6 +185,10 @@ license:LGPL-3_0 a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
   skos:prefLabel "GNU Lesser General Public License 3.0"@en .
 
+license:LO-FR-1_0 a skos:Concept ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:prefLabel "Open License 1.0"@en .
+
 license:LO-FR-2_0 a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
   skos:prefLabel "Open License 2.0"@en .


### PR DESCRIPTION
feat: add open licence v1

This feature declares the `Open License Version 1.0` in `licence`.
`Open License Version 1.0` facilitates and encourages the reuse of freely available French public data.

See https://www.etalab.gouv.fr/licence-ouverte-open-licence/ for more.

