### PR TITLE
feat: add Open Licence version 1.0 to dataLicences collection

### DIFF
--- a/src/vocab-license.ttl
+++ b/src/vocab-license.ttl
@@ -431,6 +431,7 @@ license:dataLicenses a skos:Collection ;
   skos:member license:CC-BY-NC-4_0 ;
   skos:member license:CC-BY-SA-4_0 ;
   skos:member license:CC0-1_0 ;
+  skos:member license:LO-FR-1_0 ;
   skos:member license:LO-FR-2_0 ;
   skos:member license:ODC-BY-1_0 ;
   skos:member license:ODbL-1_0 ;


### PR DESCRIPTION
feat: add Open Licence version 1.0 to dataLicences collection

Add Open Licence version 1.0 to dataLicences collection as indicated [here](https://github.com/okp4/ontology/pull/84/files/566f892b121eaeeb269c0e885fa47a2104299b5f#r1137208120)