### PR TITLE
feat(core): add Service execution concepts

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -52,11 +52,6 @@ okp4core:Dataset a owl:Class ;
   """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:anyURI ;
-    owl:onProperty okp4core:hasIdentifier ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
     owl:allValuesFrom okp4core:DIDURI ;
     owl:onProperty okp4core:hasRegistrar ;
   ] ;
@@ -64,6 +59,11 @@ okp4core:Dataset a owl:Class ;
     a owl:Restriction ;
     owl:allValuesFrom okp4core:Service ;
     owl:onProperty okp4core:providedBy ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
   ] .
 
 okp4core:Metadata a owl:Class ;
@@ -120,17 +120,78 @@ okp4core:Service a owl:Class ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:allValuesFrom okp4core:DIDURI ;
-    owl:onProperty okp4core:hasRegistrar ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
-    owl:allValuesFrom okp4core:DIDURI ;
     owl:onProperty okp4core:hasIdentity ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:allValuesFrom xsd:anyURI ;
     owl:onProperty okp4core:hasIdentifier ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
+  ] .
+
+okp4core:ServiceExecution a owl:Class ;
+  rdfs:label "Service Execution"@en ;
+  rdfs:comment """
+     The execution of a service with specific inputs and outputs. It represents the actual execution of a service in a ServiceExecutionOrder, along with its 
+     input and output datasets and metadata.
+  """@en ;
+  owl:equivalentClass [
+    a owl:Class ;
+    owl:intersectionOf ( [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:Service ;
+      owl:onProperty okp4core:hasObject ;
+    ] [
+      a owl:Class ;
+      owl:unionOf ( [
+        a owl:Restriction ;
+        owl:allValuesFrom okp4core:Dataset ;
+        owl:onProperty okp4core:produces ;
+      ] [
+        a owl:Restriction ;
+        owl:allValuesFrom okp4core:Metadata ;
+        owl:onProperty okp4core:produces ;
+      ] ) ;
+    ] [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:Dataset ;
+      owl:onProperty okp4core:hasInput ;
+    ] [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:ServiceExecutionOrder ;
+      owl:onProperty okp4core:specifiedBy ;
+    ] [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:ServiceExecution ;
+      owl:onProperty okp4core:hasParent ;
+    ] ) ;
+  ] .
+
+okp4core:ServiceExecutionOrder a owl:Class ;
+  rdfs:label "Service Execution Order"@en ;
+  rdfs:comment """
+    Formal representation of the order in which services should be executed. To specify the details of a service execution, such as the required resources 
+    (datasets), expected results, and potential time considerations, metadata should be used.
+    """@en ;
+  owl:equivalentClass [
+    a owl:Class ;
+    owl:intersectionOf ( [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:DIDURI ;
+      owl:onProperty okp4core:hasContractingParty ;
+    ] [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:Service ;
+      owl:onProperty okp4core:hasContractor ;
+    ] [
+      a owl:Restriction ;
+      owl:allValuesFrom okp4core:Service ;
+      owl:onProperty okp4core:hasObject ;
+    ] ) ;
   ] .
 
 okp4core:belongsTo a owl:ObjectProperty ;
@@ -152,6 +213,15 @@ okp4core:hasCategory a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has category"@en ;
   rdfs:comment "A category of the resource."@en ;
   rdfs:range skos:Concept .
+
+okp4core:hasContractingParty a owl:ObjectProperty ;
+  rdfs:label "has contracting party"@en ;
+  rdfs:comment "Link to the contracting party, identified by a decentralized identifier (DID)."@en ;
+  rdfs:range okp4core:DIDURI .
+
+okp4core:hasContractor a owl:ObjectProperty ;
+  rdfs:label "has contractor"@en ;
+  rdfs:comment "Link to the contractor responsible for executing a work on a contract basis."@en .
 
 okp4core:hasFormat a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has format"@en ;
@@ -175,10 +245,18 @@ okp4core:hasImage a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:comment "An image of the resource."@en ;
   rdfs:range xsd:anyURI .
 
+okp4core:hasInput a owl:ObjectProperty ;
+  rdfs:label "has input"@en ;
+  rdfs:comment "Specifies a resource which acts as an input."@en .
+
 okp4core:hasLicense a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has license"@en ;
   rdfs:comment "A legal document giving official permission to do something with the resource."@en ;
   rdfs:range okp4th:license .
+
+okp4core:hasParent a owl:ObjectProperty ;
+  rdfs:label "has parent"@en ;
+  rdfs:comment "describe the relationship between two resources, where one resource is the parent of another resource."@en .
 
 okp4core:hasRegistrar a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has registrar"@en ;
@@ -200,6 +278,10 @@ okp4core:hasTopic a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:comment "A topic of the resource."@en ;
   rdfs:range skos:Concept .
 
+okp4core:hasObject a owl:ObjectProperty ;
+  rdfs:label "has object"@en ;
+  rdfs:comment "Express the relationship between two resources where the second one is related to, or included in, the first one in some way."@en .
+
 okp4core:lastModifiedBy a owl:ObjectProperty ;
   rdfs:label "last modified by"@en ;
   rdfs:comment """
