### PR TITLE
Feat/insert geopackage mime type

### DIFF
--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -1567,6 +1567,12 @@ media-type:application_x-gettext-translation a skos:Concept ;
   skos:prefLabel "translated messages (machine-readable)"@en ;
   skos:prefLabel "übersetzte Meldungen (maschinenlesbar)"@de .
 
+media-type:application_x-gis a skos:Concept ;
+  media-type:hasMediaType "application/x-gis" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile"@en .
+
 media-type:application_x-glade a skos:Concept ;
   media-type:hasMediaType "application/x-glade" ;
   skos:broader media-type:text_plain ;
@@ -2291,6 +2297,12 @@ media-type:application_x-sc a skos:Concept ;
   media-type:hasMediaType "application/x-sc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
+media-type:application_x-shapfile a skos:Concept ;
+  media-type:hasMediaType "application/x-shapefile" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile"@en .
+  
 media-type:application_x-shar a skos:Concept ;
   media-type:hasMediaType "application/x-shar" ;
   skos:broader media-type:text_plain ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -247,6 +247,12 @@ media-type:application_andrew-inset a skos:Concept ;
   skos:prefLabel "Mewnosodiad Andrew Toolkit"@cy ;
   skos:prefLabel "ajout Andrew Toolkit"@fr .
 
+media-type:application_geopackage a skos:Concept ;
+  media-type:hasMediaType "application/geopackage+sqlite3" ;
+  skos:broader media-type:application_octet-stream 
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GeoPackage"@en .
+
 media-type:application_illustrator a skos:Concept ;
   media-type:hasMediaType "application/illustrator" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;


### PR DESCRIPTION
feat: insert geopackage mime type

I have inserted `application/geopackage+sqlite3` the MIME type for the GeoPackage format (`.gpkg`)
. GeoPackage (GPKG) is a format for raster or vector geospatial data that is open, non-proprietary, not tied to an operating system, and defined as much as possible on the basis of OGC or other standards, implemented as an SQLite database.

More information [here](https://fr.wikipedia.org/wiki/Geopackage).