### PR TITLE
docs(example): fix metadata id uniqueness

### DIFF
--- a/example/rhizome/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde.ttl
+++ b/example/rhizome/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:d1615703-4ee1-4e2f-997e-15aecf1eea4e a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:0ea1fc7a-dd97-4adc-a10e-169c6597bcde ;
     core:hasCreator "Anses" ;
@@ -32,7 +32,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Tabelle der Nährstoffzusammensetzung von Lebensmitteln Ciqual 2020"@fr ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:15592fd4-e368-46d3-b113-5d0ef8d4d10f a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/10ca8ff2-f0c3-47ba-b37a-8560b2e41ae7.ttl
+++ b/example/rhizome/dataset/10ca8ff2-f0c3-47ba-b37a-8560b2e41ae7.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:99fa4dda-08a5-4145-9fef-15d78e35de80 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:10ca8ff2-f0c3-47ba-b37a-8560b2e41ae7 ;
     core:hasCreator "IGN" ;
@@ -33,7 +33,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "OCS GE"@de ;
     core:hasTopic topic:Other .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:dec944c1-9e27-4e1d-bdc7-52151cdfe219 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/1a4c5896-b13e-40f7-a603-5a5b3ed996a1.ttl
+++ b/example/rhizome/dataset/1a4c5896-b13e-40f7-a603-5a5b3ed996a1.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:d37d4917-549a-434d-9dc5-68eb685f9a88 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:1a4c5896-b13e-40f7-a603-5a5b3ed996a1 ;
     core:hasCreator "INAO" ;
@@ -30,7 +30,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Geografisches Gebiet der g.g.A."@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:fd6944b0-887d-470b-aa4f-85cd35ccfe87 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/1ef341e8-de34-4561-95b6-29c834901c1f.ttl
+++ b/example/rhizome/dataset/1ef341e8-de34-4561-95b6-29c834901c1f.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:5187bd9c-289f-4e2d-9b7f-f481d6f84c18 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:1ef341e8-de34-4561-95b6-29c834901c1f ;
     core:hasCreator "IGN" ;
@@ -30,7 +30,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Höhenkurven"@de ;
     core:hasTopic topic:Other .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:e58b4546-8603-41e3-9d57-739f44c451b1 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/3ed871dc-72d0-499f-b8c2-7edcad56a76e.ttl
+++ b/example/rhizome/dataset/3ed871dc-72d0-499f-b8c2-7edcad56a76e.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:b353e7a7-8708-438d-8288-1345e10b39d7 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:3ed871dc-72d0-499f-b8c2-7edcad56a76e ;
     core:hasCreator "INAO" ;
@@ -31,7 +31,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Geografische Gebiete der AOC/AOP"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:a612fa2b-3642-4d51-80bc-5914c3567450 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/441bb5ec-6c00-428f-938f-720e5e918a50.ttl
+++ b/example/rhizome/dataset/441bb5ec-6c00-428f-938f-720e5e918a50.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:75aea3ba-17a9-428a-8f50-a0059e2f0672 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:441bb5ec-6c00-428f-938f-720e5e918a50 ;
     core:hasCreator "Agence Bio" ;
@@ -42,7 +42,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Parzellen mit biologischem Landbau (AB), die für die GAP 2021 angemeldet wurden"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:a4b20f17-040c-4fbd-b67f-961e75fe5bcd a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/46f75dd8-0b13-4762-bde3-bf31f85810f6.ttl
+++ b/example/rhizome/dataset/46f75dd8-0b13-4762-bde3-bf31f85810f6.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:01ab3423-ac4c-4402-8554-22472ac55566 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:46f75dd8-0b13-4762-bde3-bf31f85810f6 ;
     core:hasCreator "Ministère de l'agriculture et de l'Alimentation" ;
@@ -38,7 +38,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Referenzdosen Indikator für die Häufigkeit von Pflanzenschutzbehandlungen"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:6380faf9-683d-4269-8372-e21a2e137c07 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/49c66bf2-8cda-4b87-9430-ad4a65ff5793.ttl
+++ b/example/rhizome/dataset/49c66bf2-8cda-4b87-9430-ad4a65ff5793.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:92094624-aaa3-46b1-a59a-af6ebfcf204d a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:49c66bf2-8cda-4b87-9430-ad4a65ff5793 ;
     core:hasCreator "IGN" ;
