### PR TITLE
Build/fuseki deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,6 +237,10 @@ fuseki-stop: ## Stop Fuseki server
 	@docker stop ${DEPLOYMENT_FUSEKI_CONTAINER}
 	@echo "${COLOR_CYAN}⚪️ Fuseki server stopped${COLOR_RESET}"
 
+.PHONY: fuseki-log
+fuseki-log: ## Show Fuseki server logs
+	@docker logs ${DEPLOYMENT_FUSEKI_CONTAINER}
+
 ## Documentation:
 .PHONY: doc
 doc: build-ontology ## Generate documentation site

--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,12 @@ fuseki-start: build ## Start Fuseki server with the ontology and examples loaded
 	@curl -X POST -H "Content-Type: text/turtle" --data-binary "@${BIN_EXAMPLE_TTL}" http://localhost:${DEPLOYMENT_FUSEKI_PORT}/${DEPLOYMENT_FUSEKI_DATASET}/data
 	@echo "${COLOR_CYAN}🟢 running on: ${COLOR_GREEN}http://localhost:${DEPLOYMENT_FUSEKI_PORT}/${COLOR_RESET} - have fun 🎉"
 
+.PHONY: fuseki-stop
+fuseki-stop: ## Stop Fuseki server
+	@echo "${COLOR_CYAN}✋ stopping ${COLOR_GREEN}Fuseki${COLOR_RESET} server"
+	@docker stop ${DEPLOYMENT_FUSEKI_CONTAINER}
+	@echo "${COLOR_CYAN}⚪️ Fuseki server stopped${COLOR_RESET}"
+
 ## Documentation:
 .PHONY: doc
 doc: build-ontology ## Generate documentation site

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ OBJ_ONTS           := $(patsubst $(SRC_ONT)/%.ttl,$(DST_ONT)/%.nt,$(SRC_ONTS))
 FLG_TSTS           := $(patsubst $(SRC_TST)/%.ttl,$(DST_TEST)/%.tested.flag,$(SRC_TSTS))
 FLG_TTLS_FMT       := $(patsubst $(ROOT)/%.ttl,$(DST_LINT)/%.formatted.flag,$(SRC_TTLS))
 FLG_TTLS_LNT       := $(patsubst $(ROOT)/%.ttl,$(DST_LINT)/%.linted.flag,$(SRC_TTLS))
+FLG_CHECK_OK       := $(DST)/check.ok.flag
 
 BIN_OKP4_TTL       := $(DST)/okp4.ttl
 BIN_OKP4_NT        := $(DST)/okp4.nt
@@ -110,10 +111,10 @@ clean: ## Clean all generated files
 build: build-ontology build-examples ## Build all the files (ontology and examples)
 
 .PHONY: cache build-ontology
-build-ontology: $(BIN_OKP4_TTL) $(BIN_OKP4_RDFXML) ## Build the ontology
+build-ontology: check $(BIN_OKP4_TTL) $(BIN_OKP4_RDFXML) ## Build the ontology
 
 .PHONY: cache build-examples
-build-examples: $(BIN_EXAMPLE_TTL) $(BIN_EXAMPLE_JSONLD) ## Build the examples
+build-examples: check $(BIN_EXAMPLE_TTL) $(BIN_EXAMPLE_JSONLD) ## Build the examples
 
 $(OBJ_ONTS): $(DST_ONT)/%.nt: $(SRC_ONT)/%.ttl
 	@echo "${COLOR_CYAN}🔄 converting${COLOR_RESET} to ${COLOR_GREEN}$@${COLOR_RESET}"
@@ -155,10 +156,10 @@ $(BIN_EXAMPLE_JSONLD): $(BIN_EXAMPLE_NT)
 
 ## Format:
 .PHONY: format
-format: format-ttl ## Format with all available formatters
+format: check format-ttl ## Format with all available formatters
 
 .PHONY: format-ttl
-format-ttl: cache $(FLG_TTLS_FMT) ## Format all Turtle files
+format-ttl: check cache $(FLG_TTLS_FMT) ## Format all Turtle files
 
 $(FLG_TTLS_FMT): $(DST_LINT)/%.formatted.flag: $(ROOT)/%.ttl
 	@echo "${COLOR_CYAN}📐 formating: ${COLOR_GREEN}$<${COLOR_RESET}"
