### PR TITLE
fix: extends AgricultureEnvironnementAndForestry topic to food

### DIFF
--- a/src/vocab-topic.ttl
+++ b/src/vocab-topic.ttl
@@ -11,7 +11,7 @@
   """@en ;
   dcterms:title "The OKP4 Topic Thesaurus"@en .
 
-<https://ontology.okp4.space/thesaurus/topic/AgricultureEnvironmentAndForestry> a skos:Concept ;
+<https://ontology.okp4.space/thesaurus/topic/AgricultureFoodEnvironmentAndForestry> a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
   skos:prefLabel "Agriculture, food, environment and forestry"@en .
 

--- a/src/vocab-topic.ttl
+++ b/src/vocab-topic.ttl
@@ -13,7 +13,7 @@
 
 <https://ontology.okp4.space/thesaurus/topic/AgricultureEnvironmentAndForestry> a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
-  skos:prefLabel "Agriculture, environment and forestry"@en .
+  skos:prefLabel "Agriculture, food, environment and forestry"@en .
 
 <https://ontology.okp4.space/thesaurus/topic/BiologyGeologyAndChemistry> a skos:Concept ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;


### PR DESCRIPTION
fix: extends AgricutureEnvironnementAndForestry topic to food

Changes have been made to `skos:prefLabel` of the `AgricutureEnvironnementAndForestry` `topic` to include `food`.