### PR TITLE
feat(metadata): add metadata governance schema

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -66,6 +66,22 @@ okp4core:Dataset a owl:Class ;
     owl:onProperty okp4core:hasIdentifier ;
   ] .
 
+okp4core:Governance a owl:Class ;
+  rdfs:label "Governance"@en ;
+  rdfs:comment """
+    `Governance` is a set of rules that define how a `Data Space` is managed and how the resources are shared.
+  """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:anyURI ;
+    owl:onProperty okp4core:hasIdentifier ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom okp4core:DIDURI ;
+    owl:onProperty okp4core:hasRegistrar ;
+  ] .
+
 okp4core:Metadata a owl:Class ;
   rdfs:label "Metadata"@en ;
   rdfs:comment """
@@ -84,14 +100,14 @@ okp4core:Period a owl:Class ;
   """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom xsd:dateTime ;
-    owl:onProperty okp4core:hasStartDate ;
-  ] ;
-  rdfs:subClassOf [
-    a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
     owl:onDataRange xsd:dateTime ;
     owl:onProperty okp4core:hasEndDate ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:dateTime ;
+    owl:onProperty okp4core:hasStartDate ;
   ] .
 
 okp4core:Resource a owl:Class ;
@@ -99,7 +115,7 @@ okp4core:Resource a owl:Class ;
   rdfs:comment """
   `Resource` denotes members of a `Data Space`, including datasets, services...
   """@en ;
-  owl:unionOf ( okp4core:Dataset okp4core:Service ) ;
+  owl:unionOf ( okp4core:Dataset okp4core:Service okp4core:Governance ) ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:allValuesFrom okp4core:DataSpace ;

--- a/src/metadata-governance.ttl
+++ b/src/metadata-governance.ttl
@@ -1,0 +1,151 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix core: <https://ontology.okp4.space/core/> .
+@prefix meta: <https://ontology.okp4.space/metadata/governance/> .
+
+meta:Article a owl:Class ;
+  rdfs:label "Article"@en ;
+  rdfs:comment """
+    An article of a governance text, which states a specific (legal) rule or principle. Articles are the smallest unit of a governance text which represents a significant rule that can be enforced. 
+  """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom meta:Subsection ;
+    owl:onProperty core:isPartOf ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty meta:hasNumber ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] .
+
+meta:Chapter a owl:Class ;
+  rdfs:label "Chapter"@en ;
+  rdfs:comment "A chapter of a governance text, which groups related sections together."@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] .
+
+meta:GovernanceMetadata a owl:Class ;
+  rdfs:label "Governance metadata"@en ;
+  rdfs:comment """
+    Metadata provides descriptive information about a governance text. This metadata is distinct from the governance text itself, but helps to understand the governance text 
+    by providing important context. The metadata describes the governance text in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
+
+    This metadata is especially valuable in decentralized applications and web3 interfaces where governance texts are utilized to describe and represent the rules governing dataspaces. This enables users to more readily engage with the governance text, allowing them to gain a better understanding of how the text operates and the rules governing the relationship between all resources within the dataspaces.
+  """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom meta:Chapter ;
+    owl:onProperty meta:hasChapter ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:dateTime ;
+    owl:onProperty core:createdOn ;
+  ] ;
+  rdfs:subClassOf core:Metadata .
+
+meta:Paragraph a owl:Class ;
+  rdfs:label "Paragraph"@en ;
+  rdfs:comment """
+    A paragraph of an article, which expresses a sub-rule or sub-principle of the article.
+  """@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty meta:hasNumber ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom meta:Article ;
+    owl:onProperty core:isPartOf ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] .
+
+meta:Section a owl:Class ;
+  rdfs:label "Section"@en ;
+  rdfs:comment "A section of a governance text, which groups related subsections together."@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom meta:Chapter ;
+    owl:onProperty core:isPartOf ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty meta:hasNumber ;
+  ] .
+
+meta:Subsection a owl:Class ;
+  rdfs:label "Subsection"@en ;
+  rdfs:comment "A subsection of a governance text, which groups related articles together within a section."@en ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom meta:Section ;
+    owl:onProperty core:isPartOf ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty meta:hasNumber ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasTitle ;
+  ] ;
+  rdfs:subClassOf [
+    a owl:Restriction ;
+    owl:allValuesFrom xsd:string ;
+    owl:onProperty core:hasDescription ;
+  ] .
+
+meta:hasNumber a owl:DatatypeProperty, owl:FunctionalProperty ;
+  rdfs:label "has number"@en ;
+  rdfs:comment """
+  A property that links a governance concept to its number.
+  
+  The value of the property is presented as a string, to allow for different numbering styles, such as Roman numerals or decimal numbers 
+  with sub-numbers, like '1.2'.
+  """@en ;
+  rdfs:range xsd:string .
+
+