@@ -172,7 +173,7 @@ $(FLG_TTLS_FMT): $(DST_LINT)/%.formatted.flag: $(ROOT)/%.ttl
 lint: lint-ttl ## Lint with all available linters
 
 .PHONY: lint-ttl
-lint-ttl: cache $(FLG_TTLS_LNT) ## Lint all Turtle files
+lint-ttl: check cache $(FLG_TTLS_LNT) ## Lint all Turtle files
 
 $(FLG_TTLS_LNT): $(DST_LINT)/%.linted.flag: $(ROOT)/%.ttl
 	@echo "${COLOR_CYAN}🔬 linting: ${COLOR_GREEN}$<${COLOR_RESET}"
@@ -188,7 +189,7 @@ $(FLG_TTLS_LNT): $(DST_LINT)/%.linted.flag: $(ROOT)/%.ttl
 test: test-ontology ## Run all available tests
 
 .PHONY: test-ontology
-test-ontology: build $(FLG_TSTS) ## Test final (generated) ontology
+test-ontology: check build $(FLG_TSTS) ## Test final (generated) ontology
 
 $(FLG_TSTS): $(DST_TEST)/%.tested.flag: $(SRC_TST)/%.ttl $(wildcard $(SRC_ONT)/*.ttl)
 	@echo "${COLOR_CYAN}🧪 testing: ${COLOR_GREEN}$<${COLOR_RESET}"
@@ -202,7 +203,7 @@ $(FLG_TSTS): $(DST_TEST)/%.tested.flag: $(SRC_TST)/%.ttl $(wildcard $(SRC_ONT)/*
 
 ## Fuseki:
 .PHONY: fuseki-start
-fuseki-start: build ## Start Fuseki server with the ontology and examples loaded in it
+fuseki-start: check build ## Start Fuseki server with the ontology and examples loaded in it
 	@echo "${COLOR_CYAN}🚀 starting ${COLOR_GREEN}Fuseki${COLOR_RESET} server"
 	@if [ "$$(docker ps -q -f name=${DEPLOYMENT_FUSEKI_CONTAINER})" ]; then \
       echo "${COLOR_CYAN}❌ container ${COLOR_GREEN}${DEPLOYMENT_FUSEKI_CONTAINER}${COLOR_RESET} already running"; \
@@ -231,19 +232,19 @@ fuseki-start: build ## Start Fuseki server with the ontology and examples loaded
 	@curl -X POST -H "Content-Type: text/turtle" --data-binary "@${BIN_EXAMPLE_TTL}" http://localhost:${DEPLOYMENT_FUSEKI_PORT}/${DEPLOYMENT_FUSEKI_DATASET}/data
 	@echo "${COLOR_CYAN}🟢 running on: ${COLOR_GREEN}http://localhost:${DEPLOYMENT_FUSEKI_PORT}/${COLOR_RESET} - have fun 🎉"
 
-.PHONY: fuseki-stop
+.PHONY: check fuseki-stop
 fuseki-stop: ## Stop Fuseki server
 	@echo "${COLOR_CYAN}✋ stopping ${COLOR_GREEN}Fuseki${COLOR_RESET} server"
 	@docker stop ${DEPLOYMENT_FUSEKI_CONTAINER}
 	@echo "${COLOR_CYAN}⚪️ Fuseki server stopped${COLOR_RESET}"
 
 .PHONY: fuseki-log
-fuseki-log: ## Show Fuseki server logs
+fuseki-log: check ## Show Fuseki server logs
 	@docker logs ${DEPLOYMENT_FUSEKI_CONTAINER}
 
 ## Documentation:
 .PHONY: doc
-doc: build-ontology ## Generate documentation site
+doc: check build-ontology ## Generate documentation site
 	@echo "${COLOR_CYAN}📖 generating documentation for ${COLOR_GREEN}${BIN_OKP4_TTL}${COLOR_RESET}"
 	@docker run \
         --rm \
@@ -262,13 +263,14 @@ doc: build-ontology ## Generate documentation site
 	@cp -R public/* ${DST_DOC}
 
 .PHONY: doc-serve
-doc-serve: doc ## Start a web server for serving generated documentation
+doc-serve: check doc ## Start a web server for serving generated documentation
 	@echo "${COLOR_CYAN}🌐 serving documentation - available at ${COLOR_GREEN}http://localhost:8080/index-en.html${COLOR_RESET}"
 	@docker run --rm \
       -p 8080:80 \
       -v `pwd`/${DOC}/ontology/:/usr/local/apache2/htdocs/:ro \
       ${DOCKER_IMAGE_HTTPD}
 
+## Misc:
 .PHONY: cache
 cache: $(DST_CACHE)/owl-cli-1.2.2.jar ## Download all required files to cache
 
@@ -278,6 +280,21 @@ $(DST_CACHE)/owl-cli-1.2.2.jar:
     cd $(DST_CACHE); \
     wget https://github.com/atextor/owl-cli/releases/download/v1.2.2/owl-cli-1.2.2.jar
 
+.PHONY: check
+check: $(FLG_CHECK_OK) ## Check if all required commands are available in the system
+
+$(FLG_CHECK_OK):
+	@echo "${COLOR_CYAN}☑️ checking ${COLOR_RESET} if required commands are available..."
+	@for cmd in awk curl docker md5sum timeout wget; do \
+		path=$$(which $$cmd); \
+		if [ -z "$$path" ]; then \
+			echo "${COLOR_CYAN}❌ ${COLOR_GREEN}$$cmd${COLOR_RESET} command is not available, please install it." && exit 1; \
+		else \
+			echo "${COLOR_CYAN}✅ ${COLOR_GREEN}$$cmd${COLOR_RESET} ($$path)"; \
+		fi \
+	done
+	@mkdir -p -m 777 $(@D)
+	@touch $(FLG_CHECK_OK)
 
 ## Help:
 .PHONY: vars

--- a/README.md
+++ b/README.md
@@ -74,6 +74,26 @@ This will build the ontology and the examples under the `target` directory. The 
    └── okp4.ttl
 ```
 
+## Deploying the ontology in local triple store
+
+The ontology can be deployed in a local triple store using [Docker](https://www.docker.com/). The triple store used is [Apache Jena Fuseki](https://jena.apache.org/documentation/fuseki2/).
+
+To start the triple store, run the following command. This will start the triple store and load the ontology and the examples in it.
+
+```bash
+make fuseki-start
+```
+
+You can now play with the ontology using the Fuseki UI - <http://localhost:3030/>.
+
+Conversaly, to stop the triple store, run the following command:
+
+```bash
+make fuseki-stop
+```
+
+Note that the triple store is not persistent, so all the data will be lost when the triple store is stopped.
+
 ## Contributing
 
 Contributions are welcome. Please check the following guidelines:

--- a/shiro.ini
+++ b/shiro.ini
@@ -1,0 +1,9 @@
+[main]
+ssl.enabled = false 
+
+[users]
+
+[roles]
+
+[urls]
+/**=anon


### PR DESCRIPTION
## Purpose

This PR adds three new goals to the `Makefile` for managing a ontology deployments in a local environment. The triple store used is [Apache Jena Fuseki](https://jena.apache.org/documentation/fuseki2/).

The goals added are quite clear:

- `fuseki-start`: starts the Fuseki server in a Docker container if not already running, and uploads the ontology and the examples in it.
- `fuseki-stop`: stops the running Fuseki container if it exists.
- `fuseki-log`: displays the logs of the running Fuseki container.

## Note

- [Fuseki](https://jena.apache.org/documentation/fuseki2/) server is configured with `anonymous` access to simplify administration, so all endpoints are available without needing to provide any credentials. This is very useful for testing and development purposes.
- [docker-compose](https://docs.docker.com/compose/) is not use but instead the `docker run` command directly. This approach allows for greater flexibility and customization, and is in line with what we are doing in other projects @okp4.
- Added the goal `check` which checks if all required commands are available in the system.