### PR TITLE
ci(workflow): outputs the details of failed tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,3 +23,12 @@ jobs:
       - name: Test ontology
         run: |
           make test-ontology
+
+      - name: Output test results
+        if: ${{ failure() }}
+        run: |
+          find target/test -name "*.tested.flag" -type f \
+            -exec grep -q "Conforms: False" {} \; \
+            -exec echo "❌ {}" \; \
+            -exec cat {} \; \
+            -exec echo "" \;


### PR DESCRIPTION
This PR enhances the `test` workflow by introducing a new step. In the event of test failures, this step prints out the contents of the test result files associated with the failed tests, thereby offering better comprehension of the reasons behind the failures from the CI (I hope).