### PR TITLE
Correct property ranges & restrictions

### DIFF
--- a/src/core.ttl
+++ b/src/core.ttl
@@ -4,7 +4,6 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix okp4core: <https://ontology.okp4.space/core/> .
-@prefix okp4th: <https://ontology.okp4.space/thesaurus/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 okp4core:DIDURI a owl:Class ;
@@ -257,7 +256,7 @@ okp4core:hasInput a owl:ObjectProperty ;
 okp4core:hasLicense a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has license"@en ;
   rdfs:comment "A legal document giving official permission to do something with the resource."@en ;
-  rdfs:range okp4th:license .
+  rdfs:range skos:Concept .
 
 okp4core:hasParent a owl:ObjectProperty ;
   rdfs:label "has parent"@en ;
@@ -271,7 +270,7 @@ okp4core:hasRegistrar a owl:ObjectProperty, owl:FunctionalProperty ;
 okp4core:hasSpatialCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has spatial coverage"@en ;
   rdfs:comment "The spatial applicability of the resource."@en ;
-  rdfs:range okp4th:area .
+  rdfs:range skos:Concept .
 
 okp4core:hasTemporalCoverage a owl:ObjectProperty, owl:FunctionalProperty ;
   rdfs:label "has temporal coverage"@en ;

--- a/src/metadata-dataset-general.ttl
+++ b/src/metadata-dataset-general.ttl
@@ -42,7 +42,10 @@ meta:GeneralMetadata a owl:Class ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-    owl:onClass thesaurus:area ;
+    owl:allValuesFrom [ 
+      a owl:Class ;
+      skos:inScheme thesaurus:area ;
+    ] ;
     owl:onProperty core:hasSpatialCoverage ;
   ] ;
   rdfs:subClassOf [
@@ -56,18 +59,24 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:topic ;
+    owl:allValuesFrom [ 
+      a owl:Class ;
+      skos:inScheme thesaurus:topic ;
+    ] ;
     owl:onProperty core:hasTopic ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:media-type ;
+    owl:allValuesFrom [ 
+      a owl:Class ;
+      skos:inScheme thesaurus:media-type ;
+    ] ;
     owl:onProperty core:hasFormat ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
     owl:minQualifiedCardinality "0"^^xsd:nonNegativeInteger ;
-    owl:onClass core:Period ;
+    owl:allValuesFrom core:Period ;
     owl:onProperty core:hasTemporalCoverage ;
   ] ;
   rdfs:subClassOf [

--- a/src/metadata-service-general.ttl
+++ b/src/metadata-service-general.ttl
@@ -3,6 +3,7 @@
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix core: <https://ontology.okp4.space/core/> .
 @prefix meta: <https://ontology.okp4.space/metadata/service/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
 
 meta:GeneralMetadata a owl:Class ;
@@ -35,7 +36,10 @@ meta:GeneralMetadata a owl:Class ;
   ] ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:service-category ;
+    owl:allValuesFrom [ 
+      a owl:Class ;
+      skos:inScheme thesaurus:service-category ;
+    ] ;
     owl:onProperty core:hasCategory ;
   ] ;
   rdfs:subClassOf [

--- a/src/metadata-zone-general.ttl
+++ b/src/metadata-zone-general.ttl
@@ -18,7 +18,10 @@ meta:GeneralMetadata a owl:Class ;
    """@en ;
   rdfs:subClassOf [
     a owl:Restriction ;
-    owl:allValuesFrom thesaurus:topic ;
+    owl:allValuesFrom [ 
+      a owl:Class ;
+      skos:inScheme thesaurus:topic ;
+    ] ;
     owl:onProperty core:hasTopic ;
   ] ;
   rdfs:subClassOf [


### PR DESCRIPTION
This PR corrects the range specifications of certain properties in the ontology that points to terms in SKOS vocabularies, as pointed out by @fredericvilcot. The changes ensure that the ranges and restrictions on these properties are accurately specified in the OWL language.