@@ -34,7 +34,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Datenbank über Waldbrände in Frankreich (BDIFF)"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:9dc373b3-fe8e-453c-9c35-5ce6b0de6947 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/552382cb-9043-455d-b155-fc738930fe28.ttl
+++ b/example/rhizome/dataset/552382cb-9043-455d-b155-fc738930fe28.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:529c7b7c-4f94-4e95-84c1-c2b3bb0394bf a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:552382cb-9043-455d-b155-fc738930fe28 ;
     core:hasCreator "INAO" ;
@@ -34,7 +34,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Abgrenzung der geografischen Gebiete von SIQOs"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:44605340-e05f-4fda-bce4-85bdde3ba6bc a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/55421f8d-b36a-48a4-961a-dc18ed5088b5.ttl
+++ b/example/rhizome/dataset/55421f8d-b36a-48a4-961a-dc18ed5088b5.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:acc3a664-0787-48d3-9f6b-5f98f251de39 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:55421f8d-b36a-48a4-961a-dc18ed5088b5 ;
     core:hasCreator "Agence Bio" ;
@@ -32,7 +32,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Bio-Flächen, Viehbestand und Anzahl der Bio-Betreiber in der Gemeinde"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:df328a95-6f35-4871-817a-e18a382927cf a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/5626b242-0c02-45a7-98ca-34c9f4d42b04.ttl
+++ b/example/rhizome/dataset/5626b242-0c02-45a7-98ca-34c9f4d42b04.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:2815ce79-100e-49a9-940e-f806fcf4f034 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:5626b242-0c02-45a7-98ca-34c9f4d42b04 ;
     core:hasCreator "INAO" ;
@@ -31,7 +31,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Parzellarische Abgrenzung der AOC-Weinbaugebiete des INAO"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:85d38e2c-9e7b-4dbb-965f-d5a8b410dbbc a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/5aeba752-dfb2-48c1-a90d-c0edd0738c0d.ttl
+++ b/example/rhizome/dataset/5aeba752-dfb2-48c1-a90d-c0edd0738c0d.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:cb78a6b9-b39e-43f7-89f4-22f55ab6de8d a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:5aeba752-dfb2-48c1-a90d-c0edd0738c0d ;
     core:hasCreator "IGN" ;
@@ -43,7 +43,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "BD TOPO departements"@de ;
     core:hasTopic topic:Other .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:2346735a-dea8-4d6b-9419-3b81f78ce940 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/5da01b5b-af91-4ecd-9458-c885a248417e.ttl
+++ b/example/rhizome/dataset/5da01b5b-af91-4ecd-9458-c885a248417e.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:ebcb28c0-0751-403f-85f7-a185b913c6d9 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:5da01b5b-af91-4ecd-9458-c885a248417e ;
     core:hasCreator "Agence Bio" ;
@@ -32,7 +32,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Detaillierter historischer Überblick über Flächen, Viehbestand und Anzahl der Marktteilnehmer pro Departement"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:125f3bf4-08ac-46e1-bf8e-371fb81ed835 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/6377fcb1-21a1-4f28-bebc-20f065c3000a.ttl
+++ b/example/rhizome/dataset/6377fcb1-21a1-4f28-bebc-20f065c3000a.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:9413c4db-8102-4c02-8035-5c7cc55f9605 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:6377fcb1-21a1-4f28-bebc-20f065c3000a ;
     core:hasCreator "Ministère de l'agriculture et de l'Alimentation" ;
@@ -31,7 +31,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Liste der regulierten Forstarten"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:e9fc69ac-6e92-4c94-b955-3054ea364965 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/8ad881d8-f350-4cc0-bab3-8e694aa63cd3.ttl
+++ b/example/rhizome/dataset/8ad881d8-f350-4cc0-bab3-8e694aa63cd3.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:cb9e9dd2-b84f-4dde-bb54-de9476b16162 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:8ad881d8-f350-4cc0-bab3-8e694aa63cd3 ;
     core:hasCreator "Agence Bio" ;
@@ -42,7 +42,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Parzellen mit biologischem Landbau (AB), die für die GAP 2020 angemeldet wurden"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:e657206f-fe0b-4199-b9f4-96593d134081 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/965dae6f-19ad-4a2b-93f3-05e2d09d7496.ttl
+++ b/example/rhizome/dataset/965dae6f-19ad-4a2b-93f3-05e2d09d7496.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:6274df8d-2492-443a-80a7-9791372bf8b8 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:965dae6f-19ad-4a2b-93f3-05e2d09d7496 ;
     core:hasCreator "Ministère de l'agriculture et de l'Alimentation" ;