@@ -207,10 +289,18 @@ okp4core:lastModifiedBy a owl:ObjectProperty ;
   """@en ;
   rdfs:range okp4core:DIDURI .
 
+okp4core:produces a owl:ObjectProperty, owl:FunctionalProperty ;
+  rdfs:label "produces"@en ;
+  rdfs:comment "Specifies a resource which is produced."@en .
+
 okp4core:providedBy a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "provided by"@en ;
   rdfs:comment "References the entity that provides the resource."@en ;
   rdfs:range xsd:anyURI .
+
+okp4core:specifiedBy a owl:ObjectProperty ;
+  rdfs:label "specified by"@en ;
+  rdfs:comment "Reference the resource which specify clearly, exactly this resource."@en .
 
 okp4core:createdOn a owl:DatatypeProperty ;
   rdfs:label "created on"@en ;


### PR DESCRIPTION
## Purpose

This PR introduces the concepts related to the execution of services as required by #98.

## What's included

### `ServiceExecutionOrder`

Added the `ServiceExecutionOrder` class, which provides a formal representation of the order of the services that should be executed. To specify the details of a service execution, such as the required resources (datasets), expected results, and potential time considerations, `metadata` should be used.

The `ServiceExecutionOrder` class is defined using the following restrictions:

- `hasContractingParty`: relationship between a Service Execution Order and the contracting party (aka Client) who initiates the _contract_.
- `hasContractor`: represents the relationship between a Service Execution Order and the contractor (aka Service Provider, typically the workflow engine) responsible for executing the terms and conditions of the contract as agreed upon with the contracting party.
- `hasObject`: specifies the service which is the object of the execution.

```
Class: 'Service Execution Order'
   EquivalentTo: 
        ('has contracting party' only 'Decentralized Identifier URI')
         and ('has contractor' only Service)
         and ('has object' only Service)
```

### `ServiceExecution`

Added the `Service Execution` class, which represents the execution of a service in a workflow with specific inputs and outputs.

The ServiceExecution class is defined using the following restrictions:

- `hasObject`: a property that expresses the relationship between a service execution and the object of the execution, i.e. the service executed.
- `produces`: a property that specifies the output of a service execution, which could be metadata or datasets.
- `hasInput`: a property that specifies the input datasets required for a service execution.
- `specifiedBy`: a property that references the `ServiceExecutionOrder` that describes the service execution order in which this service execution belongs.
- `hasParent`: a property that specifies the parent service execution that this service execution belongs to, if any. This property allows to define a directed acyclic graph (DAG) of service executions, where each service execution is a node in the graph and the `hasParent` property defines the edges between nodes.

```
Class: 'Service Execution'
    EquivalentTo: 
        ((produces only Dataset) or (produces only Metadata))
         and ('has input' only Dataset)
         and ('has object' only Service)
         and ('has parent' only 'Service Execution')
         and ('specified by' only 'Service Execution Order')
```

## Overview

The following diagram depicts the introduced concepts and their relationship with the already existing concepts of the ontology.

```mermaid
classDiagram
    Dataset --> Service : providedBy

    class Metadata{
      <<abstract>>
    }
    Metadata <|.. ServiceGeneralMetadata
    Metadata <|.. DatasetGeneralMetadata
    Metadata <|.. ServiceExecutionMetadata
    Metadata <|.. ServiceSpecificationMetadata

    ServiceExecutionMetadata ..> ServiceExecution : describes

    ServiceGeneralMetadata ..> Service : describes
    ServiceSpecificationMetadata ..> Service : describes
    DatasetGeneralMetadata ..> Dataset : describes

    ServiceExecutionOrder --> Service : hasObject
    ServiceExecutionOrder --> Service : has contractor

    ServiceExecution --> ServiceExecutionOrder : specifiedBy

    ServiceExecution --> Service : hasObject
    ServiceExecution --> ServiceExecution : hasParent

    ServiceExecution --> Dataset : hasInput
    ServiceExecution --> Dataset : produces
    ServiceExecution --> Metadata : produces
```

The following diagram shows the possible instances of Service Execution:

```mermaid
graph TD;
  subgraph data
    D1
    D2
    D3   
  end
  subgraph metadata
    M1
    M2
    M3
  end
  subgraph service
    SE1
    SE2
    SE3
    SE4
  end

  M1 -.describes.-> D1
  M2 -.describes.-> D1
  M3 -.describes.-> D1
  SE4 --hasParent--> SE3
  SE3 --hasParent--> SE2
  SE2 --hasParent--> SE1
  SE1 --hasInput--> D1
  SE2 --hasInput--> D1
  SE1 --produces--> M1
  SE2 --produces--> M2
  SE2 --produces--> M3
  SE3 --hasInput--> M1
  SE3 --hasInput--> M2
  SE3 --hasInput--> M3
  SE3 --hasInput--> D1
  SE3 --produces--> D2
  SE4 --hasInput--> D1
  SE4 --hasInput--> D2
  SE4 --produces--> D3
```