### PR TITLE
Handle input format errors during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ RDF_SHACL = \
     --format human \
     /usr/src/ontology/$2
 NT_UNIQUIFY = \
-  @HASH=`md5sum $1 | awk '{print $$1}'`; \
+  HASH=`md5sum $1 | awk '{print $$1}'`; \
   sed -E -i ${SED_FLAG} "s/_:(g[0-9]+)/_:$${HASH}_\1/g" $1
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,7 @@ RDF_SERIALIZE = \
     -w /usr/src/ontology \
     ${DOCKER_IMAGE_RUBY_RDF} \
       serialize \
+	  --validate \
       -o $4 \
       --output-format $2 \
       --input-format $1 \

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ DOCKER_IMAGE_FUSEKI   := docuteam/fuseki:4.2.0
 DOCKER_IMAGE_HTTPD    := httpd:2.4.51
 DOCKER_IMAGE_JRE      := eclipse-temurin:19.0.2_7-jre-focal
 DOCKER_IMAGE_PYSHACL  := ashleysommer/pyshacl:0.20.0
-DOCKER_IMAGE_RUBY_RDF := ghcr.io/okp4/ruby-rdf:3.1.15
+DOCKER_IMAGE_RUBY_RDF := ghcr.io/okp4/ruby-rdf:3.2.9
 DOCKER_IMAGE_WIDOCO   := ghcr.io/okp4/widoco:1.4.15
 
 # Deployment


### PR DESCRIPTION
This PR resolves the problem of building the ontology in the event of an error when the input format is incorrect. The previous implementation resulted in the build not stopping and no errors being reported in the CI (which was bad).

PS: I took opportunity to update the version of the [rdf tool](https://github.com/ruby-rdf/rdf) used to serialize triples.