@@ -32,7 +32,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Liste der Waldmassive, die als Schutzwälder eingestuft sind"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:ba404ea5-7cbf-426e-beaf-9b8bd651f734 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/96a562a9-5feb-4a41-bcf2-cc8610af9f78.ttl
+++ b/example/rhizome/dataset/96a562a9-5feb-4a41-bcf2-cc8610af9f78.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:69db3c60-29eb-46f5-a600-c64e46a4b4cf a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:96a562a9-5feb-4a41-bcf2-cc8610af9f78 ;
     core:hasCreator "Anses" ;
@@ -31,7 +31,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Daten Studie zur Gesamternährung von Kindern"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:eb29181e-b3eb-48cc-b0c8-85d0b811a619 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/9cda6da3-c587-41d1-96a1-7435f90d7492.ttl
+++ b/example/rhizome/dataset/9cda6da3-c587-41d1-96a1-7435f90d7492.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:76eee7b6-789b-4793-830e-daa0d096fd66 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:9cda6da3-c587-41d1-96a1-7435f90d7492 ;
     core:hasCreator "Météo France" ;
@@ -31,7 +31,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Monatliche Bodenfeuchtigkeitsindexdaten für die einheitliche SWI Natural Disaster Facility"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:02375bc9-fde4-4017-a20a-5e30fb9f80f9 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/aec18920-43ca-464e-bea9-1a642ba56dda.ttl
+++ b/example/rhizome/dataset/aec18920-43ca-464e-bea9-1a642ba56dda.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:5ce9674c-0b59-427e-94cc-7c44f6683713 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:aec18920-43ca-464e-bea9-1a642ba56dda ;
     core:hasCreator "Ministère de la Transition écologique" ;
@@ -35,7 +35,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Statistiken zur Fischereiüberwachung"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:e67859ae-4062-4588-b5c3-aef37a16b026 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/c0cc2228-c88b-40a9-9afd-fe0204774abe.ttl
+++ b/example/rhizome/dataset/c0cc2228-c88b-40a9-9afd-fe0204774abe.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:19f854f3-d945-49c4-8026-13abf6eb0786 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:c0cc2228-c88b-40a9-9afd-fe0204774abe ;
     core:hasCreator "Ministère de la Transition écologique" ;
@@ -36,7 +36,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Verzeichnis von Betrieben mit hohem Umweltwert (High Environmental Value)"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:cde73ecf-a7d0-44e0-8edc-e2adc2bb024c a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/e3fb5ffc-31fd-45e5-a60b-1bf1c3e317e5.ttl
+++ b/example/rhizome/dataset/e3fb5ffc-31fd-45e5-a60b-1bf1c3e317e5.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:ccd18b27-8059-4602-a263-5afaf9e78551 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:e3fb5ffc-31fd-45e5-a60b-1bf1c3e317e5 ;
     core:hasCreator "IGN" ;
@@ -33,7 +33,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "BD Forest"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:738881c8-c2da-4156-9a14-fed5800175c8 a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;

--- a/example/rhizome/dataset/f047abf0-cbad-49d7-985e-7171b9b0e619.ttl
+++ b/example/rhizome/dataset/f047abf0-cbad-49d7-985e-7171b9b0e619.ttl
@@ -12,7 +12,7 @@
 @prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
+dstmeta:af77412b-487f-48b7-ae38-63a1198ce449 a owl:NamedIndividual,
         metadst:GeneralMetadata ;
     core:describes dataset:f047abf0-cbad-49d7-985e-7171b9b0e619 ;
     core:hasCreator "Agence Bio" ;
@@ -42,7 +42,7 @@ dstmeta:496c7dc1-42a1-423f-9274-dd72168a8da2 a owl:NamedIndividual,
     core:hasTitle "Parzellen mit biologischem Landbau (AB), die für die GAP 2021 angemeldet wurden"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-dstmeta:659b4a4d-5a45-4769-ac7f-0b746ef10ef1 a owl:NamedIndividual,
+dstmeta:e7362132-893e-49ee-91cf-270372911dfa a owl:NamedIndividual,
         meta:AuditMetadata ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-28T00:00:00+00:00"^^xsd:dateTime ;


### PR DESCRIPTION
Self explanatory.

----

Applied this script:

```sh
#!/bin/bash

old_uuids=('496c7dc1-42a1-423f-9274-dd72168a8da2' '659b4a4d-5a45-4769-ac7f-0b746ef10ef1')

for file in example/rhizome/dataset/*.ttl
do
    for old_uuid in "${old_uuids[@]}"
    do
        echo "🩹 patch $file"
        new_uuid=$(uuidgen | tr "[:upper:]" "[:lower:]")
        sed -i "" -E "s/dstmeta:$old_uuid/dstmeta:$new_uuid/g" "$file"
    done
done
echo "🆗 done"
```