### PR DESCRIPTION
## Purpose

Introduces the definition of governance metadata to describe the rules governing Dataspaces, that are currently expressed as Prolog programs and [interpreted on-chain](https://github.com/okp4/contracts/blob/05147f33c3e758a60e6354840ab037c6a3766811/contracts/cw-law-stone/README.md), to fullfil #100.

## Philosophy behind

This approach takes inspiration from the organizational structure of legal texts, which subdivide and organize content for  explicit and precise understanding. It is also informed by the product-oriented understanding of Governance, as well as a the various UX interfaces created to describe governance (https://github.com/okp4/dataverse-portal/issues/72, https://github.com/okp4/dataverse-portal/issues/105, https://github.com/okp4/dataverse-portal/issues/106, https://github.com/okp4/dataverse-portal/issues/107, https://github.com/okp4/dataverse-portal/issues/108). 

The proposed governance metadata aims to provide a clear and comprehensive description and understanding of the governance rules, without requiring the interpretation of the logic program.

## What's included

### `GovernanceMetadata`

The governance metadata provides a structured and organized way of representing and understanding the rules and principles found in governance texts. Governance texts are documents that outline the governing principles, laws, or guidelines for a dataspace, and currently implemented by prolog programs.

```
Class: 'Governance metadata'
    SubClassOf: 
        Metadata,
        hasChapter only Chapter,
        createdOn only xsd:dateTime
```

The metadata is designed in a hierarchical manner, which consists of  a `chapter`, and a 3-level organization: `sections`, `subsections`, `articles`, and `paragraphs`. The hierarchy within the organizational level of `sections`, `subsections`, `articles`, and `paragraphs` is established through the use of numbering, represented as a string, allows for different numbering styles, such as Roman numerals or decimal numbers with sub-numbers, like "1.2".

The levels of hierarchy are:

- `Chapter`:  It groups related sections together, providing a high-level organization of the content within the governance text.

```
Class: Chapter
    SubClassOf: 
        hasDescription only xsd:string,
        hasTitle only xsd:string
```

- `Sections`: They group related subsections together, serving as an intermediate level of organization.

```
Class: Section
    SubClassOf: 
        isPartOf only Chapter,
        hasDescription only xsd:string,
        hasTitle only xsd:string,
        hasNumber only xsd:string
```

- `Subsections`: They group related articles together, serving as an intermediate level of organization.

```
Class: Subsection
    SubClassOf: 
        isPartOf only Section,
        hasDescription only xsd:string,
        hasTitle only xsd:string,
        hasNumber only xsd:string
```

- `Articles`: They represent the smallest unit of a governance text that carries a significant, enforceable rule or principle.

```
Class: Article
    SubClassOf: 
        isPartOf only Subsection,
        hasDescription only xsd:string,
        hasTitle only xsd:string,
        hasNumber only xsd:string
```

- `Paragraphs`: They express sub-rules or sub-principles within an article, providing further granularity and detail.

```
Class: Paragraph
    SubClassOf: 
        isPartOf only Article,
        hasDescription only xsd:string,
        hasTitle only xsd:string,
        hasNumber only xsd:string
```

### `Governance`

Introduce a new resource called `Governance` for the dataspace, which represents the governance and is uniquely identified by its URI. The URI serves as a unique reference for the governance text (e.g. prolog program).

```
Class: Governance
    SubClassOf: 
        'has identifier' only xsd:anyURI,
        'has registrar' only 'Decentralized Identifier URI'
```

The `Resource` has been changed to include the `Governance` class introduced:

```
Class: Resource
    EquivalentTo: 
        Dataset or Service or Governance
    SubClassOf: 
        'belongs to' only 'Data Space'
```

## Overview

```mermaid
classDiagram
    class Metadata

    class Dataspace

    class Governance

    Governance --> Dataspace : belongsTo

    GovernanceMetadata --> Governance : describes 

    class Article {
        +hasDescription: string
        +hasNumber: string
        +hasTitle: string
    }
    class Paragraph {
        +hasDescription: string
        +hasNumber: string
        +hasTitle: string
    }
    class Chapter {
        +hasDescription: string
        +hasTitle: string
    }
    class GovernanceMetadata {
        +hasIdentifier: anyURI
        +createdOn: dateTime
    }
    class Section {
        +hasDescription: string
        +hasTitle: string
        +hasNumber: string
    }
    class Subsection {
        +hasDescription: string
        +hasTitle: string
        +hasNumber: string
    }
    
    Metadata <|.. GovernanceMetadata
    Article o--> Subsection: isPartOf
    Paragraph o--> Article: isPartOf
    Subsection o--> Section: isPartOf
    Section o--> Chapter: isPartOf
    GovernanceMetadata --> Chapter: hasChapter
```

## UI relation

The following picture describes the relation of the different elements of the metadata profile with the elements presented in the UI.

<img width="1235" alt="image" src="https://user-images.githubusercontent.com/9574336/229777641-ac9e4879-f75a-4f74-bd63-d5b2d075bece.png">

## Example

```turtle
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix core: <https://ontology.okp4.space/core/> .
@prefix meta: <https://ontology.okp4.space/metadata/governance/> .
@prefix ex: <https://example.com/> .

ex:GovernanceFooMetadata a meta:GovernanceMetadata, owl:NamedIndividual ;
  core:createdOn "2023-04-04T00:00:00"^^xsd:dateTime ;
  meta:hasChapter ex:Chapter1 .

ex:Chapter1 a meta:Chapter, owl:NamedIndividual ;
  core:hasTitle "Foo Governance" ;
  core:hasDescription "The Foo dataspace is a private dataspace which aims to..." .

ex:Section1 a meta:Section, owl:NamedIndividual ;
  core:hasTitle "Datasets Management" ;
  core:hasDescription "Specifies the governance rules regarding the management of datasets." ;
  meta:hasNumber "1.1" ;
  core:isPartOf ex:Chapter1 .

ex:Subsection1 a meta:Subsection, owl:NamedIndividual ;
  core:hasTitle "Reference" ;
  core:hasDescription "Specifies the governance rules for the referencing of datasets." ;
  meta:hasNumber "1.1.1" ;
  core:isPartOf ex:Section1 .

ex:Article1 a meta:Article, owl:NamedIndividual ;
  core:hasTitle "Dataset referencing rules" ;
  core:hasDescription "User did:foo:1234 can reference datasets if" ;
  meta:hasNumber "1.1.1.1" ;
  core:isPartOf ex:Section1 .

ex:Paragraph1 a meta:Paragraph, owl:NamedIndividual ;
  core:hasTitle "Topic" ;
  core:hasDescription "Agriculture or food" ;
  meta:hasNumber "1.1.1.1.1" ;
  core:isPartOf ex:Article1 .

ex:Paragraph2 a meta:Paragraph, owl:NamedIndividual ;
  core:hasTitle "Size" ;
  core:hasDescription "Smaller than 5Gb" ;
  meta:hasNumber "1.1.1.1.2" ;
  core:isPartOf ex:Article1 .

ex:Paragraph2 a meta:Paragraph, owl:NamedIndividual ;
  core:hasTitle "Language" ;
  core:hasDescription "English, French" ;
  meta:hasNumber "1.1.1.1.2" ;
  core:isPartOf ex:Article1 .
```

