### PR TITLE
fix(vocab-mediatype): fix wrong license prefix

### DIFF
--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -1,10 +1,10 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dct: <http://purl.org/dc/terms/> .
-@prefix media-type: <https://ontology.okp4.space/thesaurus/license/> .
+@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-media-type:hasMediaType a owl:DatatypeProperty, owl:FunctionalProperty ;
+mediatype:hasMediaType a owl:DatatypeProperty, owl:FunctionalProperty ;
   rdfs:label "has media type"@en ;
   rdfs:comment "Specifies the Media Type for the term of this vocabulary."@en ;
   rdfs:domain skos:Concept ;
@@ -27,211 +27,211 @@ media-type:hasMediaType a owl:DatatypeProperty, owl:FunctionalProperty ;
     Note that this thesaurus may not be complete and all the media-type terms may not have all translations.
   """@en .
 
-media-type:application a skos:Collection ;
+mediatype:application a skos:Collection ;
   rdfs:label "Application types"@en ;
   dct:description "The collection of application types"@en ;
   dct:title "Application types"@en ;
-  skos:member media-type:application_andrew-inset ;
-  skos:member media-type:application_illustrator ;
-  skos:member media-type:application_mac-binhex40 ;
-  skos:member media-type:application_octet-stream ;
-  skos:member media-type:application_oda ;
-  skos:member media-type:application_ogg ;
-  skos:member media-type:application_pdf ;
-  skos:member media-type:application_pgp ;
-  skos:member media-type:application_pgp-encrypted ;
-  skos:member media-type:application_pgp-keys ;
-  skos:member media-type:application_pgp-signature ;
-  skos:member media-type:application_pkcs7-mime ;
-  skos:member media-type:application_pkcs7-signature ;
-  skos:member media-type:application_postscript ;
-  skos:member media-type:application_rtf ;
-  skos:member media-type:application_smil ;
-  skos:member media-type:application_vndcorel-draw ;
-  skos:member media-type:application_vndhp-hpgl ;
-  skos:member media-type:application_vndhp-pcl ;
-  skos:member media-type:application_vndlotus-1-2-3 ;
-  skos:member media-type:application_vndms-excel ;
-  skos:member media-type:application_vndms-powerpoint ;
-  skos:member media-type:application_vndms-word ;
-  skos:member media-type:application_vndpalm ;
-  skos:member media-type:application_vndrn-realmedia ;
-  skos:member media-type:application_vndstardivisioncalc ;
-  skos:member media-type:application_vndstardivisionchart ;
-  skos:member media-type:application_vndstardivisiondraw ;
-  skos:member media-type:application_vndstardivisionimpress ;
-  skos:member media-type:application_vndstardivisionmail ;
-  skos:member media-type:application_vndstardivisionmath ;
-  skos:member media-type:application_vndstardivisionwriter ;
-  skos:member media-type:application_vndsunxmlcalc ;
-  skos:member media-type:application_vndsunxmlcalctemplate ;
-  skos:member media-type:application_vndsunxmldraw ;
-  skos:member media-type:application_vndsunxmldrawtemplate ;
-  skos:member media-type:application_vndsunxmlimpress ;
-  skos:member media-type:application_vndsunxmlimpresstemplate ;
-  skos:member media-type:application_vndsunxmlmath ;
-  skos:member media-type:application_vndsunxmlwriter ;
-  skos:member media-type:application_vndsunxmlwriterglobal ;
-  skos:member media-type:application_vndsunxmlwritertemplate ;
-  skos:member media-type:application_vndwordperfect ;
-  skos:member media-type:application_x-abiword ;
-  skos:member media-type:application_x-amipro ;
-  skos:member media-type:application_x-applix-spreadsheet ;
-  skos:member media-type:application_x-applix-word ;
-  skos:member media-type:application_x-arc ;
-  skos:member media-type:application_x-archive ;
-  skos:member media-type:application_x-arj ;
-  skos:member media-type:application_x-asp ;
-  skos:member media-type:application_x-awk ;
-  skos:member media-type:application_x-bcpio ;
-  skos:member media-type:application_x-bittorrent ;
-  skos:member media-type:application_x-blender ;
-  skos:member media-type:application_x-bzip ;
-  skos:member media-type:application_x-bzip-compressed-tar ;
-  skos:member media-type:application_x-cd-image ;
-  skos:member media-type:application_x-cgi ;
-  skos:member media-type:application_x-chess-pgn ;
-  skos:member media-type:application_x-class-file ;
-  skos:member media-type:application_x-compress ;
-  skos:member media-type:application_x-compressed-tar ;
-  skos:member media-type:application_x-core ;
-  skos:member media-type:application_x-cpio ;
-  skos:member media-type:application_x-cpio-compressed ;
-  skos:member media-type:application_x-csh ;
-  skos:member media-type:application_x-dbase ;
-  skos:member media-type:application_x-dbm ;
-  skos:member media-type:application_x-dc-rom ;
-  skos:member media-type:application_x-deb ;
-  skos:member media-type:application_x-designer ;
-  skos:member media-type:application_x-desktop ;
-  skos:member media-type:application_x-dia-diagram ;
-  skos:member media-type:application_x-dvi ;
-  skos:member media-type:application_x-e-theme ;
-  skos:member media-type:application_x-egon ;
-  skos:member media-type:application_x-executable ;
-  skos:member media-type:application_x-font-afm ;
-  skos:member media-type:application_x-font-bdf ;
-  skos:member media-type:application_x-font-dos ;
-  skos:member media-type:application_x-font-framemaker ;
-  skos:member media-type:application_x-font-libgrx ;
-  skos:member media-type:application_x-font-linux-psf ;
-  skos:member media-type:application_x-font-otf ;
-  skos:member media-type:application_x-font-pcf ;
-  skos:member media-type:application_x-font-speedo ;
-  skos:member media-type:application_x-font-sunos-news ;
-  skos:member media-type:application_x-font-tex ;
-  skos:member media-type:application_x-font-tex-tfm ;
-  skos:member media-type:application_x-font-ttf ;
-  skos:member media-type:application_x-font-type1 ;
-  skos:member media-type:application_x-font-vfont ;
-  skos:member media-type:application_x-frame ;
-  skos:member media-type:application_x-gameboy-rom ;
-  skos:member media-type:application_x-gdbm ;
-  skos:member media-type:application_x-genesis-rom ;
-  skos:member media-type:application_x-gettext-translation ;
-  skos:member media-type:application_x-glade ;
-  skos:member media-type:application_x-gmc-link ;
-  skos:member media-type:application_x-gnucash ;
-  skos:member media-type:application_x-gnumeric ;
-  skos:member media-type:application_x-graphite ;
-  skos:member media-type:application_x-gtar ;
-  skos:member media-type:application_x-gtktalog ;
-  skos:member media-type:application_x-gzip ;
-  skos:member media-type:application_x-gzpostscript ;
-  skos:member media-type:application_x-hdf ;
-  skos:member media-type:application_x-ipod-firmware ;
-  skos:member media-type:application_x-jar ;
-  skos:member media-type:application_x-java ;
-  skos:member media-type:application_x-javascript ;
-  skos:member media-type:application_x-jbuilder-project ;
-  skos:member media-type:application_x-karbon ;
-  skos:member media-type:application_x-kchart ;
-  skos:member media-type:application_x-kformula ;
-  skos:member media-type:application_x-killustrator ;
-  skos:member media-type:application_x-kivio ;
-  skos:member media-type:application_x-kontour ;
-  skos:member media-type:application_x-kpovmodeler ;
-  skos:member media-type:application_x-kpresenter ;
-  skos:member media-type:application_x-krita ;
-  skos:member media-type:application_x-kspread ;
-  skos:member media-type:application_x-kspread-crypt ;
-  skos:member media-type:application_x-ksysv-package ;
-  skos:member media-type:application_x-kugar ;
-  skos:member media-type:application_x-kword ;
-  skos:member media-type:application_x-kword-crypt ;
-  skos:member media-type:application_x-lha ;
-  skos:member media-type:application_x-lhz ;
-  skos:member media-type:application_x-linguist ;
-  skos:member media-type:application_x-lyx ;
-  skos:member media-type:application_x-lzop ;
-  skos:member media-type:application_x-macbinary ;
-  skos:member media-type:application_x-magicpoint ;
-  skos:member media-type:application_x-matroska ;
-  skos:member media-type:application_x-mif ;
-  skos:member media-type:application_x-mozilla-bookmarks ;
-  skos:member media-type:application_x-ms-dos-executable ;
-  skos:member media-type:application_x-mswinurl ;
-  skos:member media-type:application_x-mswrite ;
-  skos:member media-type:application_x-msx-rom ;
-  skos:member media-type:application_x-n64-rom ;
-  skos:member media-type:application_x-nautilus-link ;
-  skos:member media-type:application_x-nes-rom ;
-  skos:member media-type:application_x-netcdf ;
-  skos:member media-type:application_x-netscape-bookmarks ;
-  skos:member media-type:application_x-object ;
-  skos:member media-type:application_x-ole-storage ;
-  skos:member media-type:application_x-oleo ;
-  skos:member media-type:application_x-palm-database ;
-  skos:member media-type:application_x-pef-executable ;
-  skos:member media-type:application_x-perl ;
-  skos:member media-type:application_x-php ;
-  skos:member media-type:application_x-pkcs12 ;
-  skos:member media-type:application_x-profile ;
-  skos:member media-type:application_x-pw ;
-  skos:member media-type:application_x-python ;
-  skos:member media-type:application_x-python-bytecode ;
-  skos:member media-type:application_x-quattropro ;
-  skos:member media-type:application_x-qw ;
-  skos:member media-type:application_x-rar ;
-  skos:member media-type:application_x-reject ;
-  skos:member media-type:application_x-rpm ;
-  skos:member media-type:application_x-ruby ;
-  skos:member media-type:application_x-sc ;
-  skos:member media-type:application_x-shar ;
-  skos:member media-type:application_x-shared-library-la ;
-  skos:member media-type:application_x-sharedlib ;
-  skos:member media-type:application_x-shellscript ;
-  skos:member media-type:application_x-shockwave-flash ;
-  skos:member media-type:application_x-siag ;
-  skos:member media-type:application_x-slp ;
-  skos:member media-type:application_x-sms-rom ;
-  skos:member media-type:application_x-stuffit ;
-  skos:member media-type:application_x-sv4cpio ;
-  skos:member media-type:application_x-sv4crc ;
-  skos:member media-type:application_x-tar ;
-  skos:member media-type:application_x-tarz ;
-  skos:member media-type:application_x-tex-gf ;
-  skos:member media-type:application_x-tex-pk ;
-  skos:member media-type:application_x-tgif ;
-  skos:member media-type:application_x-theme ;
-  skos:member media-type:application_x-toutdoux ;
-  skos:member media-type:application_x-trash ;
-  skos:member media-type:application_x-troff ;
-  skos:member media-type:application_x-troff-man ;
-  skos:member media-type:application_x-troff-man-compressed ;
-  skos:member media-type:application_x-tzo ;
-  skos:member media-type:application_x-ustar ;
-  skos:member media-type:application_x-wais-source ;
-  skos:member media-type:application_x-wpg ;
-  skos:member media-type:application_x-x509-ca-cert ;
-  skos:member media-type:application_x-xbel ;
-  skos:member media-type:application_x-zerosize ;
-  skos:member media-type:application_x-zoo ;
-  skos:member media-type:application_xhtmlxml ;
-  skos:member media-type:application_zip .
+  skos:member mediatype:application_andrew-inset ;
+  skos:member mediatype:application_illustrator ;
+  skos:member mediatype:application_mac-binhex40 ;
+  skos:member mediatype:application_octet-stream ;
+  skos:member mediatype:application_oda ;
+  skos:member mediatype:application_ogg ;
+  skos:member mediatype:application_pdf ;
+  skos:member mediatype:application_pgp ;
+  skos:member mediatype:application_pgp-encrypted ;
+  skos:member mediatype:application_pgp-keys ;
+  skos:member mediatype:application_pgp-signature ;
+  skos:member mediatype:application_pkcs7-mime ;
+  skos:member mediatype:application_pkcs7-signature ;
+  skos:member mediatype:application_postscript ;
+  skos:member mediatype:application_rtf ;
+  skos:member mediatype:application_smil ;
+  skos:member mediatype:application_vndcorel-draw ;
+  skos:member mediatype:application_vndhp-hpgl ;
+  skos:member mediatype:application_vndhp-pcl ;
+  skos:member mediatype:application_vndlotus-1-2-3 ;
+  skos:member mediatype:application_vndms-excel ;
+  skos:member mediatype:application_vndms-powerpoint ;
+  skos:member mediatype:application_vndms-word ;
+  skos:member mediatype:application_vndpalm ;
+  skos:member mediatype:application_vndrn-realmedia ;
+  skos:member mediatype:application_vndstardivisioncalc ;
+  skos:member mediatype:application_vndstardivisionchart ;
+  skos:member mediatype:application_vndstardivisiondraw ;
+  skos:member mediatype:application_vndstardivisionimpress ;
+  skos:member mediatype:application_vndstardivisionmail ;
+  skos:member mediatype:application_vndstardivisionmath ;
+  skos:member mediatype:application_vndstardivisionwriter ;
+  skos:member mediatype:application_vndsunxmlcalc ;
+  skos:member mediatype:application_vndsunxmlcalctemplate ;
+  skos:member mediatype:application_vndsunxmldraw ;
+  skos:member mediatype:application_vndsunxmldrawtemplate ;
+  skos:member mediatype:application_vndsunxmlimpress ;
+  skos:member mediatype:application_vndsunxmlimpresstemplate ;
+  skos:member mediatype:application_vndsunxmlmath ;
+  skos:member mediatype:application_vndsunxmlwriter ;
+  skos:member mediatype:application_vndsunxmlwriterglobal ;
+  skos:member mediatype:application_vndsunxmlwritertemplate ;
+  skos:member mediatype:application_vndwordperfect ;
+  skos:member mediatype:application_x-abiword ;
+  skos:member mediatype:application_x-amipro ;
+  skos:member mediatype:application_x-applix-spreadsheet ;
+  skos:member mediatype:application_x-applix-word ;
+  skos:member mediatype:application_x-arc ;
+  skos:member mediatype:application_x-archive ;
+  skos:member mediatype:application_x-arj ;
+  skos:member mediatype:application_x-asp ;
+  skos:member mediatype:application_x-awk ;
+  skos:member mediatype:application_x-bcpio ;
+  skos:member mediatype:application_x-bittorrent ;
+  skos:member mediatype:application_x-blender ;
+  skos:member mediatype:application_x-bzip ;
+  skos:member mediatype:application_x-bzip-compressed-tar ;
+  skos:member mediatype:application_x-cd-image ;
+  skos:member mediatype:application_x-cgi ;
+  skos:member mediatype:application_x-chess-pgn ;
+  skos:member mediatype:application_x-class-file ;
+  skos:member mediatype:application_x-compress ;
+  skos:member mediatype:application_x-compressed-tar ;
+  skos:member mediatype:application_x-core ;
+  skos:member mediatype:application_x-cpio ;
+  skos:member mediatype:application_x-cpio-compressed ;
+  skos:member mediatype:application_x-csh ;
+  skos:member mediatype:application_x-dbase ;
+  skos:member mediatype:application_x-dbm ;
+  skos:member mediatype:application_x-dc-rom ;
+  skos:member mediatype:application_x-deb ;
+  skos:member mediatype:application_x-designer ;
+  skos:member mediatype:application_x-desktop ;
+  skos:member mediatype:application_x-dia-diagram ;
+  skos:member mediatype:application_x-dvi ;
+  skos:member mediatype:application_x-e-theme ;
+  skos:member mediatype:application_x-egon ;
+  skos:member mediatype:application_x-executable ;
+  skos:member mediatype:application_x-font-afm ;
+  skos:member mediatype:application_x-font-bdf ;
+  skos:member mediatype:application_x-font-dos ;
+  skos:member mediatype:application_x-font-framemaker ;
+  skos:member mediatype:application_x-font-libgrx ;
+  skos:member mediatype:application_x-font-linux-psf ;
+  skos:member mediatype:application_x-font-otf ;
+  skos:member mediatype:application_x-font-pcf ;
+  skos:member mediatype:application_x-font-speedo ;
+  skos:member mediatype:application_x-font-sunos-news ;
+  skos:member mediatype:application_x-font-tex ;
+  skos:member mediatype:application_x-font-tex-tfm ;
+  skos:member mediatype:application_x-font-ttf ;
+  skos:member mediatype:application_x-font-type1 ;
+  skos:member mediatype:application_x-font-vfont ;
+  skos:member mediatype:application_x-frame ;
+  skos:member mediatype:application_x-gameboy-rom ;
+  skos:member mediatype:application_x-gdbm ;
+  skos:member mediatype:application_x-genesis-rom ;
+  skos:member mediatype:application_x-gettext-translation ;
+  skos:member mediatype:application_x-glade ;
+  skos:member mediatype:application_x-gmc-link ;
+  skos:member mediatype:application_x-gnucash ;
+  skos:member mediatype:application_x-gnumeric ;
+  skos:member mediatype:application_x-graphite ;
+  skos:member mediatype:application_x-gtar ;
+  skos:member mediatype:application_x-gtktalog ;
+  skos:member mediatype:application_x-gzip ;
+  skos:member mediatype:application_x-gzpostscript ;
+  skos:member mediatype:application_x-hdf ;
+  skos:member mediatype:application_x-ipod-firmware ;
+  skos:member mediatype:application_x-jar ;
+  skos:member mediatype:application_x-java ;
+  skos:member mediatype:application_x-javascript ;
+  skos:member mediatype:application_x-jbuilder-project ;
+  skos:member mediatype:application_x-karbon ;
+  skos:member mediatype:application_x-kchart ;
+  skos:member mediatype:application_x-kformula ;
+  skos:member mediatype:application_x-killustrator ;
+  skos:member mediatype:application_x-kivio ;
+  skos:member mediatype:application_x-kontour ;
+  skos:member mediatype:application_x-kpovmodeler ;
+  skos:member mediatype:application_x-kpresenter ;
+  skos:member mediatype:application_x-krita ;
+  skos:member mediatype:application_x-kspread ;
+  skos:member mediatype:application_x-kspread-crypt ;
+  skos:member mediatype:application_x-ksysv-package ;
+  skos:member mediatype:application_x-kugar ;
+  skos:member mediatype:application_x-kword ;
+  skos:member mediatype:application_x-kword-crypt ;
+  skos:member mediatype:application_x-lha ;
+  skos:member mediatype:application_x-lhz ;
+  skos:member mediatype:application_x-linguist ;
+  skos:member mediatype:application_x-lyx ;
+  skos:member mediatype:application_x-lzop ;
+  skos:member mediatype:application_x-macbinary ;
+  skos:member mediatype:application_x-magicpoint ;
+  skos:member mediatype:application_x-matroska ;
+  skos:member mediatype:application_x-mif ;
+  skos:member mediatype:application_x-mozilla-bookmarks ;
+  skos:member mediatype:application_x-ms-dos-executable ;
+  skos:member mediatype:application_x-mswinurl ;
+  skos:member mediatype:application_x-mswrite ;
+  skos:member mediatype:application_x-msx-rom ;
+  skos:member mediatype:application_x-n64-rom ;
+  skos:member mediatype:application_x-nautilus-link ;
+  skos:member mediatype:application_x-nes-rom ;
+  skos:member mediatype:application_x-netcdf ;
+  skos:member mediatype:application_x-netscape-bookmarks ;
+  skos:member mediatype:application_x-object ;
+  skos:member mediatype:application_x-ole-storage ;
+  skos:member mediatype:application_x-oleo ;
+  skos:member mediatype:application_x-palm-database ;
+  skos:member mediatype:application_x-pef-executable ;
+  skos:member mediatype:application_x-perl ;
+  skos:member mediatype:application_x-php ;
+  skos:member mediatype:application_x-pkcs12 ;
+  skos:member mediatype:application_x-profile ;
+  skos:member mediatype:application_x-pw ;
+  skos:member mediatype:application_x-python ;
+  skos:member mediatype:application_x-python-bytecode ;
+  skos:member mediatype:application_x-quattropro ;
+  skos:member mediatype:application_x-qw ;
+  skos:member mediatype:application_x-rar ;
+  skos:member mediatype:application_x-reject ;
+  skos:member mediatype:application_x-rpm ;
+  skos:member mediatype:application_x-ruby ;
+  skos:member mediatype:application_x-sc ;
+  skos:member mediatype:application_x-shar ;
+  skos:member mediatype:application_x-shared-library-la ;
+  skos:member mediatype:application_x-sharedlib ;
+  skos:member mediatype:application_x-shellscript ;
+  skos:member mediatype:application_x-shockwave-flash ;
+  skos:member mediatype:application_x-siag ;
+  skos:member mediatype:application_x-slp ;
+  skos:member mediatype:application_x-sms-rom ;
+  skos:member mediatype:application_x-stuffit ;
+  skos:member mediatype:application_x-sv4cpio ;
+  skos:member mediatype:application_x-sv4crc ;
+  skos:member mediatype:application_x-tar ;
+  skos:member mediatype:application_x-tarz ;
+  skos:member mediatype:application_x-tex-gf ;
+  skos:member mediatype:application_x-tex-pk ;
+  skos:member mediatype:application_x-tgif ;
+  skos:member mediatype:application_x-theme ;
+  skos:member mediatype:application_x-toutdoux ;
+  skos:member mediatype:application_x-trash ;
+  skos:member mediatype:application_x-troff ;
+  skos:member mediatype:application_x-troff-man ;
+  skos:member mediatype:application_x-troff-man-compressed ;
+  skos:member mediatype:application_x-tzo ;
+  skos:member mediatype:application_x-ustar ;
+  skos:member mediatype:application_x-wais-source ;
+  skos:member mediatype:application_x-wpg ;
+  skos:member mediatype:application_x-x509-ca-cert ;
+  skos:member mediatype:application_x-xbel ;
+  skos:member mediatype:application_x-zerosize ;
+  skos:member mediatype:application_x-zoo ;
+  skos:member mediatype:application_xhtmlxml ;
+  skos:member mediatype:application_zip .
 
-media-type:application_andrew-inset a skos:Concept ;
-  media-type:hasMediaType "application/andrew-inset" ;
+mediatype:application_andrew-inset a skos:Concept ;
+  mediatype:hasMediaType "application/andrew-inset" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Andrew Toolkit -osio"@fi ;
   skos:prefLabel "Andrew Toolkit innsats"@nn ;
@@ -247,8 +247,8 @@ media-type:application_andrew-inset a skos:Concept ;
   skos:prefLabel "Mewnosodiad Andrew Toolkit"@cy ;
   skos:prefLabel "ajout Andrew Toolkit"@fr .
 
-media-type:application_illustrator a skos:Concept ;
-  media-type:hasMediaType "application/illustrator" ;
+mediatype:application_illustrator a skos:Concept ;
+  mediatype:hasMediaType "application/illustrator" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Adobe Illustrator -asiakirja"@fi ;
   skos:prefLabel "Adobe Illustrator document"@en ;
@@ -258,8 +258,8 @@ media-type:application_illustrator a skos:Concept ;
   skos:prefLabel "Adobe Illustrator-dokument"@sv ;
   skos:prefLabel "Έγγραφο Adobe Illustrator"@el .
 
-media-type:application_mac-binhex40 a skos:Concept ;
-  media-type:hasMediaType "application/mac-binhex40" ;
+mediatype:application_mac-binhex40 a skos:Concept ;
+  mediatype:hasMediaType "application/mac-binhex40" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil BinHex-amgodwyd Macintosh"@cy ;
   skos:prefLabel "Macintosh BinHe-kodet arkiv"@no ;
@@ -277,8 +277,8 @@ media-type:application_mac-binhex40 a skos:Concept ;
   skos:prefLabel "Мекинтош BinHex-encoded датотека"@sr ;
   skos:prefLabel "맥킨토시 BinHex-encoded 압축파일"@ko .
 
-media-type:application_octet-stream a skos:Concept ;
-  media-type:hasMediaType "application/octet-stream" ;
+mediatype:application_octet-stream a skos:Concept ;
+  mediatype:hasMediaType "application/octet-stream" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tuntematon"@fi ;
   skos:prefLabel "ukjent"@no ;
@@ -287,8 +287,8 @@ media-type:application_octet-stream a skos:Concept ;
   skos:prefLabel "inconnu"@fr ;
   skos:prefLabel "άγνωστο"@el .
 
-media-type:application_oda a skos:Concept ;
-  media-type:hasMediaType "application/oda" ;
+mediatype:application_oda a skos:Concept ;
+  mediatype:hasMediaType "application/oda" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen ODA"@cy ;
   skos:prefLabel "Dokument ODA"@cs ;
@@ -306,8 +306,8 @@ media-type:application_oda a skos:Concept ;
   skos:prefLabel "document ODA"@fr ;
   skos:prefLabel "Έγγραφο ODA"@el .
 
-media-type:application_ogg a skos:Concept ;
-  media-type:hasMediaType "application/ogg" ;
+mediatype:application_ogg a skos:Concept ;
+  mediatype:hasMediaType "application/ogg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ogg Vorbis -ääni"@fi ;
   skos:prefLabel "Ogg Vorbis audio faylı"@az ;
@@ -325,8 +325,8 @@ media-type:application_ogg a skos:Concept ;
   skos:prefLabel "Ήχος Ogg Vobris"@el ;
   skos:prefLabel "Ог-ворбис звучни запис"@sr .
 
-media-type:application_pdf a skos:Concept ;
-  media-type:hasMediaType "application/pdf" ;
+mediatype:application_pdf a skos:Concept ;
+  mediatype:hasMediaType "application/pdf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen PDF"@cy ;
   skos:prefLabel "PDF document"@en ;
@@ -339,8 +339,8 @@ media-type:application_pdf a skos:Concept ;
   skos:prefLabel "PDF-dokument"@sv ;
   skos:prefLabel "Έγγραφο PDF"@el .
 
-media-type:application_pgp a skos:Concept ;
-  media-type:hasMediaType "application/pgp" ;
+mediatype:application_pgp a skos:Concept ;
+  mediatype:hasMediaType "application/pgp" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Neges PGP"@cy ;
   skos:prefLabel "PGP bericht"@nl ;
@@ -358,8 +358,8 @@ media-type:application_pgp a skos:Concept ;
   skos:prefLabel "message PGP"@fr ;
   skos:prefLabel "Μήνυμα PGP"@el .
 
-media-type:application_pgp-encrypted a skos:Concept ;
-  media-type:hasMediaType "application/pgp-encrypted" ;
+mediatype:application_pgp-encrypted a skos:Concept ;
+  mediatype:hasMediaType "application/pgp-encrypted" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PGP/MIME-encrypted message header"@en ;
   skos:prefLabel "En-tête de message chiffré PGP/MIME"@fr ;
@@ -367,8 +367,8 @@ media-type:application_pgp-encrypted a skos:Concept ;
   skos:prefLabel "PGP/MIME-salattu viestiotsikko"@fi ;
   skos:prefLabel "PGP/MIME-verschlüsselter Nachrichtenkopf"@de .
 
-media-type:application_pgp-keys a skos:Concept ;
-  media-type:hasMediaType "application/pgp-keys" ;
+mediatype:application_pgp-keys a skos:Concept ;
+  mediatype:hasMediaType "application/pgp-keys" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Allweddi PGP"@cy ;
   skos:prefLabel "Klíče PGP"@cs ;
@@ -386,8 +386,8 @@ media-type:application_pgp-keys a skos:Concept ;
   skos:prefLabel "clés PGP"@fr ;
   skos:prefLabel "Κλειδιά PGP"@el .
 
-media-type:application_pgp-signature a skos:Concept ;
-  media-type:hasMediaType "application/pgp-signature" ;
+mediatype:application_pgp-signature a skos:Concept ;
+  mediatype:hasMediaType "application/pgp-signature" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "detached OpenPGP signature"@en ;
   skos:prefLabel "signature OpenPGP détachée"@fr ;
@@ -395,8 +395,8 @@ media-type:application_pgp-signature a skos:Concept ;
   skos:prefLabel "frakoblet OpenPGP-signatur"@no ;
   skos:prefLabel "isolierte OpenPGP-Signatur"@de .
 
-media-type:application_pkcs7-mime a skos:Concept ;
-  media-type:hasMediaType "application/pkcs7-mime" ;
+mediatype:application_pkcs7-mime a skos:Concept ;
+  mediatype:hasMediaType "application/pkcs7-mime" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil S/MIME"@cy ;
   skos:prefLabel "S/MIME bestand"@nl ;
@@ -414,8 +414,8 @@ media-type:application_pkcs7-mime a skos:Concept ;
   skos:prefLabel "fichier S/MIME"@fr ;
   skos:prefLabel "Αρχείο S/MIME"@el .
 
-media-type:application_pkcs7-signature a skos:Concept ;
-  media-type:hasMediaType "application/pkcs7-signature" ;
+mediatype:application_pkcs7-signature a skos:Concept ;
+  mediatype:hasMediaType "application/pkcs7-signature" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "detached S/MIME signature"@en ;
   skos:prefLabel "signature S/MIME détachée"@fr ;
@@ -423,8 +423,8 @@ media-type:application_pkcs7-signature a skos:Concept ;
   skos:prefLabel "frakoblet S/MIME-signatur"@no ;
   skos:prefLabel "isolierte S/MIME-Signatur"@de .
 
-media-type:application_postscript a skos:Concept ;
-  media-type:hasMediaType "application/postscript" ;
+mediatype:application_postscript a skos:Concept ;
+  mediatype:hasMediaType "application/postscript" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PostScript document"@en ;
   skos:prefLabel "Document PostScript"@fr ;
@@ -434,9 +434,9 @@ media-type:application_postscript a skos:Concept ;
   skos:prefLabel "PostScript-dokument"@sv ;
   skos:prefLabel "Έγγραφο PostScript"@el .
 
-media-type:application_rtf a skos:Concept ;
-  media-type:hasMediaType "application/rtf" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_rtf a skos:Concept ;
+  mediatype:hasMediaType "application/rtf" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Testun Gyfoethog"@cy ;
   skos:prefLabel "RTF-asiakirja"@fi ;
@@ -453,9 +453,9 @@ media-type:application_rtf a skos:Concept ;
   skos:prefLabel "Zəngin Mətn Formatı"@az ;
   skos:prefLabel "Обогаћени текстуални запис (RTF)"@sr .
 
-media-type:application_smil a skos:Concept ;
-  media-type:hasMediaType "application/smil" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_smil a skos:Concept ;
+  mediatype:hasMediaType "application/smil" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Gesynchroniseerde multimedia integratie taal"@nl ;
   skos:prefLabel "Iaith Integreiddio Aml-Gyfrwng wedi ei Chydweddu"@cy ;
@@ -471,8 +471,8 @@ media-type:application_smil a skos:Concept ;
   skos:prefLabel "Синхронизовани језик за интеграцију мултимедије (SMIL)"@sr ;
   skos:prefLabel "동기화 멀티미디어 통합 언어"@ko .
 
-media-type:application_vndcorel-draw a skos:Concept ;
-  media-type:hasMediaType "application/vnd.corel-draw" ;
+mediatype:application_vndcorel-draw a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.corel-draw" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Corel Draw -piirros"@fi ;
   skos:prefLabel "Corel Draw drawing"@en ;
@@ -490,24 +490,24 @@ media-type:application_vndcorel-draw a skos:Concept ;
   skos:prefLabel "Σχέδιο Corel Draw "@el ;
   skos:prefLabel "코렐 드로우 드로잉"@ko .
 
-media-type:application_vndhp-hpgl a skos:Concept ;
-  media-type:hasMediaType "application/vnd.hp-hpgl" ;
+mediatype:application_vndhp-hpgl a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.hp-hpgl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "HP Graphics Language (piirturi)"@fi ;
   skos:prefLabel "HP Graphics Language (plotter)"@en ;
   skos:prefLabel "Langage graphique HP (traceur)"@fr ;
   skos:prefLabel "HP-Grafiksprache (Plotter)"@de .
 
-media-type:application_vndhp-pcl a skos:Concept ;
-  media-type:hasMediaType "application/vnd.hp-pcl" ;
+mediatype:application_vndhp-pcl a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.hp-pcl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "HP Printer Control Language -tiedosto"@fi ;
   skos:prefLabel "HP Printer Control Language file"@en ;
   skos:prefLabel "Fichier du langage de contrôle de l'imprimante HP"@fr ;
   skos:prefLabel "HP-Druckersteuerungs-Sprachdatei"@de .
 
-media-type:application_vndlotus-1-2-3 a skos:Concept ;
-  media-type:hasMediaType "application/vnd.lotus-1-2-3" ;
+mediatype:application_vndlotus-1-2-3 a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.lotus-1-2-3" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Lotus 1-2-3 -taulukko"@fi ;
   skos:prefLabel "Lotus 1-2-3 hesab cədvəli"@az ;
@@ -525,9 +525,9 @@ media-type:application_vndlotus-1-2-3 a skos:Concept ;
   skos:prefLabel "chiffrier Lotus 1-2-3"@fr ;
   skos:prefLabel "Λογιστικό φύλλο Lotus 1-2-3"@el .
 
-media-type:application_vndms-excel a skos:Concept ;
-  media-type:hasMediaType "application/vnd.ms-excel" ;
-  skos:exactMatch media-type:application_msexcel ;
+mediatype:application_vndms-excel a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.ms-excel" ;
+  skos:exactMatch mediatype:application_msexcel ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft Excel -taulukko"@fi ;
   skos:prefLabel "Microsoft Excel hesab cədvəli"@az ;
@@ -545,8 +545,8 @@ media-type:application_vndms-excel a skos:Concept ;
   skos:prefLabel "Микрософт Ексел табеларни прорачун"@sr ;
   skos:prefLabel "마이크로소프트 엑셀 스프레드시트"@ko .
 
-media-type:application_vndms-powerpoint a skos:Concept ;
-  media-type:hasMediaType "application/vnd.ms-powerpoint" ;
+mediatype:application_vndms-powerpoint a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.ms-powerpoint" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft PowerPoint -esitys"@fi ;
   skos:prefLabel "Microsoft PowerPoint presentation"@en ;
@@ -555,9 +555,9 @@ media-type:application_vndms-powerpoint a skos:Concept ;
   skos:prefLabel "Microsoft PowerPoint-presentasjon"@no ;
   skos:prefLabel "Παρουσίαση Microsoft PowerPoint"@el .
 
-media-type:application_vndms-word a skos:Concept ;
-  media-type:hasMediaType "application/vnd.ms-word" ;
-  skos:exactMatch media-type:application_msword ;
+mediatype:application_vndms-word a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.ms-word" ;
+  skos:exactMatch mediatype:application_msword ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Miscrosoft Word"@cy ;
   skos:prefLabel "Dokument Microsoft Word"@cs ;
@@ -575,15 +575,15 @@ media-type:application_vndms-word a skos:Concept ;
   skos:prefLabel "Микрософт Word документ"@sr ;
   skos:prefLabel "마이크로소프트 워드 문서"@ko .
 
-media-type:application_vndpalm a skos:Concept ;
-  media-type:hasMediaType "application/vnd.palm" ;
+mediatype:application_vndpalm a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.palm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Palmpilot database/document"@en ;
   skos:prefLabel "Palmpilot-Datenbank/-Dokument"@de ;
   skos:prefLabel "Palmpilot-tietokanta tai -asiakirja"@fi .
 
-media-type:application_vndrn-realmedia a skos:Concept ;
-  media-type:hasMediaType "application/vnd.rn-realmedia" ;
+mediatype:application_vndrn-realmedia a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.rn-realmedia" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen RealAudio neu RealVideo"@cy ;
   skos:prefLabel "Dokument RealAudio/Video"@cs ;
@@ -601,8 +601,8 @@ media-type:application_vndrn-realmedia a skos:Concept ;
   skos:prefLabel "Έγγραφο RealAudio/Video"@el ;
   skos:prefLabel "리얼오디오/비디오 문서"@ko .
 
-media-type:application_vndstardivisioncalc a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.calc" ;
+mediatype:application_vndstardivisioncalc a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.calc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "StarCalc hesab cədvəli"@az ;
   skos:prefLabel "StarCalc spreadsheet"@en ;
@@ -620,8 +620,8 @@ media-type:application_vndstardivisioncalc a skos:Concept ;
   skos:prefLabel "Feuille de calcul StarCalc"@fr ;
   skos:prefLabel "Λογιστικό φύλλο StarCalc"@el .
 
-media-type:application_vndstardivisionchart a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.chart" ;
+mediatype:application_vndstardivisionchart a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.chart" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Graf StarChart"@cs ;
   skos:prefLabel "Siart StarChart"@cy ;
@@ -639,8 +639,8 @@ media-type:application_vndstardivisionchart a skos:Concept ;
   skos:prefLabel "graphique StarChart"@fr ;
   skos:prefLabel "Γράφημα StarChart"@el .
 
-media-type:application_vndstardivisiondraw a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.draw" ;
+mediatype:application_vndstardivisiondraw a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.draw" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Darlun StarDraw"@cy ;
   skos:prefLabel "Kresba StarDraw"@cs ;
@@ -658,8 +658,8 @@ media-type:application_vndstardivisiondraw a skos:Concept ;
   skos:prefLabel "dessin StarDraw"@fr ;
   skos:prefLabel "Σχέδιο StarDraw"@el .
 
-media-type:application_vndstardivisionimpress a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.impress" ;
+mediatype:application_vndstardivisionimpress a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.impress" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Cyflwyniad StarImpress"@cy ;
   skos:prefLabel "Prezentace StarImpress"@cs ;
@@ -677,24 +677,24 @@ media-type:application_vndstardivisionimpress a skos:Concept ;
   skos:prefLabel "présentation StarImpress"@fr ;
   skos:prefLabel "Παρουσίαση StarImpress"@el .
 
-media-type:application_vndstardivisionmail a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.mail" ;
+mediatype:application_vndstardivisionmail a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.mail" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "StarMail email"@en ;
   skos:prefLabel "StarMail-E-Mail"@de ;
   skos:prefLabel "StarMail-melding"@no ;
   skos:prefLabel "StarMail-tiedosto"@fi .
 
-media-type:application_vndstardivisionmath a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.math" ;
+mediatype:application_vndstardivisionmath a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.math" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "StarMath formula"@en ;
   skos:prefLabel "StarMath-Formel"@de ;
   skos:prefLabel "StarMath-asiakirja"@fi ;
   skos:prefLabel "StarMath-formel"@no .
 
-media-type:application_vndstardivisionwriter a skos:Concept ;
-  media-type:hasMediaType "application/vnd.stardivision.writer" ;
+mediatype:application_vndstardivisionwriter a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.stardivision.writer" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen StarWriter"@cy ;
   skos:prefLabel "Dokument StarWriter"@cs ;
@@ -712,8 +712,8 @@ media-type:application_vndstardivisionwriter a skos:Concept ;
   skos:prefLabel "document StarWriter"@fr ;
   skos:prefLabel "Έγγραφο StarWriter"@el .
 
-media-type:application_vndsunxmlcalc a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.calc" ;
+mediatype:application_vndsunxmlcalc a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.calc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Calc -taulukko"@fi ;
   skos:prefLabel "OpenOffice.org Calc spreadsheet"@en ;
@@ -722,8 +722,8 @@ media-type:application_vndsunxmlcalc a skos:Concept ;
   skos:prefLabel "OpenOffice.org Calc-regneark"@no ;
   skos:prefLabel "Λογιστικό φύλλο OpenOffice.org Calc"@el .
 
-media-type:application_vndsunxmlcalctemplate a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.calc.template" ;
+mediatype:application_vndsunxmlcalctemplate a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.calc.template" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Calc -taulukkomalli"@fi ;
   skos:prefLabel "OpenOffice.org Calc spreadsheet template"@en ;
@@ -732,8 +732,8 @@ media-type:application_vndsunxmlcalctemplate a skos:Concept ;
   skos:prefLabel "OpenOffice.org Calc-regnearkmal"@no ;
   skos:prefLabel "Πρότυπο λογιστικό φύλλο OpenOffice.org Calc"@el .
 
-media-type:application_vndsunxmldraw a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.draw" ;
+mediatype:application_vndsunxmldraw a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.draw" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Draw drawing"@en ;
   skos:prefLabel "OpenOffice.org Draw dessin"@fr ;
@@ -741,8 +741,8 @@ media-type:application_vndsunxmldraw a skos:Concept ;
   skos:prefLabel "OpenOffice.org Draw-tegning"@no ;
   skos:prefLabel "OpenOffice.org-Draw -piirros"@fi .
 
-media-type:application_vndsunxmldrawtemplate a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.draw.template" ;
+mediatype:application_vndsunxmldrawtemplate a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.draw.template" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Draw -piirrosmalli"@fi ;
   skos:prefLabel "OpenOffice.org Draw drawing template"@en ;
@@ -750,8 +750,8 @@ media-type:application_vndsunxmldrawtemplate a skos:Concept ;
   skos:prefLabel "OpenOffice.org Draw-tegningsmal"@no ;
   skos:prefLabel "OpenOffice.org·Draw-Zeichnungsvorlage"@de .
 
-media-type:application_vndsunxmlimpress a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.impress" ;
+mediatype:application_vndsunxmlimpress a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.impress" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Impress -esitys"@fi ;
   skos:prefLabel "OpenOffice.org Impress presentation"@en ;
@@ -761,8 +761,8 @@ media-type:application_vndsunxmlimpress a skos:Concept ;
   skos:prefLabel "OpenOffice.org·Impress-Präsentation"@de ;
   skos:prefLabel "Παρουσίαση OpenOffice.org Impress"@el .
 
-media-type:application_vndsunxmlimpresstemplate a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.impress.template" ;
+mediatype:application_vndsunxmlimpresstemplate a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.impress.template" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Impress -esitysmalli"@fi ;
   skos:prefLabel "OpenOffice.org Impress presentation template"@en ;
@@ -772,8 +772,8 @@ media-type:application_vndsunxmlimpresstemplate a skos:Concept ;
   skos:prefLabel "OpenOffice.org·Impress-Präsentationsvorlage"@de ;
   skos:prefLabel "Πρότυπο Παρουσίασης OpenOffice.org Impress"@el .
 
-media-type:application_vndsunxmlmath a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.math" ;
+mediatype:application_vndsunxmlmath a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.math" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Math formula"@en ;
   skos:prefLabel "OpenOffice.org Formule mathématique"@fr ;
@@ -781,8 +781,8 @@ media-type:application_vndsunxmlmath a skos:Concept ;
   skos:prefLabel "OpenOffice.org Math-dokument"@no ;
   skos:prefLabel "OpenOffice.org·Math-Formel"@de .
 
-media-type:application_vndsunxmlwriter a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.writer" ;
+mediatype:application_vndsunxmlwriter a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.writer" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Writer -asiakirja"@fi ;
   skos:prefLabel "OpenOffice.org Writer document"@en ;
@@ -792,8 +792,8 @@ media-type:application_vndsunxmlwriter a skos:Concept ;
   skos:prefLabel "OpenOffice.org·Writer-Dokument"@de ;
   skos:prefLabel "Έγγραφο OpenOffice.org Writer"@el .
 
-media-type:application_vndsunxmlwriterglobal a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.writer.global" ;
+mediatype:application_vndsunxmlwriterglobal a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.writer.global" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Globalt OpenOffice.org Writer-dokument"@no ;
   skos:prefLabel "OpenOffice.org Writer global document"@en ;
@@ -801,8 +801,8 @@ media-type:application_vndsunxmlwriterglobal a skos:Concept ;
   skos:prefLabel "OpenOffice.org·Writer-Globaldokument"@de ;
   skos:prefLabel "yleinen OpenOffice.org Write -asiakirja"@fi .
 
-media-type:application_vndsunxmlwritertemplate a skos:Concept ;
-  media-type:hasMediaType "application/vnd.sun.xml.writer.template" ;
+mediatype:application_vndsunxmlwritertemplate a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.sun.xml.writer.template" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Writer -asiakirjamalli"@fi ;
   skos:prefLabel "OpenOffice.org Writer document template"@en ;
@@ -811,10 +811,10 @@ media-type:application_vndsunxmlwritertemplate a skos:Concept ;
   skos:prefLabel "OpenOffice.org·Writer-Dokumentenvorlage"@de ;
   skos:prefLabel "Πρότυπο έγγραφο OpenOffice.org Writer"@el .
 
-media-type:application_vndwordperfect a skos:Concept ;
-  media-type:hasMediaType "application/vnd.wordperfect" ;
-  skos:exactMatch media-type:application_wordperfect ;
-  skos:exactMatch media-type:application_x-wordperfect ;
+mediatype:application_vndwordperfect a skos:Concept ;
+  mediatype:hasMediaType "application/vnd.wordperfect" ;
+  skos:exactMatch mediatype:application_wordperfect ;
+  skos:exactMatch mediatype:application_x-wordperfect ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen WordPerfect"@cy ;
   skos:prefLabel "Dokument WordPerfect"@cs ;
@@ -832,8 +832,8 @@ media-type:application_vndwordperfect a skos:Concept ;
   skos:prefLabel "Έγγραφο WordPerfect"@el ;
   skos:prefLabel "워드퍼펙트 문서"@ko .
 
-media-type:application_x-abiword a skos:Concept ;
-  media-type:hasMediaType "application/x-abiword" ;
+mediatype:application_x-abiword a skos:Concept ;
+  mediatype:hasMediaType "application/x-abiword" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AbiWord document"@en ;
   skos:prefLabel "AbiWord-Dokument"@de ;
@@ -842,8 +842,8 @@ media-type:application_x-abiword a skos:Concept ;
   skos:prefLabel "AbiWord-dokument"@sv ;
   skos:prefLabel "Έγγραφο AbiWord"@el .
 
-media-type:application_x-amipro a skos:Concept ;
-  media-type:hasMediaType "application/x-amipro" ;
+mediatype:application_x-amipro a skos:Concept ;
+  mediatype:hasMediaType "application/x-amipro" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Lotus AmiPro"@cy ;
   skos:prefLabel "Dokument Lotus AmiPro"@cs ;
@@ -861,8 +861,8 @@ media-type:application_x-amipro a skos:Concept ;
   skos:prefLabel "Έγγραφο Lotus AmiPro"@el ;
   skos:prefLabel "Лотус АмиПро документ"@sr .
 
-media-type:application_x-applix-spreadsheet a skos:Concept ;
-  media-type:hasMediaType "application/x-applix-spreadsheet" ;
+mediatype:application_x-applix-spreadsheet a skos:Concept ;
+  mediatype:hasMediaType "application/x-applix-spreadsheet" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Applix Spreadsheets -taulukko"@fi ;
   skos:prefLabel "Applix Spreadsheets spreadsheet"@en ;
@@ -870,8 +870,8 @@ media-type:application_x-applix-spreadsheet a skos:Concept ;
   skos:prefLabel "Applix Spreadsheets-regneark"@no ;
   skos:prefLabel "Λογιστικό φύλλο Applix Spreadsheets"@el .
 
-media-type:application_x-applix-word a skos:Concept ;
-  media-type:hasMediaType "application/x-applix-word" ;
+mediatype:application_x-applix-word a skos:Concept ;
+  mediatype:hasMediaType "application/x-applix-word" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Applix Word 문서"@ko ;
   skos:prefLabel "Applix Words -asiakirja"@fi ;
@@ -889,20 +889,20 @@ media-type:application_x-applix-word a skos:Concept ;
   skos:prefLabel "document Applix Words"@fr ;
   skos:prefLabel "Έγγραφο Applix Words"@el .
 
-media-type:application_x-arc a skos:Concept ;
-  media-type:hasMediaType "application/x-arc" ;
+mediatype:application_x-arc a skos:Concept ;
+  mediatype:hasMediaType "application/x-arc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-archive a skos:Concept ;
-  media-type:hasMediaType "application/x-archive" ;
+mediatype:application_x-archive a skos:Concept ;
+  mediatype:hasMediaType "application/x-archive" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AR archive"@en ;
   skos:prefLabel "AR-Archiv"@de ;
   skos:prefLabel "AR-arkisto"@fi ;
   skos:prefLabel "AR-arkiv"@no .
 
-media-type:application_x-arj a skos:Concept ;
-  media-type:hasMediaType "application/x-arj" ;
+mediatype:application_x-arj a skos:Concept ;
+  mediatype:hasMediaType "application/x-arj" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "ARJ archief"@nl ;
   skos:prefLabel "ARJ archive"@en ;
@@ -919,9 +919,9 @@ media-type:application_x-arj a skos:Concept ;
   skos:prefLabel "Archiv ARJ"@cs ;
   skos:prefLabel "archive ARJ"@fr .
 
-media-type:application_x-asp a skos:Concept ;
-  media-type:hasMediaType "application/x-asp" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-asp a skos:Concept ;
+  mediatype:hasMediaType "application/x-asp" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "ASP (active server page)"@hu ;
   skos:prefLabel "Active server page"@cs ;
@@ -938,9 +938,9 @@ media-type:application_x-asp a skos:Concept ;
   skos:prefLabel "Активна серверска страна"@sr ;
   skos:prefLabel "액티브 서버 페이지"@ko .
 
-media-type:application_x-awk a skos:Concept ;
-  media-type:hasMediaType "application/x-awk" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-awk a skos:Concept ;
+  mediatype:hasMediaType "application/x-awk" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AWK script"@en ;
   skos:prefLabel "AWK script"@nl ;
@@ -957,8 +957,8 @@ media-type:application_x-awk a skos:Concept ;
   skos:prefLabel "WAK-skript"@nn ;
   skos:prefLabel "script AWK"@fr .
 
-media-type:application_x-bcpio a skos:Concept ;
-  media-type:hasMediaType "application/x-bcpio" ;
+mediatype:application_x-bcpio a skos:Concept ;
+  mediatype:hasMediaType "application/x-bcpio" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "BCPIO document"@en ;
   skos:prefLabel "BCPIO document"@nl ;
@@ -976,8 +976,8 @@ media-type:application_x-bcpio a skos:Concept ;
   skos:prefLabel "document BCPIO"@fr ;
   skos:prefLabel "Έγγραφο BCPIO"@el .
 
-media-type:application_x-bittorrent a skos:Concept ;
-  media-type:hasMediaType "application/x-bittorrent" ;
+mediatype:application_x-bittorrent a skos:Concept ;
+  mediatype:hasMediaType "application/x-bittorrent" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "BitTorrent seed faylı"@az ;
   skos:prefLabel "BitTorrent seed file"@en ;
@@ -995,49 +995,49 @@ media-type:application_x-bittorrent a skos:Concept ;
   skos:prefLabel "Αρχείο BitTorrent seed"@el ;
   skos:prefLabel "Датотека са БитТорентовим полазиштима"@sr .
 
-media-type:application_x-blender a skos:Concept ;
-  media-type:hasMediaType "application/x-blender" ;
+mediatype:application_x-blender a skos:Concept ;
+  mediatype:hasMediaType "application/x-blender" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Blender scene"@en ;
   skos:prefLabel "Blender-Szene"@de ;
   skos:prefLabel "Blender-scene"@no ;
   skos:prefLabel "Blender-tiedosto"@fi .
 
-media-type:application_x-bzip a skos:Concept ;
-  media-type:hasMediaType "application/x-bzip" ;
+mediatype:application_x-bzip a skos:Concept ;
+  mediatype:hasMediaType "application/x-bzip" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "bzip archive"@en ;
   skos:prefLabel "bzip-Archiv"@de ;
   skos:prefLabel "bzip-arkisto"@fi ;
   skos:prefLabel "bzip-arkiv"@no .
 
-media-type:application_x-bzip-compressed-tar a skos:Concept ;
-  media-type:hasMediaType "application/x-bzip-compressed-tar" ;
+mediatype:application_x-bzip-compressed-tar a skos:Concept ;
+  mediatype:hasMediaType "application/x-bzip-compressed-tar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tar archive (bzip-compressed)"@en ;
   skos:prefLabel "tar-Archiv (bzip-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (bzip-pakattu)"@fi ;
   skos:prefLabel "tar-arkiv (bzip-komprimert)"@no .
 
-media-type:application_x-cd-image a skos:Concept ;
-  media-type:hasMediaType "application/x-cd-image" ;
+mediatype:application_x-cd-image a skos:Concept ;
+  mediatype:hasMediaType "application/x-cd-image" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CD-Roh-Image"@de ;
   skos:prefLabel "raaka CD-vedos"@fi ;
   skos:prefLabel "raw CD image"@en ;
   skos:prefLabel "rått CD-bilde"@no .
 
-media-type:application_x-cgi a skos:Concept ;
-  media-type:hasMediaType "application/x-cgi" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-cgi a skos:Concept ;
+  mediatype:hasMediaType "application/x-cgi" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CGI script"@en ;
   skos:prefLabel "CGI-Skript"@de ;
   skos:prefLabel "CGI-skript"@no ;
   skos:prefLabel "CGI-skripti"@fi .
 
-media-type:application_x-chess-pgn a skos:Concept ;
-  media-type:hasMediaType "application/x-chess-pgn" ;
+mediatype:application_x-chess-pgn a skos:Concept ;
+  mediatype:hasMediaType "application/x-chess-pgn" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Gêm wyddbwyll PGN"@cy ;
   skos:prefLabel "PGN chess game"@en ;
@@ -1055,8 +1055,8 @@ media-type:application_x-chess-pgn a skos:Concept ;
   skos:prefLabel "Šachová hra PGN"@cs ;
   skos:prefLabel "Παρτίδα σκακιού PGN"@el .
 
-media-type:application_x-class-file a skos:Concept ;
-  media-type:hasMediaType "application/x-class-file" ;
+mediatype:application_x-class-file a skos:Concept ;
+  mediatype:hasMediaType "application/x-class-file" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Côd beit Java"@cy ;
   skos:prefLabel "Java bajtový kód"@cs ;
@@ -1074,31 +1074,31 @@ media-type:application_x-class-file a skos:Concept ;
   skos:prefLabel "Κώδικας Java byte"@el ;
   skos:prefLabel "자바 바이트코드"@ko .
 
-media-type:application_x-compress a skos:Concept ;
-  media-type:hasMediaType "application/x-compress" ;
+mediatype:application_x-compress a skos:Concept ;
+  mediatype:hasMediaType "application/x-compress" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "UNIX-compressed file"@en ;
   skos:prefLabel "UNIX-komprimert fil"@no ;
   skos:prefLabel "UNIX-komprimierte Datei"@de ;
   skos:prefLabel "UNIX-pakattu tiedosto"@fi .
 
-media-type:application_x-compressed-tar a skos:Concept ;
-  media-type:hasMediaType "application/x-compressed-tar" ;
+mediatype:application_x-compressed-tar a skos:Concept ;
+  mediatype:hasMediaType "application/x-compressed-tar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tar archive (gzip-compressed)"@en ;
   skos:prefLabel "tar-Archiv (gzip-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (gzip-pakattu)"@fi ;
   skos:prefLabel "tar-arkiv (gzip-komprimert)"@no .
 
-media-type:application_x-core a skos:Concept ;
-  media-type:hasMediaType "application/x-core" ;
+mediatype:application_x-core a skos:Concept ;
+  mediatype:hasMediaType "application/x-core" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Daten zu Programmabsturz"@de ;
   skos:prefLabel "ohjelman kaatumistiedot"@fi ;
   skos:prefLabel "program crash data"@en .
 
-media-type:application_x-cpio a skos:Concept ;
-  media-type:hasMediaType "application/x-cpio" ;
+mediatype:application_x-cpio a skos:Concept ;
+  mediatype:hasMediaType "application/x-cpio" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO"@cy ;
   skos:prefLabel "Archiv CPIO"@cs ;
@@ -1115,8 +1115,8 @@ media-type:application_x-cpio a skos:Concept ;
   skos:prefLabel "CPIO-arkiv"@sv ;
   skos:prefLabel "archive CPIO"@fr .
 
-media-type:application_x-cpio-compressed a skos:Concept ;
-  media-type:hasMediaType "application/x-cpio-compressed" ;
+mediatype:application_x-cpio-compressed a skos:Concept ;
+  mediatype:hasMediaType "application/x-cpio-compressed" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO (gywasgwyd drwy gzip)"@cy ;
   skos:prefLabel "Archiv CPIO (komprimovaný gzip)"@cs ;
@@ -1133,9 +1133,9 @@ media-type:application_x-cpio-compressed a skos:Concept ;
   skos:prefLabel "CPIO-arkiv (gzip-pakka)"@nn ;
   skos:prefLabel "archive CPIO (compressé gzip)"@fr .
 
-media-type:application_x-csh a skos:Concept ;
-  media-type:hasMediaType "application/x-csh" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-csh a skos:Concept ;
+  mediatype:hasMediaType "application/x-csh" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "C qabıq skripti"@az ;
   skos:prefLabel "C shell script"@en ;
@@ -1153,8 +1153,8 @@ media-type:application_x-csh a skos:Concept ;
   skos:prefLabel "script C shell"@fr ;
   skos:prefLabel "Πρόγραμμα εντολών φλοιού C"@el .
 
-media-type:application_x-dbase a skos:Concept ;
-  media-type:hasMediaType "application/x-dbase" ;
+mediatype:application_x-dbase a skos:Concept ;
+  mediatype:hasMediaType "application/x-dbase" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen dBASE"@cy ;
   skos:prefLabel "Dokument dBASE"@cs ;
@@ -1172,12 +1172,12 @@ media-type:application_x-dbase a skos:Concept ;
   skos:prefLabel "document dBASE"@fr ;
   skos:prefLabel "Έγγραφο dBASE"@el .
 
-media-type:application_x-dbm a skos:Concept ;
-  media-type:hasMediaType "application/x-dbm" ;
+mediatype:application_x-dbm a skos:Concept ;
+  mediatype:hasMediaType "application/x-dbm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-dc-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-dc-rom" ;
+mediatype:application_x-dc-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-dc-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dreamcast ROM"@el ;
   skos:prefLabel "Dreamcast ROM"@en ;
@@ -1185,8 +1185,8 @@ media-type:application_x-dc-rom a skos:Concept ;
   skos:prefLabel "Dreamcast-ROM"@fi ;
   skos:prefLabel "Dreamcast-ROM"@no .
 
-media-type:application_x-deb a skos:Concept ;
-  media-type:hasMediaType "application/x-deb" ;
+mediatype:application_x-deb a skos:Concept ;
+  mediatype:hasMediaType "application/x-deb" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Balíček Debianu"@cs ;
   skos:prefLabel "Debian package"@en ;
@@ -1204,8 +1204,8 @@ media-type:application_x-deb a skos:Concept ;
   skos:prefLabel "Πακέτο Debian"@el ;
   skos:prefLabel "데비안 꾸러미"@ko .
 
-media-type:application_x-designer a skos:Concept ;
-  media-type:hasMediaType "application/x-designer" ;
+mediatype:application_x-designer a skos:Concept ;
+  mediatype:hasMediaType "application/x-designer" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "QT Designer-Datei"@de ;
   skos:prefLabel "Qt Designer -tiedosto"@fi ;
@@ -1214,18 +1214,18 @@ media-type:application_x-designer a skos:Concept ;
   skos:prefLabel "Qt Designer-fil"@sv ;
   skos:prefLabel "Αρχείο Qt Designer"@el .
 
-media-type:application_x-desktop a skos:Concept ;
-  media-type:hasMediaType "application/x-desktop" ;
-  skos:broader media-type:text_plain ;
-  skos:exactMatch media-type:application_x-gnome-app-info ;
+mediatype:application_x-desktop a skos:Concept ;
+  mediatype:hasMediaType "application/x-desktop" ;
+  skos:broader mediatype:text_plain ;
+  skos:exactMatch mediatype:application_x-gnome-app-info ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Desktop-Konfigurationsdatei"@de ;
   skos:prefLabel "desktop configuration file"@en ;
   skos:prefLabel "konfigurasjonsfil for skrivebordet"@no ;
   skos:prefLabel "työpöydän asetustiedosto"@fi .
 
-media-type:application_x-dia-diagram a skos:Concept ;
-  media-type:hasMediaType "application/x-dia-diagram" ;
+mediatype:application_x-dia-diagram a skos:Concept ;
+  mediatype:hasMediaType "application/x-dia-diagram" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dia diagram"@en ;
   skos:prefLabel "Dia diagram"@nl ;
@@ -1243,8 +1243,8 @@ media-type:application_x-dia-diagram a skos:Concept ;
   skos:prefLabel "Διάγραμμα Dia"@el ;
   skos:prefLabel "Диа дијаграм"@sr .
 
-media-type:application_x-dvi a skos:Concept ;
-  media-type:hasMediaType "application/x-dvi" ;
+mediatype:application_x-dvi a skos:Concept ;
+  mediatype:hasMediaType "application/x-dvi" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "TeX DVI -asiakirja"@fi ;
   skos:prefLabel "TeX DVI document"@en ;
@@ -1252,8 +1252,8 @@ media-type:application_x-dvi a skos:Concept ;
   skos:prefLabel "TeX DVI-dokument"@no ;
   skos:prefLabel "TeX-DVI-Dokument"@de .
 
-media-type:application_x-e-theme a skos:Concept ;
-  media-type:hasMediaType "application/x-e-theme" ;
+mediatype:application_x-e-theme a skos:Concept ;
+  mediatype:hasMediaType "application/x-e-theme" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Enlightenment tema"@no ;
   skos:prefLabel "Enlightenment thema"@nl ;
@@ -1271,16 +1271,16 @@ media-type:application_x-e-theme a skos:Concept ;
   skos:prefLabel "Θέμα Enlightenment"@el ;
   skos:prefLabel "인라이트먼트 테마"@ko .
 
-media-type:application_x-egon a skos:Concept ;
-  media-type:hasMediaType "application/x-egon" ;
+mediatype:application_x-egon a skos:Concept ;
+  mediatype:hasMediaType "application/x-egon" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Egon Animator -animaatio"@fi ;
   skos:prefLabel "Egon Animator animation"@en ;
   skos:prefLabel "Egon Animator-Animation"@de ;
   skos:prefLabel "Egon animator-animasjon"@no .
 
-media-type:application_x-executable a skos:Concept ;
-  media-type:hasMediaType "application/x-executable" ;
+mediatype:application_x-executable a skos:Concept ;
+  mediatype:hasMediaType "application/x-executable" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Programm"@de ;
   skos:prefLabel "executable"@en ;
@@ -1289,8 +1289,8 @@ media-type:application_x-executable a skos:Concept ;
   skos:prefLabel "suoritettava ohjelma"@fi ;
   skos:prefLabel "Εκτελέσιμο"@el .
 
-media-type:application_x-font-afm a skos:Concept ;
-  media-type:hasMediaType "application/x-font-afm" ;
+mediatype:application_x-font-afm a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-afm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Adobe font metrics"@en ;
   skos:prefLabel "Adobe lettertype-metrieken"@nl ;
@@ -1307,8 +1307,8 @@ media-type:application_x-font-afm a skos:Concept ;
   skos:prefLabel "Metrika písma Adobe"@cs ;
   skos:prefLabel "métriques de fonte Adobe"@fr .
 
-media-type:application_x-font-bdf a skos:Concept ;
-  media-type:hasMediaType "application/x-font-bdf" ;
+mediatype:application_x-font-bdf a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-bdf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "BDF font"@en ;
   skos:prefLabel "BDF lettertype"@nl ;
@@ -1326,8 +1326,8 @@ media-type:application_x-font-bdf a skos:Concept ;
   skos:prefLabel "fonte BDF"@fr ;
   skos:prefLabel "Γραμματοσειρά BDF"@el .
 
-media-type:application_x-font-dos a skos:Concept ;
-  media-type:hasMediaType "application/x-font-dos" ;
+mediatype:application_x-font-dos a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-dos" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DOS font"@en ;
   skos:prefLabel "DOS lettertype"@nl ;
@@ -1345,8 +1345,8 @@ media-type:application_x-font-dos a skos:Concept ;
   skos:prefLabel "Γραμματοσειρά DOS"@el ;
   skos:prefLabel "도스 글꼴"@ko .
 
-media-type:application_x-font-framemaker a skos:Concept ;
-  media-type:hasMediaType "application/x-font-framemaker" ;
+mediatype:application_x-font-framemaker a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-framemaker" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Adobe FrameMaker -kirjasin"@fi ;
   skos:prefLabel "Adobe FrameMaker font"@en ;
@@ -1364,8 +1364,8 @@ media-type:application_x-font-framemaker a skos:Concept ;
   skos:prefLabel "fonte Adobe FrameMaker"@fr ;
   skos:prefLabel "Γραμματοσειρά Adobe FrameMaker"@el .
 
-media-type:application_x-font-libgrx a skos:Concept ;
-  media-type:hasMediaType "application/x-font-libgrx" ;
+mediatype:application_x-font-libgrx a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-libgrx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont LIBGRX"@cy ;
   skos:prefLabel "LIBGRX font"@en ;
@@ -1383,8 +1383,8 @@ media-type:application_x-font-libgrx a skos:Concept ;
   skos:prefLabel "fonte LIBGRX"@fr ;
   skos:prefLabel "Γραμματοσειρά LIBGRX"@el .
 
-media-type:application_x-font-linux-psf a skos:Concept ;
-  media-type:hasMediaType "application/x-font-linux-psf" ;
+mediatype:application_x-font-linux-psf a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-linux-psf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont Linux PSF"@cy ;
   skos:prefLabel "Linux PSF -konsolikirjasin"@fi ;
@@ -1402,8 +1402,8 @@ media-type:application_x-font-linux-psf a skos:Concept ;
   skos:prefLabel "Линукс PSF конзолни фонт"@sr ;
   skos:prefLabel "리눅스 PSF 콘솔 글꼴"@ko .
 
-media-type:application_x-font-otf a skos:Concept ;
-  media-type:hasMediaType "application/x-font-otf" ;
+mediatype:application_x-font-otf a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-otf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont OpenType"@cy ;
   skos:prefLabel "OpenType font"@en ;
@@ -1421,8 +1421,8 @@ media-type:application_x-font-otf a skos:Concept ;
   skos:prefLabel "Γραμματοσειρά OpenType "@el ;
   skos:prefLabel "트루타입 글꼴"@ko .
 
-media-type:application_x-font-pcf a skos:Concept ;
-  media-type:hasMediaType "application/x-font-pcf" ;
+mediatype:application_x-font-pcf a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-pcf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont PCF"@cy ;
   skos:prefLabel "PCF font"@en ;
@@ -1440,8 +1440,8 @@ media-type:application_x-font-pcf a skos:Concept ;
   skos:prefLabel "fonte PCF"@fr ;
   skos:prefLabel "Γραμματοσειρά PCF"@el .
 
-media-type:application_x-font-speedo a skos:Concept ;
-  media-type:hasMediaType "application/x-font-speedo" ;
+mediatype:application_x-font-speedo a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-speedo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont Speedo"@cy ;
   skos:prefLabel "Písmo Speedo"@cs ;
@@ -1459,8 +1459,8 @@ media-type:application_x-font-speedo a skos:Concept ;
   skos:prefLabel "fonte Speedo"@fr ;
   skos:prefLabel "Γραμματοσειρά Speedo"@el .
 
-media-type:application_x-font-sunos-news a skos:Concept ;
-  media-type:hasMediaType "application/x-font-sunos-news" ;
+mediatype:application_x-font-sunos-news a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-sunos-news" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont SunOS News"@cy ;
   skos:prefLabel "Písmo SunOS News"@cs ;
@@ -1478,8 +1478,8 @@ media-type:application_x-font-sunos-news a skos:Concept ;
   skos:prefLabel "fonte SunOS News"@fr ;
   skos:prefLabel "Γραμματοσειρά SunOS News"@el .
 
-media-type:application_x-font-tex a skos:Concept ;
-  media-type:hasMediaType "application/x-font-tex" ;
+mediatype:application_x-font-tex a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-tex" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont TeX"@cy ;
   skos:prefLabel "Písmo TeX"@cs ;
@@ -1497,8 +1497,8 @@ media-type:application_x-font-tex a skos:Concept ;
   skos:prefLabel "Γραμματοσειρά TeX"@el ;
   skos:prefLabel "ТеХ фонт"@sr .
 
-media-type:application_x-font-tex-tfm a skos:Concept ;
-  media-type:hasMediaType "application/x-font-tex-tfm" ;
+mediatype:application_x-font-tex-tfm a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-tex-tfm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Metrigau Ffont TeX"@cy ;
   skos:prefLabel "Metrika písma TeX"@cs ;
@@ -1515,8 +1515,8 @@ media-type:application_x-font-tex-tfm a skos:Concept ;
   skos:prefLabel "métriques de fonte TeX"@fr ;
   skos:prefLabel "ТеХ метрика фонта"@sr .
 
-media-type:application_x-font-ttf a skos:Concept ;
-  media-type:hasMediaType "application/x-font-ttf" ;
+mediatype:application_x-font-ttf a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-ttf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "TrueType font"@en ;
   skos:prefLabel "TrueType-Schrift"@de ;
@@ -1524,8 +1524,8 @@ media-type:application_x-font-ttf a skos:Concept ;
   skos:prefLabel "Truetype-kirjasin"@fi ;
   skos:prefLabel "Γραμματοσειρά TrueType"@el .
 
-media-type:application_x-font-type1 a skos:Concept ;
-  media-type:hasMediaType "application/x-font-type1" ;
+mediatype:application_x-font-type1 a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-type1" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Schrift"@de ;
   skos:prefLabel "font"@en ;
@@ -1534,8 +1534,8 @@ media-type:application_x-font-type1 a skos:Concept ;
   skos:prefLabel "typsnitt"@sv ;
   skos:prefLabel "γραμματοσειρά"@el .
 
-media-type:application_x-font-vfont a skos:Concept ;
-  media-type:hasMediaType "application/x-font-vfont" ;
+mediatype:application_x-font-vfont a skos:Concept ;
+  mediatype:hasMediaType "application/x-font-vfont" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffont V"@cy ;
   skos:prefLabel "Písmo V"@cs ;
@@ -1553,12 +1553,12 @@ media-type:application_x-font-vfont a skos:Concept ;
   skos:prefLabel "fonte V"@fr ;
   skos:prefLabel "Γραμματοσειρά V"@el .
 
-media-type:application_x-frame a skos:Concept ;
-  media-type:hasMediaType "application/x-frame" ;
+mediatype:application_x-frame a skos:Concept ;
+  mediatype:hasMediaType "application/x-frame" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-gameboy-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-gameboy-rom" ;
+mediatype:application_x-gameboy-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-gameboy-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Game Boy -ROM"@fi ;
   skos:prefLabel "Game Boy ROM"@el ;
@@ -1566,12 +1566,12 @@ media-type:application_x-gameboy-rom a skos:Concept ;
   skos:prefLabel "Game Boy-ROM"@de ;
   skos:prefLabel "Game Boy-ROM"@no .
 
-media-type:application_x-gdbm a skos:Concept ;
-  media-type:hasMediaType "application/x-gdbm" ;
+mediatype:application_x-gdbm a skos:Concept ;
+  mediatype:hasMediaType "application/x-gdbm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-genesis-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-genesis-rom" ;
+mediatype:application_x-genesis-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-genesis-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Genesis ROM"@el ;
   skos:prefLabel "Genesis ROM"@en ;
@@ -1579,17 +1579,17 @@ media-type:application_x-genesis-rom a skos:Concept ;
   skos:prefLabel "Genesis-ROM"@fi ;
   skos:prefLabel "Genesis-ROM"@no .
 
-media-type:application_x-gettext-translation a skos:Concept ;
-  media-type:hasMediaType "application/x-gettext-translation" ;
+mediatype:application_x-gettext-translation a skos:Concept ;
+  mediatype:hasMediaType "application/x-gettext-translation" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "käännetyt viestit (koneluettava)"@fi ;
   skos:prefLabel "oversatte meldinger (maskinlesbar)"@no ;
   skos:prefLabel "translated messages (machine-readable)"@en ;
   skos:prefLabel "übersetzte Meldungen (maschinenlesbar)"@de .
 
-media-type:application_x-glade a skos:Concept ;
-  media-type:hasMediaType "application/x-glade" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-glade a skos:Concept ;
+  mediatype:hasMediaType "application/x-glade" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Glade layihəsi"@az ;
   skos:prefLabel "Glade project"@en ;
@@ -1606,8 +1606,8 @@ media-type:application_x-glade a skos:Concept ;
   skos:prefLabel "projet Glade"@fr ;
   skos:prefLabel "Глејд пројекат"@sr .
 
-media-type:application_x-gmc-link a skos:Concept ;
-  media-type:hasMediaType "application/x-gmc-link" ;
+mediatype:application_x-gmc-link a skos:Concept ;
+  mediatype:hasMediaType "application/x-gmc-link" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Cyswllt GMC"@cy ;
   skos:prefLabel "GMC koppeling"@nl ;
@@ -1625,8 +1625,8 @@ media-type:application_x-gmc-link a skos:Concept ;
   skos:prefLabel "lien GMC"@fr ;
   skos:prefLabel "Σύνδεσμος GMC"@el .
 
-media-type:application_x-gnucash a skos:Concept ;
-  media-type:hasMediaType "application/x-gnucash" ;
+mediatype:application_x-gnucash a skos:Concept ;
+  mediatype:hasMediaType "application/x-gnucash" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GnuCash spreadsheet"@en ;
   skos:prefLabel "GnuCash-Tabellendokument"@de ;
@@ -1634,8 +1634,8 @@ media-type:application_x-gnucash a skos:Concept ;
   skos:prefLabel "GnuCash-taulukko"@fi ;
   skos:prefLabel "Λογιστικό φύλλο Gnucash"@el .
 
-media-type:application_x-gnumeric a skos:Concept ;
-  media-type:hasMediaType "application/x-gnumeric" ;
+mediatype:application_x-gnumeric a skos:Concept ;
+  mediatype:hasMediaType "application/x-gnumeric" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Gnumeric spreadsheet"@en ;
   skos:prefLabel "Gnumeric-Tabellendokument"@de ;
@@ -1644,15 +1644,15 @@ media-type:application_x-gnumeric a skos:Concept ;
   skos:prefLabel "Gnumeric-taulukko"@fi ;
   skos:prefLabel "Λογιστικό φύλλο Gnumeric"@el .
 
-media-type:application_x-graphite a skos:Concept ;
-  media-type:hasMediaType "application/x-graphite" ;
+mediatype:application_x-graphite a skos:Concept ;
+  mediatype:hasMediaType "application/x-graphite" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Graphite scientific graph"@en ;
   skos:prefLabel "Graphite-graafi"@fi ;
   skos:prefLabel "wissenschaftlicher Graphite-Graph"@de .
 
-media-type:application_x-gtar a skos:Concept ;
-  media-type:hasMediaType "application/x-gtar" ;
+mediatype:application_x-gtar a skos:Concept ;
+  mediatype:hasMediaType "application/x-gtar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archiv gtar"@cs ;
   skos:prefLabel "archif gtar"@cy ;
@@ -1669,16 +1669,16 @@ media-type:application_x-gtar a skos:Concept ;
   skos:prefLabel "gtar-arkiv"@sv ;
   skos:prefLabel "гтар архива"@sr .
 
-media-type:application_x-gtktalog a skos:Concept ;
-  media-type:hasMediaType "application/x-gtktalog" ;
+mediatype:application_x-gtktalog a skos:Concept ;
+  mediatype:hasMediaType "application/x-gtktalog" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GTKtalog catalog"@en ;
   skos:prefLabel "GTKtalog-Katalog"@de ;
   skos:prefLabel "GTKtalog-katalog"@no ;
   skos:prefLabel "GTKtalog-katalogi"@fi .
 
-media-type:application_x-gzip a skos:Concept ;
-  media-type:hasMediaType "application/x-gzip" ;
+mediatype:application_x-gzip a skos:Concept ;
+  mediatype:hasMediaType "application/x-gzip" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "gzip archive"@en ;
   skos:prefLabel "gzip-Archiv"@de ;
@@ -1686,8 +1686,8 @@ media-type:application_x-gzip a skos:Concept ;
   skos:prefLabel "gzip-arkiv"@no ;
   skos:prefLabel "gzip-arkiv"@sv .
 
-media-type:application_x-gzpostscript a skos:Concept ;
-  media-type:hasMediaType "application/x-gzpostscript" ;
+mediatype:application_x-gzpostscript a skos:Concept ;
+  mediatype:hasMediaType "application/x-gzpostscript" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PostScript document (gzip-compressed)"@en ;
   skos:prefLabel "PostScript-Dokument (gzip-komprimiert)"@de ;
@@ -1695,8 +1695,8 @@ media-type:application_x-gzpostscript a skos:Concept ;
   skos:prefLabel "PostScript-dokument (gzip-komprimert)"@no ;
   skos:prefLabel "Έγγραφο PostScript (συμπίεση-gzip)"@el .
 
-media-type:application_x-hdf a skos:Concept ;
-  media-type:hasMediaType "application/x-hdf" ;
+mediatype:application_x-hdf a skos:Concept ;
+  mediatype:hasMediaType "application/x-hdf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen HDF"@cy ;
   skos:prefLabel "Dokument HDF"@cs ;
@@ -1714,16 +1714,16 @@ media-type:application_x-hdf a skos:Concept ;
   skos:prefLabel "document HDF"@fr ;
   skos:prefLabel "Έγγραφο HDF"@el .
 
-media-type:application_x-ipod-firmware a skos:Concept ;
-  media-type:hasMediaType "application/x-ipod-firmware" ;
+mediatype:application_x-ipod-firmware a skos:Concept ;
+  mediatype:hasMediaType "application/x-ipod-firmware" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "iPod firmware"@en ;
   skos:prefLabel "iPod-Firmware"@de ;
   skos:prefLabel "iPod-firmware"@no ;
   skos:prefLabel "iPod-ohjelmisto"@fi .
 
-media-type:application_x-jar a skos:Concept ;
-  media-type:hasMediaType "application/x-jar" ;
+mediatype:application_x-jar a skos:Concept ;
+  mediatype:hasMediaType "application/x-jar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Java archive"@en ;
   skos:prefLabel "Java-Archiv"@de ;
@@ -1731,8 +1731,8 @@ media-type:application_x-jar a skos:Concept ;
   skos:prefLabel "Java-arkiv"@no ;
   skos:prefLabel "Java-arkiv"@sv .
 
-media-type:application_x-java a skos:Concept ;
-  media-type:hasMediaType "application/x-java" ;
+mediatype:application_x-java a skos:Concept ;
+  mediatype:hasMediaType "application/x-java" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Java class"@en ;
   skos:prefLabel "Java-Klasse"@de ;
@@ -1740,48 +1740,48 @@ media-type:application_x-java a skos:Concept ;
   skos:prefLabel "Java-klasse"@no ;
   skos:prefLabel "Java-luokka"@fi .
 
-media-type:application_x-javascript a skos:Concept ;
-  media-type:hasMediaType "application/x-javascript" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-javascript a skos:Concept ;
+  mediatype:hasMediaType "application/x-javascript" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Javascript program"@en ;
   skos:prefLabel "Javascript-Programm"@de ;
   skos:prefLabel "Πρόγραμμα Javascript"@el .
 
-media-type:application_x-jbuilder-project a skos:Concept ;
-  media-type:hasMediaType "application/x-jbuilder-project" ;
+mediatype:application_x-jbuilder-project a skos:Concept ;
+  mediatype:hasMediaType "application/x-jbuilder-project" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "JBuilder project"@en ;
   skos:prefLabel "JBuilder-Projekt"@de ;
   skos:prefLabel "JBuilder-projekti"@fi ;
   skos:prefLabel "JBuilder-prosjekt"@no .
 
-media-type:application_x-karbon a skos:Concept ;
-  media-type:hasMediaType "application/x-karbon" ;
+mediatype:application_x-karbon a skos:Concept ;
+  mediatype:hasMediaType "application/x-karbon" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Karbon14 drawing"@en ;
   skos:prefLabel "Karbon14-Zeichnung"@de ;
   skos:prefLabel "Karbon14-piirros"@fi ;
   skos:prefLabel "Karbon14-tegning"@no .
 
-media-type:application_x-kchart a skos:Concept ;
-  media-type:hasMediaType "application/x-kchart" ;
+mediatype:application_x-kchart a skos:Concept ;
+  mediatype:hasMediaType "application/x-kchart" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KChart chart"@en ;
   skos:prefLabel "KChart-Diagramm"@de ;
   skos:prefLabel "KChart-graf"@no ;
   skos:prefLabel "KChart-kaavio"@fi .
 
-media-type:application_x-kformula a skos:Concept ;
-  media-type:hasMediaType "application/x-kformula" ;
+mediatype:application_x-kformula a skos:Concept ;
+  mediatype:hasMediaType "application/x-kformula" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KFormula formula"@en ;
   skos:prefLabel "KFormula-Formel"@de ;
   skos:prefLabel "KFormula-formel"@no ;
   skos:prefLabel "KFormula-kaava"@fi .
 
-media-type:application_x-killustrator a skos:Concept ;
-  media-type:hasMediaType "application/x-killustrator" ;
+mediatype:application_x-killustrator a skos:Concept ;
+  mediatype:hasMediaType "application/x-killustrator" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KIllustrator drawing"@en ;
   skos:prefLabel "KIllustrator-Zeichnung"@de ;
@@ -1789,31 +1789,31 @@ media-type:application_x-killustrator a skos:Concept ;
   skos:prefLabel "KIllustrator-tegning"@no ;
   skos:prefLabel "Σχέδιο KIllustrator"@el .
 
-media-type:application_x-kivio a skos:Concept ;
-  media-type:hasMediaType "application/x-kivio" ;
+mediatype:application_x-kivio a skos:Concept ;
+  mediatype:hasMediaType "application/x-kivio" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Kivio flowchart"@en ;
   skos:prefLabel "Kivio-Flussdiagramm"@de ;
   skos:prefLabel "Kivio-flytdiagram"@no ;
   skos:prefLabel "Kivio-vuokaavio"@fi .
 
-media-type:application_x-kontour a skos:Concept ;
-  media-type:hasMediaType "application/x-kontour" ;
+mediatype:application_x-kontour a skos:Concept ;
+  mediatype:hasMediaType "application/x-kontour" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Kontour drawing"@en ;
   skos:prefLabel "Kontour-Zeichnung"@de ;
   skos:prefLabel "Kontour-piirros"@fi ;
   skos:prefLabel "Kontour-tegning"@no .
 
-media-type:application_x-kpovmodeler a skos:Concept ;
-  media-type:hasMediaType "application/x-kpovmodeler" ;
+mediatype:application_x-kpovmodeler a skos:Concept ;
+  mediatype:hasMediaType "application/x-kpovmodeler" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KPovModeler scene"@en ;
   skos:prefLabel "KPovModeler-Szene"@de ;
   skos:prefLabel "KPovModeler-tiedosto"@fi .
 
-media-type:application_x-kpresenter a skos:Concept ;
-  media-type:hasMediaType "application/x-kpresenter" ;
+mediatype:application_x-kpresenter a skos:Concept ;
+  mediatype:hasMediaType "application/x-kpresenter" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KPresenter presentation"@en ;
   skos:prefLabel "KPresenter-Präsentation"@de ;
@@ -1822,8 +1822,8 @@ media-type:application_x-kpresenter a skos:Concept ;
   skos:prefLabel "KPresenter-presentation"@sv ;
   skos:prefLabel "Παρουσίαση KPresenter"@el .
 
-media-type:application_x-krita a skos:Concept ;
-  media-type:hasMediaType "application/x-krita" ;
+mediatype:application_x-krita a skos:Concept ;
+  mediatype:hasMediaType "application/x-krita" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Krita document"@en ;
   skos:prefLabel "Krita-Dokument"@de ;
@@ -1831,8 +1831,8 @@ media-type:application_x-krita a skos:Concept ;
   skos:prefLabel "Krita-dokument"@no ;
   skos:prefLabel "Έγγραφο Krita"@el .
 
-media-type:application_x-kspread a skos:Concept ;
-  media-type:hasMediaType "application/x-kspread" ;
+mediatype:application_x-kspread a skos:Concept ;
+  mediatype:hasMediaType "application/x-kspread" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KSpread spreadsheet"@en ;
   skos:prefLabel "KSpread-Tabellendokument"@de ;
@@ -1840,20 +1840,20 @@ media-type:application_x-kspread a skos:Concept ;
   skos:prefLabel "KSpread-taulukko"@fi ;
   skos:prefLabel "Λογιστικό φύλλο KSpread"@el .
 
-media-type:application_x-kspread-crypt a skos:Concept ;
-  media-type:hasMediaType "application/x-kspread-crypt" ;
+mediatype:application_x-kspread-crypt a skos:Concept ;
+  mediatype:hasMediaType "application/x-kspread-crypt" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KSpread spreadsheet (encrypted)"@en ;
   skos:prefLabel "KSpread-Tabellendokument (verschlüsselt)"@de ;
   skos:prefLabel "KSpread-regneark (kryptert)"@no ;
   skos:prefLabel "KSpread-taulukko (salattu)"@fi .
 
-media-type:application_x-ksysv-package a skos:Concept ;
-  media-type:hasMediaType "application/x-ksysv-package" ;
+mediatype:application_x-ksysv-package a skos:Concept ;
+  mediatype:hasMediaType "application/x-ksysv-package" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-kugar a skos:Concept ;
-  media-type:hasMediaType "application/x-kugar" ;
+mediatype:application_x-kugar a skos:Concept ;
+  mediatype:hasMediaType "application/x-kugar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Kugar document"@en ;
   skos:prefLabel "Kugar-Dokument"@de ;
@@ -1861,8 +1861,8 @@ media-type:application_x-kugar a skos:Concept ;
   skos:prefLabel "Kugar-dokument"@no ;
   skos:prefLabel "Έγγραφο Kugar"@el .
 
-media-type:application_x-kword a skos:Concept ;
-  media-type:hasMediaType "application/x-kword" ;
+mediatype:application_x-kword a skos:Concept ;
+  mediatype:hasMediaType "application/x-kword" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen KWord"@cy ;
   skos:prefLabel "KWord document"@en ;
@@ -1873,16 +1873,16 @@ media-type:application_x-kword a skos:Concept ;
   skos:prefLabel "KWord-dokument"@no ;
   skos:prefLabel "Έγγραφο KWord"@el .
 
-media-type:application_x-kword-crypt a skos:Concept ;
-  media-type:hasMediaType "application/x-kword-crypt" ;
+mediatype:application_x-kword-crypt a skos:Concept ;
+  mediatype:hasMediaType "application/x-kword-crypt" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "KWord document (encrypted)"@en ;
   skos:prefLabel "KWord-Dokument (verschlüsselt)"@de ;
   skos:prefLabel "KWord-asiakirja (salattu)"@fi ;
   skos:prefLabel "KWord-dokument (kryptert)"@no .
 
-media-type:application_x-lha a skos:Concept ;
-  media-type:hasMediaType "application/x-lha" ;
+mediatype:application_x-lha a skos:Concept ;
+  mediatype:hasMediaType "application/x-lha" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif LHA"@cy ;
   skos:prefLabel "Archiv LHA"@cs ;
@@ -1899,24 +1899,24 @@ media-type:application_x-lha a skos:Concept ;
   skos:prefLabel "LHA-arkiv"@sv ;
   skos:prefLabel "archive LHA"@fr .
 
-media-type:application_x-lhz a skos:Concept ;
-  media-type:hasMediaType "application/x-lhz" ;
+mediatype:application_x-lhz a skos:Concept ;
+  mediatype:hasMediaType "application/x-lhz" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "LHZ archive"@en ;
   skos:prefLabel "LHZ-Archiv"@de ;
   skos:prefLabel "LHZ-arkisto"@fi ;
   skos:prefLabel "LHZ-arkiv"@no .
 
-media-type:application_x-linguist a skos:Concept ;
-  media-type:hasMediaType "application/x-linguist" ;
+mediatype:application_x-linguist a skos:Concept ;
+  mediatype:hasMediaType "application/x-linguist" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Nachrichtenkatalog"@de ;
   skos:prefLabel "meldingskatalog"@no ;
   skos:prefLabel "message catalog"@en ;
   skos:prefLabel "viestiluettelo"@fi .
 
-media-type:application_x-lyx a skos:Concept ;
-  media-type:hasMediaType "application/x-lyx" ;
+mediatype:application_x-lyx a skos:Concept ;
+  mediatype:hasMediaType "application/x-lyx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "LyX document"@en ;
   skos:prefLabel "LyX-Dokument"@de ;
@@ -1925,25 +1925,25 @@ media-type:application_x-lyx a skos:Concept ;
   skos:prefLabel "LyX-dokument"@sv ;
   skos:prefLabel "Έγγραφο LyX "@el .
 
-media-type:application_x-lzop a skos:Concept ;
-  media-type:hasMediaType "application/x-lzop" ;
+mediatype:application_x-lzop a skos:Concept ;
+  mediatype:hasMediaType "application/x-lzop" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "LZO archive"@en ;
   skos:prefLabel "LZO-Archiv"@de ;
   skos:prefLabel "LZO-arkisto"@fi ;
   skos:prefLabel "LZO-arkiv"@no .
 
-media-type:application_x-macbinary a skos:Concept ;
-  media-type:hasMediaType "application/x-macbinary" ;
+mediatype:application_x-macbinary a skos:Concept ;
+  mediatype:hasMediaType "application/x-macbinary" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MacBinary-tiedosto"@fi ;
   skos:prefLabel "Macintosh MacBinary file"@en ;
   skos:prefLabel "Macintosh MacBinary-fil"@no ;
   skos:prefLabel "Macintosh-MacBinary-Datei"@de .
 
-media-type:application_x-magicpoint a skos:Concept ;
-  media-type:hasMediaType "application/x-magicpoint" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-magicpoint a skos:Concept ;
+  mediatype:hasMediaType "application/x-magicpoint" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Cyflwyniad MagicPoint"@cy ;
   skos:prefLabel "MagicPoint presentation"@en ;
@@ -1955,8 +1955,8 @@ media-type:application_x-magicpoint a skos:Concept ;
   skos:prefLabel "MagicPoint-presentation"@sv ;
   skos:prefLabel "Παρουσίαση MagicPoint"@el .
 
-media-type:application_x-matroska a skos:Concept ;
-  media-type:hasMediaType "application/x-matroska" ;
+mediatype:application_x-matroska a skos:Concept ;
+  mediatype:hasMediaType "application/x-matroska" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Matroska video"@en ;
   skos:prefLabel "Matroska-Video"@de ;
@@ -1964,8 +1964,8 @@ media-type:application_x-matroska a skos:Concept ;
   skos:prefLabel "Matroska-video"@fi ;
   skos:prefLabel "Βίντεο Matroska"@el .
 
-media-type:application_x-mif a skos:Concept ;
-  media-type:hasMediaType "application/x-mif" ;
+mediatype:application_x-mif a skos:Concept ;
+  mediatype:hasMediaType "application/x-mif" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "FrameMaker MIF document"@en ;
   skos:prefLabel "FrameMaker MIF-dokument"@no ;
@@ -1973,8 +1973,8 @@ media-type:application_x-mif a skos:Concept ;
   skos:prefLabel "FrameMaker-välitysasiakirja"@fi ;
   skos:prefLabel "Έγγραφο FrameMaker MIF"@el .
 
-media-type:application_x-mozilla-bookmarks a skos:Concept ;
-  media-type:hasMediaType "application/x-mozilla-bookmarks" ;
+mediatype:application_x-mozilla-bookmarks a skos:Concept ;
+  mediatype:hasMediaType "application/x-mozilla-bookmarks" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Mozilla bookmarks"@en ;
   skos:prefLabel "Mozilla-Lesezeichen"@de ;
@@ -1982,8 +1982,8 @@ media-type:application_x-mozilla-bookmarks a skos:Concept ;
   skos:prefLabel "Mozilla-kirjanmerkit"@fi ;
   skos:prefLabel "Σελιδοδείκτες Mozilla"@el .
 
-media-type:application_x-ms-dos-executable a skos:Concept ;
-  media-type:hasMediaType "application/x-ms-dos-executable" ;
+mediatype:application_x-ms-dos-executable a skos:Concept ;
+  mediatype:hasMediaType "application/x-ms-dos-executable" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DOS/Windows executable"@en ;
   skos:prefLabel "DOS/Windows suoritettava ohjema"@fi ;
@@ -1991,12 +1991,12 @@ media-type:application_x-ms-dos-executable a skos:Concept ;
   skos:prefLabel "Kjørbar fil for DOS/Windows"@no ;
   skos:prefLabel "Εκτελέσιμο DOS/Windows"@el .
 
-media-type:application_x-mswinurl a skos:Concept ;
-  media-type:hasMediaType "application/x-mswinurl" ;
+mediatype:application_x-mswinurl a skos:Concept ;
+  mediatype:hasMediaType "application/x-mswinurl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-mswrite a skos:Concept ;
-  media-type:hasMediaType "application/x-mswrite" ;
+mediatype:application_x-mswrite a skos:Concept ;
+  mediatype:hasMediaType "application/x-mswrite" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Microsoft Write"@cy ;
   skos:prefLabel "Dokument Microsoft Write"@cs ;
@@ -2014,8 +2014,8 @@ media-type:application_x-mswrite a skos:Concept ;
   skos:prefLabel "Микрософт документ Писанке"@sr ;
   skos:prefLabel "마이크로소프트 워드패드 문서"@ko .
 
-media-type:application_x-msx-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-msx-rom" ;
+mediatype:application_x-msx-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-msx-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MSX ROM"@el ;
   skos:prefLabel "MSX ROM"@en ;
@@ -2027,8 +2027,8 @@ media-type:application_x-msx-rom a skos:Concept ;
   skos:prefLabel "MSX-rom"@sv ;
   skos:prefLabel "ROM MSX"@cy .
 
-media-type:application_x-n64-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-n64-rom" ;
+mediatype:application_x-n64-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-n64-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Nintendo64 ROM"@el ;
   skos:prefLabel "Nintendo64 ROM"@en ;
@@ -2036,9 +2036,9 @@ media-type:application_x-n64-rom a skos:Concept ;
   skos:prefLabel "Nintendo64-ROM"@fi ;
   skos:prefLabel "Nintendo64-ROM"@no .
 
-media-type:application_x-nautilus-link a skos:Concept ;
-  media-type:hasMediaType "application/x-nautilus-link" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-nautilus-link a skos:Concept ;
+  mediatype:hasMediaType "application/x-nautilus-link" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Cyswllt Nautilus"@cy ;
   skos:prefLabel "Nautilus koppeling"@nl ;
@@ -2056,8 +2056,8 @@ media-type:application_x-nautilus-link a skos:Concept ;
   skos:prefLabel "Наутилус веза"@sr ;
   skos:prefLabel "노틸러스 링크"@ko .
 
-media-type:application_x-nes-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-nes-rom" ;
+mediatype:application_x-nes-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-nes-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "NES ROM"@el ;
   skos:prefLabel "NES ROM"@en ;
@@ -2069,17 +2069,17 @@ media-type:application_x-nes-rom a skos:Concept ;
   skos:prefLabel "NES-rom"@sv ;
   skos:prefLabel "ROM NES"@cy .
 
-media-type:application_x-netcdf a skos:Concept ;
-  media-type:hasMediaType "application/x-netcdf" ;
+mediatype:application_x-netcdf a skos:Concept ;
+  mediatype:hasMediaType "application/x-netcdf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Unidata NetCDF document"@en ;
   skos:prefLabel "Unidata NetCDF-dokument"@no ;
   skos:prefLabel "Unidata netCDF -asiakirja"@fi ;
   skos:prefLabel "Unidata-NetCDF-Dokument"@de .
 
-media-type:application_x-netscape-bookmarks a skos:Concept ;
-  media-type:hasMediaType "application/x-netscape-bookmarks" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-netscape-bookmarks a skos:Concept ;
+  mediatype:hasMediaType "application/x-netscape-bookmarks" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Netscape bookmarks"@en ;
   skos:prefLabel "Netscape-Lesezeichen"@de ;
@@ -2087,23 +2087,23 @@ media-type:application_x-netscape-bookmarks a skos:Concept ;
   skos:prefLabel "Netscape-kirjanmerkit"@fi ;
   skos:prefLabel "Σελιδοδείκτες Netscape"@el .
 
-media-type:application_x-object a skos:Concept ;
-  media-type:hasMediaType "application/x-object" ;
+mediatype:application_x-object a skos:Concept ;
+  mediatype:hasMediaType "application/x-object" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Objekt-Code"@de ;
   skos:prefLabel "object code"@en ;
   skos:prefLabel "objektikoodi"@fi ;
   skos:prefLabel "objektkode"@no .
 
-media-type:application_x-ole-storage a skos:Concept ;
-  media-type:hasMediaType "application/x-ole-storage" ;
+mediatype:application_x-ole-storage a skos:Concept ;
+  mediatype:hasMediaType "application/x-ole-storage" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "OLE2 compound document storage"@en ;
   skos:prefLabel "OLE2-Verbunddokumentenspeicher"@de ;
   skos:prefLabel "OLE2-yhdisteasiakirja"@fi .
 
-media-type:application_x-oleo a skos:Concept ;
-  media-type:hasMediaType "application/x-oleo" ;
+mediatype:application_x-oleo a skos:Concept ;
+  mediatype:hasMediaType "application/x-oleo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GNU Oleo -taulukko"@fi ;
   skos:prefLabel "GNU Oleo regneark"@no ;
@@ -2111,8 +2111,8 @@ media-type:application_x-oleo a skos:Concept ;
   skos:prefLabel "GNU-Oleo-Tabellendokument"@de ;
   skos:prefLabel "Λογιστικό φύλλο GNU Oleo"@el .
 
-media-type:application_x-palm-database a skos:Concept ;
-  media-type:hasMediaType "application/x-palm-database" ;
+mediatype:application_x-palm-database a skos:Concept ;
+  mediatype:hasMediaType "application/x-palm-database" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Cronfa Ddata Palm OS"@cy ;
   skos:prefLabel "Databáze Palm OS"@cs ;
@@ -2130,8 +2130,8 @@ media-type:application_x-palm-database a skos:Concept ;
   skos:prefLabel "Βάση δεδομένων Palm OS"@el ;
   skos:prefLabel "팜OS 데이터베이스"@ko .
 
-media-type:application_x-pef-executable a skos:Concept ;
-  media-type:hasMediaType "application/x-pef-executable" ;
+mediatype:application_x-pef-executable a skos:Concept ;
+  mediatype:hasMediaType "application/x-pef-executable" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PEF executable"@en ;
   skos:prefLabel "PEF suoritettava ohjelma"@fi ;
@@ -2139,9 +2139,9 @@ media-type:application_x-pef-executable a skos:Concept ;
   skos:prefLabel "PEF-kjørbar"@no ;
   skos:prefLabel "εκτελέσιμο PEF"@el .
 
-media-type:application_x-perl a skos:Concept ;
-  media-type:hasMediaType "application/x-perl" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-perl a skos:Concept ;
+  mediatype:hasMediaType "application/x-perl" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Perl script"@en ;
   skos:prefLabel "Perl skript"@nn ;
@@ -2153,9 +2153,9 @@ media-type:application_x-perl a skos:Concept ;
   skos:prefLabel "Sgript Perl"@cy ;
   skos:prefLabel "Πρόγραμμα εντολών Perl"@el .
 
-media-type:application_x-php a skos:Concept ;
-  media-type:hasMediaType "application/x-php" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-php a skos:Concept ;
+  mediatype:hasMediaType "application/x-php" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PHP script"@en ;
   skos:prefLabel "PHP script"@nl ;
@@ -2173,17 +2173,17 @@ media-type:application_x-php a skos:Concept ;
   skos:prefLabel "script PHP"@fr ;
   skos:prefLabel "Πρόγραμμα εντολών PHP"@el .
 
-media-type:application_x-pkcs12 a skos:Concept ;
-  media-type:hasMediaType "application/x-pkcs12" ;
+mediatype:application_x-pkcs12 a skos:Concept ;
+  mediatype:hasMediaType "application/x-pkcs12" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PKCS#12 certificate bundle"@en ;
   skos:prefLabel "PKCS#12 sertifikathaug"@no ;
   skos:prefLabel "PKCS#12-Zertifikatspaket"@de ;
   skos:prefLabel "PKCS#12-varmennenippu"@fi .
 
-media-type:application_x-profile a skos:Concept ;
-  media-type:hasMediaType "application/x-profile" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-profile a skos:Concept ;
+  mediatype:hasMediaType "application/x-profile" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Profiler-Ergebnisse"@de ;
   skos:prefLabel "Výsledky profileru"@cs ;
@@ -2200,17 +2200,17 @@ media-type:application_x-profile a skos:Concept ;
   skos:prefLabel "резултати профилатора"@sr ;
   skos:prefLabel "프로파일러 결과"@ko .
 
-media-type:application_x-pw a skos:Concept ;
-  media-type:hasMediaType "application/x-pw" ;
+mediatype:application_x-pw a skos:Concept ;
+  mediatype:hasMediaType "application/x-pw" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Pathetic Writer -asiakirja"@fi ;
   skos:prefLabel "Pathetic Writer document"@en ;
   skos:prefLabel "Pathetic Writer-Dokument"@de ;
   skos:prefLabel "Pathetic Writer-dokument"@no .
 
-media-type:application_x-python a skos:Concept ;
-  media-type:hasMediaType "application/x-python" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-python a skos:Concept ;
+  mediatype:hasMediaType "application/x-python" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Python script"@en ;
   skos:prefLabel "Python-Skript"@de ;
@@ -2219,8 +2219,8 @@ media-type:application_x-python a skos:Concept ;
   skos:prefLabel "Pythonskript"@sv ;
   skos:prefLabel "Πρόγραμμα εντολών Python"@el .
 
-media-type:application_x-python-bytecode a skos:Concept ;
-  media-type:hasMediaType "application/x-python-bytecode" ;
+mediatype:application_x-python-bytecode a skos:Concept ;
+  mediatype:hasMediaType "application/x-python-bytecode" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bajtový kód Python"@cs ;
   skos:prefLabel "Côd beit Python"@cy ;
@@ -2237,8 +2237,8 @@ media-type:application_x-python-bytecode a skos:Concept ;
   skos:prefLabel "Питонов бајт кôд"@sr ;
   skos:prefLabel "파이썬 바이트코드"@ko .
 
-media-type:application_x-quattropro a skos:Concept ;
-  media-type:hasMediaType "application/x-quattropro" ;
+mediatype:application_x-quattropro a skos:Concept ;
+  mediatype:hasMediaType "application/x-quattropro" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Quattro Pro -taulukko"@fi ;
   skos:prefLabel "Quattro Pro spreadsheet"@en ;
@@ -2246,8 +2246,8 @@ media-type:application_x-quattropro a skos:Concept ;
   skos:prefLabel "Quattro Pro-regneark"@no ;
   skos:prefLabel "Λογιστικό φύλλο Quattro Pro"@el .
 
-media-type:application_x-qw a skos:Concept ;
-  media-type:hasMediaType "application/x-qw" ;
+mediatype:application_x-qw a skos:Concept ;
+  mediatype:hasMediaType "application/x-qw" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Quicken"@cy ;
   skos:prefLabel "Dokument Quicken"@cs ;
@@ -2265,8 +2265,8 @@ media-type:application_x-qw a skos:Concept ;
   skos:prefLabel "document Quicken"@fr ;
   skos:prefLabel "Έγγραφο Quicken"@el .
 
-media-type:application_x-rar a skos:Concept ;
-  media-type:hasMediaType "application/x-rar" ;
+mediatype:application_x-rar a skos:Concept ;
+  mediatype:hasMediaType "application/x-rar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif RAR"@cy ;
   skos:prefLabel "RAR archive"@en ;
@@ -2278,17 +2278,17 @@ media-type:application_x-rar a skos:Concept ;
   skos:prefLabel "Αρχείο RAR"@el ;
   skos:prefLabel "РАР архива"@sr .
 
-media-type:application_x-reject a skos:Concept ;
-  media-type:hasMediaType "application/x-reject" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-reject a skos:Concept ;
+  mediatype:hasMediaType "application/x-reject" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "abgelehnter Patch"@de ;
   skos:prefLabel "avvist patchfil"@no ;
   skos:prefLabel "hylättyjen muutosten tiedosto"@fi ;
   skos:prefLabel "rejected patch"@en .
 
-media-type:application_x-rpm a skos:Concept ;
-  media-type:hasMediaType "application/x-rpm" ;
+mediatype:application_x-rpm a skos:Concept ;
+  mediatype:hasMediaType "application/x-rpm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "RPM package"@en ;
   skos:prefLabel "RPM-Paket"@de ;
@@ -2297,9 +2297,9 @@ media-type:application_x-rpm a skos:Concept ;
   skos:prefLabel "RPM-pakke"@no ;
   skos:prefLabel "Πακέτο RPM"@el .
 
-media-type:application_x-ruby a skos:Concept ;
-  media-type:hasMediaType "application/x-ruby" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-ruby a skos:Concept ;
+  mediatype:hasMediaType "application/x-ruby" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ruby script"@en ;
   skos:prefLabel "Ruby-Skript"@de ;
@@ -2307,13 +2307,13 @@ media-type:application_x-ruby a skos:Concept ;
   skos:prefLabel "Ruby-skripti"@fi ;
   skos:prefLabel "Πρόγραμμα εντολών Ruby"@el .
 
-media-type:application_x-sc a skos:Concept ;
-  media-type:hasMediaType "application/x-sc" ;
+mediatype:application_x-sc a skos:Concept ;
+  mediatype:hasMediaType "application/x-sc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:application_x-shar a skos:Concept ;
-  media-type:hasMediaType "application/x-shar" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-shar a skos:Concept ;
+  mediatype:hasMediaType "application/x-shar" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archiv shellu"@cs ;
   skos:prefLabel "Shell-Archiv"@de ;
@@ -2330,16 +2330,16 @@ media-type:application_x-shar a skos:Concept ;
   skos:prefLabel "Архива љуске (SHAR)"@sr ;
   skos:prefLabel "쉘 아카이브"@ko .
 
-media-type:application_x-shared-library-la a skos:Concept ;
-  media-type:hasMediaType "application/x-shared-library-la" ;
+mediatype:application_x-shared-library-la a skos:Concept ;
+  mediatype:hasMediaType "application/x-shared-library-la" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "delt bibliotek (la)"@no ;
   skos:prefLabel "gemeinsame Bibliothek (la)"@de ;
   skos:prefLabel "jaettu kirjasto (la)"@fi ;
   skos:prefLabel "shared library (la)"@en .
 
-media-type:application_x-sharedlib a skos:Concept ;
-  media-type:hasMediaType "application/x-sharedlib" ;
+mediatype:application_x-sharedlib a skos:Concept ;
+  mediatype:hasMediaType "application/x-sharedlib" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sdílená knihovna"@cs ;
   skos:prefLabel "bölüşülmüş kitabxana"@az ;
@@ -2356,9 +2356,9 @@ media-type:application_x-sharedlib a skos:Concept ;
   skos:prefLabel "дељена библиотека"@sr ;
   skos:prefLabel "공유 라이브러리"@ko .
 
-media-type:application_x-shellscript a skos:Concept ;
-  media-type:hasMediaType "application/x-shellscript" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-shellscript a skos:Concept ;
+  mediatype:hasMediaType "application/x-shellscript" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Shell-Skript"@de ;
   skos:prefLabel "Skript shellu"@cs ;
@@ -2375,8 +2375,8 @@ media-type:application_x-shellscript a skos:Concept ;
   skos:prefLabel "скрипта љуске"@sr ;
   skos:prefLabel "쉘 스크립트"@ko .
 
-media-type:application_x-shockwave-flash a skos:Concept ;
-  media-type:hasMediaType "application/x-shockwave-flash" ;
+mediatype:application_x-shockwave-flash a skos:Concept ;
+  mediatype:hasMediaType "application/x-shockwave-flash" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Shockwave Flash -media"@fi ;
   skos:prefLabel "Shockwave Flash file"@en ;
@@ -2384,8 +2384,8 @@ media-type:application_x-shockwave-flash a skos:Concept ;
   skos:prefLabel "Shockwave Flash-fil"@no ;
   skos:prefLabel "Αρχείο Shockwave Flash"@el .
 
-media-type:application_x-siag a skos:Concept ;
-  media-type:hasMediaType "application/x-siag" ;
+mediatype:application_x-siag a skos:Concept ;
+  mediatype:hasMediaType "application/x-siag" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Siag spreadsheet"@en ;
   skos:prefLabel "Siag-kalkylblad"@sv ;
@@ -2394,8 +2394,8 @@ media-type:application_x-siag a skos:Concept ;
   skos:prefLabel "Slag-Tabellendokument"@de ;
   skos:prefLabel "Λογιστικό φύλλο Siag"@el .
 
-media-type:application_x-slp a skos:Concept ;
-  media-type:hasMediaType "application/x-slp" ;
+mediatype:application_x-slp a skos:Concept ;
+  mediatype:hasMediaType "application/x-slp" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Balíček Stampede"@cs ;
   skos:prefLabel "Pecyn Stampede"@cy ;
@@ -2413,16 +2413,16 @@ media-type:application_x-slp a skos:Concept ;
   skos:prefLabel "package Stampede"@fr ;
   skos:prefLabel "Πακέτο Stampede"@el .
 
-media-type:application_x-sms-rom a skos:Concept ;
-  media-type:hasMediaType "application/x-sms-rom" ;
+mediatype:application_x-sms-rom a skos:Concept ;
+  mediatype:hasMediaType "application/x-sms-rom" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "SMS- tai Game Gear -ROM"@fi ;
   skos:prefLabel "SMS/Game Gear ROM"@en ;
   skos:prefLabel "SMS/Game Gear-ROM"@de ;
   skos:prefLabel "SMS/Game Gear-ROM"@no .
 
-media-type:application_x-stuffit a skos:Concept ;
-  media-type:hasMediaType "application/x-stuffit" ;
+mediatype:application_x-stuffit a skos:Concept ;
+  mediatype:hasMediaType "application/x-stuffit" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif Macintosh StuffIt"@cy ;
   skos:prefLabel "Archiv Macintosh StuffIt"@cs ;
@@ -2439,8 +2439,8 @@ media-type:application_x-stuffit a skos:Concept ;
   skos:prefLabel "Мекинтош StuffIt архива"@sr ;
   skos:prefLabel "맥킨토시 StuffIt 아카이브"@ko .
 
-media-type:application_x-sv4cpio a skos:Concept ;
-  media-type:hasMediaType "application/x-sv4cpio" ;
+mediatype:application_x-sv4cpio a skos:Concept ;
+  mediatype:hasMediaType "application/x-sv4cpio" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO SV4"@cy ;
   skos:prefLabel "Archiv SV4 CPIO"@cs ;
@@ -2457,8 +2457,8 @@ media-type:application_x-sv4cpio a skos:Concept ;
   skos:prefLabel "SV4-CPIO-Archiv"@de ;
   skos:prefLabel "archive SV4 CPIO"@fr .
 
-media-type:application_x-sv4crc a skos:Concept ;
-  media-type:hasMediaType "application/x-sv4crc" ;
+mediatype:application_x-sv4crc a skos:Concept ;
+  mediatype:hasMediaType "application/x-sv4crc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "(CRC를 가지는) SV4 CPIP 아카이브"@ko ;
   skos:prefLabel "Archif CPIP SV4 (efo CRC)"@cy ;
@@ -2475,40 +2475,40 @@ media-type:application_x-sv4crc a skos:Concept ;
   skos:prefLabel "SV4-CPIP-Archiv (mit CRC)"@de ;
   skos:prefLabel "archive SV4 CPIP (avec CRC)"@fr .
 
-media-type:application_x-tar a skos:Concept ;
-  media-type:hasMediaType "application/x-tar" ;
+mediatype:application_x-tar a skos:Concept ;
+  mediatype:hasMediaType "application/x-tar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tar archive"@en ;
   skos:prefLabel "tar-Archiv"@de ;
   skos:prefLabel "tar-arkisto"@fi ;
   skos:prefLabel "tar-arkiv"@no .
 
-media-type:application_x-tarz a skos:Concept ;
-  media-type:hasMediaType "application/x-tarz" ;
+mediatype:application_x-tarz a skos:Concept ;
+  mediatype:hasMediaType "application/x-tarz" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tar archive (compressed)"@en ;
   skos:prefLabel "tar-Archiv (komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (pakattu)"@fi ;
   skos:prefLabel "tar-arkiv (komprimert)"@no .
 
-media-type:application_x-tex-gf a skos:Concept ;
-  media-type:hasMediaType "application/x-tex-gf" ;
+mediatype:application_x-tex-gf a skos:Concept ;
+  mediatype:hasMediaType "application/x-tex-gf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "generic font file"@en ;
   skos:prefLabel "generische Schriftdatei"@de ;
   skos:prefLabel "vanlig skriftfil"@no ;
   skos:prefLabel "yleiset kirjasintiedostot"@fi .
 
-media-type:application_x-tex-pk a skos:Concept ;
-  media-type:hasMediaType "application/x-tex-pk" ;
+mediatype:application_x-tex-pk a skos:Concept ;
+  mediatype:hasMediaType "application/x-tex-pk" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "gepackte Schriftdatei"@de ;
   skos:prefLabel "packed font file"@en ;
   skos:prefLabel "pakattu kirjasintiedosto"@fi ;
   skos:prefLabel "pakket skriftfil"@no .
 
-media-type:application_x-tgif a skos:Concept ;
-  media-type:hasMediaType "application/x-tgif" ;
+mediatype:application_x-tgif a skos:Concept ;
+  mediatype:hasMediaType "application/x-tgif" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "TGIF document"@en ;
   skos:prefLabel "TGIF-Dokument"@de ;
@@ -2517,9 +2517,9 @@ media-type:application_x-tgif a skos:Concept ;
   skos:prefLabel "TGIF-dokument"@sv ;
   skos:prefLabel "Έγγραφο TGIF"@el .
 
-media-type:application_x-theme a skos:Concept ;
-  media-type:hasMediaType "application/x-theme" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-theme a skos:Concept ;
+  mediatype:hasMediaType "application/x-theme" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Thema"@de ;
   skos:prefLabel "Téma"@cs ;
@@ -2537,8 +2537,8 @@ media-type:application_x-theme a skos:Concept ;
   skos:prefLabel "тема"@sr ;
   skos:prefLabel "테마"@ko .
 
-media-type:application_x-toutdoux a skos:Concept ;
-  media-type:hasMediaType "application/x-toutdoux" ;
+mediatype:application_x-toutdoux a skos:Concept ;
+  mediatype:hasMediaType "application/x-toutdoux" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen ToutDoux"@cy ;
   skos:prefLabel "Dokument ToutDoux"@cs ;
@@ -2556,17 +2556,17 @@ media-type:application_x-toutdoux a skos:Concept ;
   skos:prefLabel "document ToutDoux"@fr ;
   skos:prefLabel "Έγγραφο ToutDoux"@el .
 
-media-type:application_x-trash a skos:Concept ;
-  media-type:hasMediaType "application/x-trash" ;
+mediatype:application_x-trash a skos:Concept ;
+  mediatype:hasMediaType "application/x-trash" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sicherungsdatei"@de ;
   skos:prefLabel "backup file"@en ;
   skos:prefLabel "sikkerhetskopi"@no ;
   skos:prefLabel "varmuuskopio"@fi .
 
-media-type:application_x-troff a skos:Concept ;
-  media-type:hasMediaType "application/x-troff" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-troff a skos:Concept ;
+  mediatype:hasMediaType "application/x-troff" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen troff"@cy ;
   skos:prefLabel "Dokument troff"@cs ;
@@ -2584,16 +2584,16 @@ media-type:application_x-troff a skos:Concept ;
   skos:prefLabel "document Troff"@fr ;
   skos:prefLabel "Έγγραφο Troff"@el .
 
-media-type:application_x-troff-man a skos:Concept ;
-  media-type:hasMediaType "application/x-troff-man" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-troff-man a skos:Concept ;
+  mediatype:hasMediaType "application/x-troff-man" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Troff document (with manpage macros)"@en ;
   skos:prefLabel "Troff-Dokument (mit man-Seitenmakros)"@de ;
   skos:prefLabel "Troff-asiakirja man-sivu-makroilla"@fi .
 
-media-type:application_x-troff-man-compressed a skos:Concept ;
-  media-type:hasMediaType "application/x-troff-man-compressed" ;
+mediatype:application_x-troff-man-compressed a skos:Concept ;
+  mediatype:hasMediaType "application/x-troff-man-compressed" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "(압축된) 설명서 페이지"@ko ;
   skos:prefLabel "Handbuchseite (komprimiert)"@de ;
@@ -2610,16 +2610,16 @@ media-type:application_x-troff-man-compressed a skos:Concept ;
   skos:prefLabel "tudalen llawlyfr (wedi ei gywasgu)"@cy ;
   skos:prefLabel "страна упутства (компресована)"@sr .
 
-media-type:application_x-tzo a skos:Concept ;
-  media-type:hasMediaType "application/x-tzo" ;
+mediatype:application_x-tzo a skos:Concept ;
+  mediatype:hasMediaType "application/x-tzo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "tar archive (LZO-compressed)"@en ;
   skos:prefLabel "tar-Archiv (LZO-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (LZO-pakattu)"@fi ;
   skos:prefLabel "tar-arkiv (LZO-komprimert)"@no .
 
-media-type:application_x-ustar a skos:Concept ;
-  media-type:hasMediaType "application/x-ustar" ;
+mediatype:application_x-ustar a skos:Concept ;
+  mediatype:hasMediaType "application/x-ustar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Archiv ustar"@cs ;
   skos:prefLabel "Ustar 아카이브"@ko ;
@@ -2636,8 +2636,8 @@ media-type:application_x-ustar a skos:Concept ;
   skos:prefLabel "ustar-arkiv"@no ;
   skos:prefLabel "ustar-arkiv"@sv .
 
-media-type:application_x-wais-source a skos:Concept ;
-  media-type:hasMediaType "application/x-wais-source" ;
+mediatype:application_x-wais-source a skos:Concept ;
+  mediatype:hasMediaType "application/x-wais-source" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Rhaglen WAIS"@cy ;
   skos:prefLabel "WAIS broncode"@nl ;
@@ -2655,25 +2655,25 @@ media-type:application_x-wais-source a skos:Concept ;
   skos:prefLabel "code source WAIS"@fr ;
   skos:prefLabel "Πηγαίος κώδικας WAIS"@el .
 
-media-type:application_x-wpg a skos:Concept ;
-  media-type:hasMediaType "application/x-wpg" ;
+mediatype:application_x-wpg a skos:Concept ;
+  mediatype:hasMediaType "application/x-wpg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "WordPerfect- tai DrawPerfect -kuva"@fi ;
   skos:prefLabel "WordPerfect/DrawPerfect-Bild"@de ;
   skos:prefLabel "WordPerfect/Drawperfect image"@en ;
   skos:prefLabel "Εικόνα WordPerfect/Drawperfect"@el .
 
-media-type:application_x-x509-ca-cert a skos:Concept ;
-  media-type:hasMediaType "application/x-x509-ca-cert" ;
+mediatype:application_x-x509-ca-cert a skos:Concept ;
+  mediatype:hasMediaType "application/x-x509-ca-cert" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DER-, PEM- tai Netscape-koodattu X.509-varmenne"@fi ;
   skos:prefLabel "DER/PEM/Netscape-encoded X.509 certificate"@en ;
   skos:prefLabel "DER/PEM/Netscape-kodet X.509-sertifikat"@no ;
   skos:prefLabel "DER/PEM/Netscape-kodiertes X.509-Zertifikat"@de .
 
-media-type:application_x-xbel a skos:Concept ;
-  media-type:hasMediaType "application/x-xbel" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_x-xbel a skos:Concept ;
+  mediatype:hasMediaType "application/x-xbel" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "XBEL bookmarks"@en ;
   skos:prefLabel "XBEL-Lesezeichen"@de ;
@@ -2681,8 +2681,8 @@ media-type:application_x-xbel a skos:Concept ;
   skos:prefLabel "XBEL-kirjanmerkit"@fi ;
   skos:prefLabel "Σελιδοδείκτες XBEL"@el .
 
-media-type:application_x-zerosize a skos:Concept ;
-  media-type:hasMediaType "application/x-zerosize" ;
+mediatype:application_x-zerosize a skos:Concept ;
+  mediatype:hasMediaType "application/x-zerosize" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "empty document"@en ;
   skos:prefLabel "leeres Dokument"@de ;
@@ -2690,17 +2690,17 @@ media-type:application_x-zerosize a skos:Concept ;
   skos:prefLabel "tomt dokument"@sv ;
   skos:prefLabel "tyhjä asiakirja"@fi .
 
-media-type:application_x-zoo a skos:Concept ;
-  media-type:hasMediaType "application/x-zoo" ;
+mediatype:application_x-zoo a skos:Concept ;
+  mediatype:hasMediaType "application/x-zoo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "zoo archive"@en ;
   skos:prefLabel "zoo-Archiv"@de ;
   skos:prefLabel "zoo-arkisto"@fi ;
   skos:prefLabel "zoo-arkiv"@no .
 
-media-type:application_xhtmlxml a skos:Concept ;
-  media-type:hasMediaType "application/xhtml+xml" ;
-  skos:broader media-type:text_plain ;
+mediatype:application_xhtmlxml a skos:Concept ;
+  mediatype:hasMediaType "application/xhtml+xml" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "XHTML page"@en ;
   skos:prefLabel "XHTML-Seite"@de ;
@@ -2709,46 +2709,46 @@ media-type:application_xhtmlxml a skos:Concept ;
   skos:prefLabel "XHTML-sivu"@fi ;
   skos:prefLabel "Σελίδα XHTML"@el .
 
-media-type:application_zip a skos:Concept ;
-  media-type:hasMediaType "application/zip" ;
+mediatype:application_zip a skos:Concept ;
+  mediatype:hasMediaType "application/zip" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "ZIP archive"@en ;
   skos:prefLabel "ZIP-Archiv"@de ;
   skos:prefLabel "ZIP-arkisto"@fi ;
   skos:prefLabel "ZIP-arkiv"@no .
 
-media-type:audio a skos:Collection ;
+mediatype:audio a skos:Collection ;
   rdfs:label "Audio types"@en ;
   dct:description "The collection of audio types"@en ;
   dct:title "Audio types"@en ;
-  skos:member media-type:audio_ac3 ;
-  skos:member media-type:audio_basic ;
-  skos:member media-type:audio_midi ;
-  skos:member media-type:audio_prssid ;
-  skos:member media-type:audio_x-adpcm ;
-  skos:member media-type:audio_x-aifc ;
-  skos:member media-type:audio_x-aiff ;
-  skos:member media-type:audio_x-aiffc ;
-  skos:member media-type:audio_x-flac ;
-  skos:member media-type:audio_x-it ;
-  skos:member media-type:audio_x-mod ;
-  skos:member media-type:audio_x-mp3 ;
-  skos:member media-type:audio_x-mp3-playlist ;
-  skos:member media-type:audio_x-mpeg ;
-  skos:member media-type:audio_x-mpegurl ;
-  skos:member media-type:audio_x-ms-asx ;
-  skos:member media-type:audio_x-pn-realaudio ;
-  skos:member media-type:audio_x-riff ;
-  skos:member media-type:audio_x-s3m ;
-  skos:member media-type:audio_x-scpls ;
-  skos:member media-type:audio_x-stm ;
-  skos:member media-type:audio_x-voc ;
-  skos:member media-type:audio_x-wav ;
-  skos:member media-type:audio_x-xi ;
-  skos:member media-type:audio_x-xm .
+  skos:member mediatype:audio_ac3 ;
+  skos:member mediatype:audio_basic ;
+  skos:member mediatype:audio_midi ;
+  skos:member mediatype:audio_prssid ;
+  skos:member mediatype:audio_x-adpcm ;
+  skos:member mediatype:audio_x-aifc ;
+  skos:member mediatype:audio_x-aiff ;
+  skos:member mediatype:audio_x-aiffc ;
+  skos:member mediatype:audio_x-flac ;
+  skos:member mediatype:audio_x-it ;
+  skos:member mediatype:audio_x-mod ;
+  skos:member mediatype:audio_x-mp3 ;
+  skos:member mediatype:audio_x-mp3-playlist ;
+  skos:member mediatype:audio_x-mpeg ;
+  skos:member mediatype:audio_x-mpegurl ;
+  skos:member mediatype:audio_x-ms-asx ;
+  skos:member mediatype:audio_x-pn-realaudio ;
+  skos:member mediatype:audio_x-riff ;
+  skos:member mediatype:audio_x-s3m ;
+  skos:member mediatype:audio_x-scpls ;
+  skos:member mediatype:audio_x-stm ;
+  skos:member mediatype:audio_x-voc ;
+  skos:member mediatype:audio_x-wav ;
+  skos:member mediatype:audio_x-xi ;
+  skos:member mediatype:audio_x-xm .
 
-media-type:audio_ac3 a skos:Concept ;
-  media-type:hasMediaType "audio/ac3" ;
+mediatype:audio_ac3 a skos:Concept ;
+  mediatype:hasMediaType "audio/ac3" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dolby Digital -ääni"@fi ;
   skos:prefLabel "Dolby Digital audio"@az ;
@@ -2766,8 +2766,8 @@ media-type:audio_ac3 a skos:Concept ;
   skos:prefLabel "Дигитални Dolby звучни запис"@sr ;
   skos:prefLabel "돌비 디지털 오디오"@ko .
 
-media-type:audio_basic a skos:Concept ;
-  media-type:hasMediaType "audio/basic" ;
+mediatype:audio_basic a skos:Concept ;
+  mediatype:hasMediaType "audio/basic" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sain ULAW (Sun)"@cy ;
   skos:prefLabel "ULAW (Sun) -ääni"@fi ;
@@ -2784,9 +2784,9 @@ media-type:audio_basic a skos:Concept ;
   skos:prefLabel "ULAW-lyd (Sun)"@no ;
   skos:prefLabel "Zvuk ULAW (Sun)"@cs .
 
-media-type:audio_midi a skos:Concept ;
-  media-type:hasMediaType "audio/midi" ;
-  skos:exactMatch media-type:audio_x-midi ;
+mediatype:audio_midi a skos:Concept ;
+  mediatype:hasMediaType "audio/midi" ;
+  skos:exactMatch mediatype:audio_x-midi ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MIDI audio faylı"@az ;
   skos:prefLabel "MIDI audio"@en ;
@@ -2804,8 +2804,8 @@ media-type:audio_midi a skos:Concept ;
   skos:prefLabel "Ήχος MIDI"@el ;
   skos:prefLabel "미디 오디오"@ko .
 
-media-type:audio_prssid a skos:Concept ;
-  media-type:hasMediaType "audio/prs.sid" ;
+mediatype:audio_prssid a skos:Concept ;
+  mediatype:hasMediaType "audio/prs.sid" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Commodore 64 -ääni"@fi ;
   skos:prefLabel "Commodore 64 audio"@en ;
@@ -2814,8 +2814,8 @@ media-type:audio_prssid a skos:Concept ;
   skos:prefLabel "Commodore 64-lyd"@no ;
   skos:prefLabel "Ήχος Commodore 64"@el .
 
-media-type:audio_x-adpcm a skos:Concept ;
-  media-type:hasMediaType "audio/x-adpcm" ;
+mediatype:audio_x-adpcm a skos:Concept ;
+  mediatype:hasMediaType "audio/x-adpcm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "PCM audio faylı"@az ;
   skos:prefLabel "PCM audio"@en ;
@@ -2833,8 +2833,8 @@ media-type:audio_x-adpcm a skos:Concept ;
   skos:prefLabel "audio PCM"@fr ;
   skos:prefLabel "Ήχος PCM"@el .
 
-media-type:audio_x-aifc a skos:Concept ;
-  media-type:hasMediaType "audio/x-aifc" ;
+mediatype:audio_x-aifc a skos:Concept ;
+  mediatype:hasMediaType "audio/x-aifc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AIFC audio faylı"@az ;
   skos:prefLabel "AIFC audio"@en ;
@@ -2852,8 +2852,8 @@ media-type:audio_x-aifc a skos:Concept ;
   skos:prefLabel "audio AIFC"@fr ;
   skos:prefLabel "Ήχος AIFC"@el .
 
-media-type:audio_x-aiff a skos:Concept ;
-  media-type:hasMediaType "audio/x-aiff" ;
+mediatype:audio_x-aiff a skos:Concept ;
+  mediatype:hasMediaType "audio/x-aiff" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AIFF/Amiga/Mac audio faylı"@az ;
   skos:prefLabel "AIFF/Amiga/Mac audio"@en ;
@@ -2870,8 +2870,8 @@ media-type:audio_x-aiff a skos:Concept ;
   skos:prefLabel "Zvuk AIFF/Amiga/Mac"@cs ;
   skos:prefLabel "audio AIFF/Amiga/Mac"@fr .
 
-media-type:audio_x-aiffc a skos:Concept ;
-  media-type:hasMediaType "audio/x-aiffc" ;
+mediatype:audio_x-aiffc a skos:Concept ;
+  mediatype:hasMediaType "audio/x-aiffc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AIFF audio faylı"@az ;
   skos:prefLabel "AIFF audio"@en ;
@@ -2889,8 +2889,8 @@ media-type:audio_x-aiffc a skos:Concept ;
   skos:prefLabel "audio AIFF"@fr ;
   skos:prefLabel "Ήχος AIFF"@el .
 
-media-type:audio_x-flac a skos:Concept ;
-  media-type:hasMediaType "audio/x-flac" ;
+mediatype:audio_x-flac a skos:Concept ;
+  mediatype:hasMediaType "audio/x-flac" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "FLAC audio"@en ;
   skos:prefLabel "FLAC-Audio"@de ;
@@ -2898,8 +2898,8 @@ media-type:audio_x-flac a skos:Concept ;
   skos:prefLabel "FLAC-ääni"@fi ;
   skos:prefLabel "Ήχος FLAC"@el .
 
-media-type:audio_x-it a skos:Concept ;
-  media-type:hasMediaType "audio/x-it" ;
+mediatype:audio_x-it a skos:Concept ;
+  mediatype:hasMediaType "audio/x-it" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Impulse Tracker -ääni"@fi ;
   skos:prefLabel "Impulse Tracker audio faylı"@az ;
@@ -2917,16 +2917,16 @@ media-type:audio_x-it a skos:Concept ;
   skos:prefLabel "audio Impulse Tracker"@fr ;
   skos:prefLabel "Ήχος Impulse Tracker"@el .
 
-media-type:audio_x-mod a skos:Concept ;
-  media-type:hasMediaType "audio/x-mod" ;
+mediatype:audio_x-mod a skos:Concept ;
+  mediatype:hasMediaType "audio/x-mod" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Amiga SoundTracker -ääni"@fi ;
   skos:prefLabel "Amiga SoundTracker audio"@en ;
   skos:prefLabel "Amiga SoundTracker-Audio"@de ;
   skos:prefLabel "Amiga SoundTracker-lyd"@no .
 
-media-type:audio_x-mp3 a skos:Concept ;
-  media-type:hasMediaType "audio/x-mp3" ;
+mediatype:audio_x-mp3 a skos:Concept ;
+  mediatype:hasMediaType "audio/x-mp3" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio faylı"@az ;
   skos:prefLabel "MP3 audio"@en ;
@@ -2944,16 +2944,16 @@ media-type:audio_x-mp3 a skos:Concept ;
   skos:prefLabel "audio MP3"@fr ;
   skos:prefLabel "Ήχος MP3"@el .
 
-media-type:audio_x-mp3-playlist a skos:Concept ;
-  media-type:hasMediaType "audio/x-mp3-playlist" ;
+mediatype:audio_x-mp3-playlist a skos:Concept ;
+  mediatype:hasMediaType "audio/x-mp3-playlist" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MP3 playlist"@en ;
   skos:prefLabel "MP3-Wiedergabeliste"@de ;
   skos:prefLabel "MP3-soittolista"@fi ;
   skos:prefLabel "MP3-spilleliste"@no .
 
-media-type:audio_x-mpeg a skos:Concept ;
-  media-type:hasMediaType "audio/x-mpeg" ;
+mediatype:audio_x-mpeg a skos:Concept ;
+  mediatype:hasMediaType "audio/x-mpeg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio faylı"@az ;
   skos:prefLabel "MP3 audio"@en ;
@@ -2971,16 +2971,16 @@ media-type:audio_x-mpeg a skos:Concept ;
   skos:prefLabel "audio MP3"@fr ;
   skos:prefLabel "Ήχος MP3"@el .
 
-media-type:audio_x-mpegurl a skos:Concept ;
-  media-type:hasMediaType "audio/x-mpegurl" ;
+mediatype:audio_x-mpegurl a skos:Concept ;
+  mediatype:hasMediaType "audio/x-mpegurl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio (streamed)"@en ;
   skos:prefLabel "MP3-Audio (Stream)"@de ;
   skos:prefLabel "MP3-lyd (streaming)"@no ;
   skos:prefLabel "MP3-ääni (virtaava)"@fi .
 
-media-type:audio_x-ms-asx a skos:Concept ;
-  media-type:hasMediaType "audio/x-ms-asx" ;
+mediatype:audio_x-ms-asx a skos:Concept ;
+  mediatype:hasMediaType "audio/x-ms-asx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Afspeellijst"@nl ;
   skos:prefLabel "Lejátszható felvételek listája"@hu ;
@@ -2998,9 +2998,9 @@ media-type:audio_x-ms-asx a skos:Concept ;
   skos:prefLabel "Листа нумера"@sr ;
   skos:prefLabel "연주목록"@ko .
 
-media-type:audio_x-pn-realaudio a skos:Concept ;
-  media-type:hasMediaType "audio/x-pn-realaudio" ;
-  skos:exactMatch media-type:audio_vndrn-realaudio ;
+mediatype:audio_x-pn-realaudio a skos:Concept ;
+  mediatype:hasMediaType "audio/x-pn-realaudio" ;
+  skos:exactMatch mediatype:audio_vndrn-realaudio ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Darllediad RealAudio"@cy ;
   skos:prefLabel "RealAudio broadcast"@en ;
@@ -3017,8 +3017,8 @@ media-type:audio_x-pn-realaudio a skos:Concept ;
   skos:prefLabel "diffusion RealAudio"@fr ;
   skos:prefLabel "리얼오디오 방송"@ko .
 
-media-type:audio_x-riff a skos:Concept ;
-  media-type:hasMediaType "audio/x-riff" ;
+mediatype:audio_x-riff a skos:Concept ;
+  mediatype:hasMediaType "audio/x-riff" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "RIFF audio faylı"@az ;
   skos:prefLabel "RIFF audio"@en ;
@@ -3036,8 +3036,8 @@ media-type:audio_x-riff a skos:Concept ;
   skos:prefLabel "audio RIFF"@fr ;
   skos:prefLabel "Ήχος RIFF"@el .
 
-media-type:audio_x-s3m a skos:Concept ;
-  media-type:hasMediaType "audio/x-s3m" ;
+mediatype:audio_x-s3m a skos:Concept ;
+  mediatype:hasMediaType "audio/x-s3m" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sain Scream Tracker 3"@cy ;
   skos:prefLabel "Scream Tracker 3 -ääni"@fi ;
@@ -3055,16 +3055,16 @@ media-type:audio_x-s3m a skos:Concept ;
   skos:prefLabel "aiudio Scream Tracker 3"@fr ;
   skos:prefLabel "Ήχος Scream Tracker 3"@el .
 
-media-type:audio_x-scpls a skos:Concept ;
-  media-type:hasMediaType "audio/x-scpls" ;
+mediatype:audio_x-scpls a skos:Concept ;
+  mediatype:hasMediaType "audio/x-scpls" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MP3 ShoutCast -soittolista"@fi ;
   skos:prefLabel "MP3 ShoutCast playlist"@en ;
   skos:prefLabel "MP3 ShoutCast-spilleliste"@no ;
   skos:prefLabel "MP3-ShoutCast-Wiedergabeliste"@de .
 
-media-type:audio_x-stm a skos:Concept ;
-  media-type:hasMediaType "audio/x-stm" ;
+mediatype:audio_x-stm a skos:Concept ;
+  mediatype:hasMediaType "audio/x-stm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sain Scream Tracker"@cy ;
   skos:prefLabel "Scream Tracker -ääni"@fi ;
@@ -3082,8 +3082,8 @@ media-type:audio_x-stm a skos:Concept ;
   skos:prefLabel "audio Scream Tracker"@fr ;
   skos:prefLabel "Ήχος Scream Tracker"@el .
 
-media-type:audio_x-voc a skos:Concept ;
-  media-type:hasMediaType "audio/x-voc" ;
+mediatype:audio_x-voc a skos:Concept ;
+  mediatype:hasMediaType "audio/x-voc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sain VOC"@cy ;
   skos:prefLabel "VOC audio faylı"@az ;
@@ -3101,8 +3101,8 @@ media-type:audio_x-voc a skos:Concept ;
   skos:prefLabel "audio VOC"@fr ;
   skos:prefLabel "Ήχος VOC"@el .
 
-media-type:audio_x-wav a skos:Concept ;
-  media-type:hasMediaType "audio/x-wav" ;
+mediatype:audio_x-wav a skos:Concept ;
+  mediatype:hasMediaType "audio/x-wav" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Sain WAV"@cy ;
   skos:prefLabel "WAV audio faylı"@az ;
@@ -3120,8 +3120,8 @@ media-type:audio_x-wav a skos:Concept ;
   skos:prefLabel "audio WAV"@fr ;
   skos:prefLabel "Ήχος WAV"@el .
 
-media-type:audio_x-xi a skos:Concept ;
-  media-type:hasMediaType "audio/x-xi" ;
+mediatype:audio_x-xi a skos:Concept ;
+  mediatype:hasMediaType "audio/x-xi" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Nástroj pro Scream Tracker"@cs ;
   skos:prefLabel "Offeryn Scream Tracker"@cy ;
@@ -3139,8 +3139,8 @@ media-type:audio_x-xi a skos:Concept ;
   skos:prefLabel "instrument Scream Tracker"@fr ;
   skos:prefLabel "Μουσικό όργανο Scream Tracker"@el .
 
-media-type:audio_x-xm a skos:Concept ;
-  media-type:hasMediaType "audio/x-xm" ;
+mediatype:audio_x-xm a skos:Concept ;
+  mediatype:hasMediaType "audio/x-xm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "FastTracker II -ääni"@fi ;
   skos:prefLabel "FastTracker II audio faylı"@az ;
@@ -3158,76 +3158,76 @@ media-type:audio_x-xm a skos:Concept ;
   skos:prefLabel "audio FastTracker II"@fr ;
   skos:prefLabel "Ήχος FastTracker II"@el .
 
-media-type:example a skos:Collection ;
+mediatype:example a skos:Collection ;
   rdfs:label "Example types"@en ;
   dct:description "The collection of example types"@en ;
   dct:title "Example types"@en .
 
-media-type:font a skos:Collection ;
+mediatype:font a skos:Collection ;
   rdfs:label "Font types"@en ;
   dct:description "The collection of font types"@en ;
   dct:title "Font types"@en .
 
-media-type:image a skos:Collection ;
+mediatype:image a skos:Collection ;
   rdfs:label "Image types"@en ;
   dct:description "The collection of image types"@en ;
   dct:title "Image types"@en ;
-  skos:member media-type:image_bmp ;
-  skos:member media-type:image_cgm ;
-  skos:member media-type:image_dpx ;
-  skos:member media-type:image_fax-g3 ;
-  skos:member media-type:image_g3fax ;
-  skos:member media-type:image_gif ;
-  skos:member media-type:image_ief ;
-  skos:member media-type:image_jpeg ;
-  skos:member media-type:image_jpeg2000 ;
-  skos:member media-type:image_png ;
-  skos:member media-type:image_rle ;
-  skos:member media-type:image_svgxml ;
-  skos:member media-type:image_tiff ;
-  skos:member media-type:image_vnddjvu ;
-  skos:member media-type:image_vnddwg ;
-  skos:member media-type:image_vnddxf ;
-  skos:member media-type:image_x-3ds ;
-  skos:member media-type:image_x-applix-graphics ;
-  skos:member media-type:image_x-cmu-raster ;
-  skos:member media-type:image_x-compressed-xcf ;
-  skos:member media-type:image_x-dcm ;
-  skos:member media-type:image_x-dib ;
-  skos:member media-type:image_x-eps ;
-  skos:member media-type:image_x-fits ;
-  skos:member media-type:image_x-fpx ;
-  skos:member media-type:image_x-icb ;
-  skos:member media-type:image_x-ico ;
-  skos:member media-type:image_x-iff ;
-  skos:member media-type:image_x-ilbm ;
-  skos:member media-type:image_x-jng ;
-  skos:member media-type:image_x-lwo ;
-  skos:member media-type:image_x-lws ;
-  skos:member media-type:image_x-msod ;
-  skos:member media-type:image_x-niff ;
-  skos:member media-type:image_x-pcx ;
-  skos:member media-type:image_x-photo-cd ;
-  skos:member media-type:image_x-pict ;
-  skos:member media-type:image_x-portable-anymap ;
-  skos:member media-type:image_x-portable-bitmap ;
-  skos:member media-type:image_x-portable-graymap ;
-  skos:member media-type:image_x-portable-pixmap ;
-  skos:member media-type:image_x-psd ;
-  skos:member media-type:image_x-rgb ;
-  skos:member media-type:image_x-sgi ;
-  skos:member media-type:image_x-sun-raster ;
-  skos:member media-type:image_x-tga ;
-  skos:member media-type:image_x-win-bitmap ;
-  skos:member media-type:image_x-wmf ;
-  skos:member media-type:image_x-xbitmap ;
-  skos:member media-type:image_x-xcf ;
-  skos:member media-type:image_x-xfig ;
-  skos:member media-type:image_x-xpixmap ;
-  skos:member media-type:image_x-xwindowdump .
+  skos:member mediatype:image_bmp ;
+  skos:member mediatype:image_cgm ;
+  skos:member mediatype:image_dpx ;
+  skos:member mediatype:image_fax-g3 ;
+  skos:member mediatype:image_g3fax ;
+  skos:member mediatype:image_gif ;
+  skos:member mediatype:image_ief ;
+  skos:member mediatype:image_jpeg ;
+  skos:member mediatype:image_jpeg2000 ;
+  skos:member mediatype:image_png ;
+  skos:member mediatype:image_rle ;
+  skos:member mediatype:image_svgxml ;
+  skos:member mediatype:image_tiff ;
+  skos:member mediatype:image_vnddjvu ;
+  skos:member mediatype:image_vnddwg ;
+  skos:member mediatype:image_vnddxf ;
+  skos:member mediatype:image_x-3ds ;
+  skos:member mediatype:image_x-applix-graphics ;
+  skos:member mediatype:image_x-cmu-raster ;
+  skos:member mediatype:image_x-compressed-xcf ;
+  skos:member mediatype:image_x-dcm ;
+  skos:member mediatype:image_x-dib ;
+  skos:member mediatype:image_x-eps ;
+  skos:member mediatype:image_x-fits ;
+  skos:member mediatype:image_x-fpx ;
+  skos:member mediatype:image_x-icb ;
+  skos:member mediatype:image_x-ico ;
+  skos:member mediatype:image_x-iff ;
+  skos:member mediatype:image_x-ilbm ;
+  skos:member mediatype:image_x-jng ;
+  skos:member mediatype:image_x-lwo ;
+  skos:member mediatype:image_x-lws ;
+  skos:member mediatype:image_x-msod ;
+  skos:member mediatype:image_x-niff ;
+  skos:member mediatype:image_x-pcx ;
+  skos:member mediatype:image_x-photo-cd ;
+  skos:member mediatype:image_x-pict ;
+  skos:member mediatype:image_x-portable-anymap ;
+  skos:member mediatype:image_x-portable-bitmap ;
+  skos:member mediatype:image_x-portable-graymap ;
+  skos:member mediatype:image_x-portable-pixmap ;
+  skos:member mediatype:image_x-psd ;
+  skos:member mediatype:image_x-rgb ;
+  skos:member mediatype:image_x-sgi ;
+  skos:member mediatype:image_x-sun-raster ;
+  skos:member mediatype:image_x-tga ;
+  skos:member mediatype:image_x-win-bitmap ;
+  skos:member mediatype:image_x-wmf ;
+  skos:member mediatype:image_x-xbitmap ;
+  skos:member mediatype:image_x-xcf ;
+  skos:member mediatype:image_x-xfig ;
+  skos:member mediatype:image_x-xpixmap ;
+  skos:member mediatype:image_x-xwindowdump .
 
-media-type:image_bmp a skos:Concept ;
-  media-type:hasMediaType "image/bmp" ;
+mediatype:image_bmp a skos:Concept ;
+  mediatype:hasMediaType "image/bmp" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd BMP Windows"@cy ;
   skos:prefLabel "Obrázek Windows BMP"@cs ;
@@ -3245,8 +3245,8 @@ media-type:image_bmp a skos:Concept ;
   skos:prefLabel "Εικόνα Windows BMP"@el ;
   skos:prefLabel "윈도우즈 BMP 이미지"@ko .
 
-media-type:image_cgm a skos:Concept ;
-  media-type:hasMediaType "image/cgm" ;
+mediatype:image_cgm a skos:Concept ;
+  mediatype:hasMediaType "image/cgm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CGM-Datei"@de ;
   skos:prefLabel "Computer Graphics -metatiedosto"@fi ;
@@ -3263,8 +3263,8 @@ media-type:image_cgm a skos:Concept ;
   skos:prefLabel "Метадатотека са рачунарском графиком (CGM)"@sr ;
   skos:prefLabel "컴퓨터 그래픽스 메타파일"@ko .
 
-media-type:image_dpx a skos:Concept ;
-  media-type:hasMediaType "image/dpx" ;
+mediatype:image_dpx a skos:Concept ;
+  mediatype:hasMediaType "image/dpx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DPX-Bild"@de ;
   skos:prefLabel "DPX-bild (Digital Moving Picture Exchange)"@sv ;
@@ -3281,8 +3281,8 @@ media-type:image_dpx a skos:Concept ;
   skos:prefLabel "image « Digital Moving Picture Exchange »"@fr ;
   skos:prefLabel "Дигитални облик за размену покретних слика"@sr .
 
-media-type:image_fax-g3 a skos:Concept ;
-  media-type:hasMediaType "image/fax-g3" ;
+mediatype:image_fax-g3 a skos:Concept ;
+  mediatype:hasMediaType "image/fax-g3" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CCITT G3 fax"@en ;
   skos:prefLabel "CCITT G3-faks"@no ;
@@ -3290,8 +3290,8 @@ media-type:image_fax-g3 a skos:Concept ;
   skos:prefLabel "CCITT-G3-Fax"@de ;
   skos:prefLabel "Φαξ CCITT G3"@el .
 
-media-type:image_g3fax a skos:Concept ;
-  media-type:hasMediaType "image/g3fax" ;
+mediatype:image_g3fax a skos:Concept ;
+  mediatype:hasMediaType "image/g3fax" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Ffacs G3"@cy ;
   skos:prefLabel "G3 faks rəsmi"@az ;
@@ -3309,8 +3309,8 @@ media-type:image_g3fax a skos:Concept ;
   skos:prefLabel "image de télécopie G3 « fax »"@fr ;
   skos:prefLabel "Εικόνα φαξ G3"@el .
 
-media-type:image_gif a skos:Concept ;
-  media-type:hasMediaType "image/gif" ;
+mediatype:image_gif a skos:Concept ;
+  mediatype:hasMediaType "image/gif" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd GIF"@cy ;
   skos:prefLabel "GIF afbeelding"@nl ;
@@ -3328,8 +3328,8 @@ media-type:image_gif a skos:Concept ;
   skos:prefLabel "image GIF"@fr ;
   skos:prefLabel "Εικόνα GIF"@el .
 
-media-type:image_ief a skos:Concept ;
-  media-type:hasMediaType "image/ief" ;
+mediatype:image_ief a skos:Concept ;
+  mediatype:hasMediaType "image/ief" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd IEF"@cy ;
   skos:prefLabel "IEF afbeelding"@nl ;
@@ -3347,8 +3347,8 @@ media-type:image_ief a skos:Concept ;
   skos:prefLabel "image IEF"@fr ;
   skos:prefLabel "Εικόνα IEF"@el .
 
-media-type:image_jpeg a skos:Concept ;
-  media-type:hasMediaType "image/jpeg" ;
+mediatype:image_jpeg a skos:Concept ;
+  mediatype:hasMediaType "image/jpeg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd JPEG"@cy ;
   skos:prefLabel "JPEG afbeelding"@nl ;
@@ -3366,16 +3366,16 @@ media-type:image_jpeg a skos:Concept ;
   skos:prefLabel "image JPEG"@fr ;
   skos:prefLabel "Εικόνα JPEG"@el .
 
-media-type:image_jpeg2000 a skos:Concept ;
-  media-type:hasMediaType "image/jpeg2000" ;
+mediatype:image_jpeg2000 a skos:Concept ;
+  mediatype:hasMediaType "image/jpeg2000" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "JPEG-2000 -kuva"@fi ;
   skos:prefLabel "JPEG-2000 image"@en ;
   skos:prefLabel "JPEG-2000-Bild"@de ;
   skos:prefLabel "Εικόνα JPEG-2000"@el .
 
-media-type:image_png a skos:Concept ;
-  media-type:hasMediaType "image/png" ;
+mediatype:image_png a skos:Concept ;
+  mediatype:hasMediaType "image/png" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PNG"@cy ;
   skos:prefLabel "Obrázek PNG"@cs ;
@@ -3393,22 +3393,22 @@ media-type:image_png a skos:Concept ;
   skos:prefLabel "image PNG"@fr ;
   skos:prefLabel "Εικόνα PNG"@el .
 
-media-type:image_rle a skos:Concept ;
-  media-type:hasMediaType "image/rle" ;
+mediatype:image_rle a skos:Concept ;
+  mediatype:hasMediaType "image/rle" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "RLE-Bitmap"@de ;
   skos:prefLabel "Run Length Encoded bitmap"@en .
 
-media-type:image_svgxml a skos:Concept ;
-  media-type:hasMediaType "image/svg+xml" ;
+mediatype:image_svgxml a skos:Concept ;
+  mediatype:hasMediaType "image/svg+xml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "SVG-kuva"@fi ;
   skos:prefLabel "scalable SVG image"@en ;
   skos:prefLabel "skalerbart SVG-bilde"@no ;
   skos:prefLabel "skalierbares SVG-Bild"@de .
 
-media-type:image_tiff a skos:Concept ;
-  media-type:hasMediaType "image/tiff" ;
+mediatype:image_tiff a skos:Concept ;
+  mediatype:hasMediaType "image/tiff" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "TIFF image"@en ;
   skos:prefLabel "TIFF-Bild"@de ;
@@ -3417,9 +3417,9 @@ media-type:image_tiff a skos:Concept ;
   skos:prefLabel "TIFF-kuva"@fi ;
   skos:prefLabel "Εικόνα TIFF"@el .
 
-media-type:image_vnddjvu a skos:Concept ;
-  media-type:hasMediaType "image/vnd.djvu" ;
-  skos:exactMatch media-type:image_x-djvu ;
+mediatype:image_vnddjvu a skos:Concept ;
+  mediatype:hasMediaType "image/vnd.djvu" ;
+  skos:exactMatch mediatype:image_x-djvu ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DjVu -kuva"@fi ;
   skos:prefLabel "DjVu image"@en ;
@@ -3429,8 +3429,8 @@ media-type:image_vnddjvu a skos:Concept ;
   skos:prefLabel "DjVu-bilete"@nn ;
   skos:prefLabel "Εικόνα DjVu"@el .
 
-media-type:image_vnddwg a skos:Concept ;
-  media-type:hasMediaType "image/vnd.dwg" ;
+mediatype:image_vnddwg a skos:Concept ;
+  mediatype:hasMediaType "image/vnd.dwg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AutoCAD afbeelding"@nl ;
   skos:prefLabel "AutoCAD image"@en ;
@@ -3448,16 +3448,16 @@ media-type:image_vnddwg a skos:Concept ;
   skos:prefLabel "image AutoCAD"@fr ;
   skos:prefLabel "Εικόνα AutoCAD"@el .
 
-media-type:image_vnddxf a skos:Concept ;
-  media-type:hasMediaType "image/vnd.dxf" ;
+mediatype:image_vnddxf a skos:Concept ;
+  mediatype:hasMediaType "image/vnd.dxf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DXF vector image"@en ;
   skos:prefLabel "DXF-Vektorbild"@de ;
   skos:prefLabel "DXF-vektorgrafikk"@no ;
   skos:prefLabel "DXF-vektorigrafiikka"@fi .
 
-media-type:image_x-3ds a skos:Concept ;
-  media-type:hasMediaType "image/x-3ds" ;
+mediatype:image_x-3ds a skos:Concept ;
+  mediatype:hasMediaType "image/x-3ds" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "3D Studio -kuva"@fi ;
   skos:prefLabel "3D Studio afbeelding"@nl ;
@@ -3475,8 +3475,8 @@ media-type:image_x-3ds a skos:Concept ;
   skos:prefLabel "image 3D Studio"@fr ;
   skos:prefLabel "Εικόνα 3D Studio"@el .
 
-media-type:image_x-applix-graphics a skos:Concept ;
-  media-type:hasMediaType "image/x-applix-graphics" ;
+mediatype:image_x-applix-graphics a skos:Concept ;
+  mediatype:hasMediaType "image/x-applix-graphics" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Applix Graphics -kuva"@fi ;
   skos:prefLabel "Applix Graphics image"@en ;
@@ -3484,8 +3484,8 @@ media-type:image_x-applix-graphics a skos:Concept ;
   skos:prefLabel "Applix Graphics-dokument"@no ;
   skos:prefLabel "Εικόνα  Applix Graphics"@el .
 
-media-type:image_x-cmu-raster a skos:Concept ;
-  media-type:hasMediaType "image/x-cmu-raster" ;
+mediatype:image_x-cmu-raster a skos:Concept ;
+  mediatype:hasMediaType "image/x-cmu-raster" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CMU raster afbeelding"@nl ;
   skos:prefLabel "CMU raster image"@en ;
@@ -3502,8 +3502,8 @@ media-type:image_x-cmu-raster a skos:Concept ;
   skos:prefLabel "Rastrový obrázek CMU"@cs ;
   skos:prefLabel "image raster CMU"@fr .
 
-media-type:image_x-compressed-xcf a skos:Concept ;
-  media-type:hasMediaType "image/x-compressed-xcf" ;
+mediatype:image_x-compressed-xcf a skos:Concept ;
+  mediatype:hasMediaType "image/x-compressed-xcf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GIMP image (compressed)"@en ;
   skos:prefLabel "GIMP-Bild (komprimiert)"@de ;
@@ -3511,8 +3511,8 @@ media-type:image_x-compressed-xcf a skos:Concept ;
   skos:prefLabel "GIMP-kuva (pakattu)"@fi ;
   skos:prefLabel "Εικόνα GIMP (Συμπιεσμένη)"@el .
 
-media-type:image_x-dcm a skos:Concept ;
-  media-type:hasMediaType "image/x-dcm" ;
+mediatype:image_x-dcm a skos:Concept ;
+  mediatype:hasMediaType "image/x-dcm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bildformat för digital bildbehandling och medicinsk kommunikation"@sv ;
   skos:prefLabel "DICOM-Bild"@de ;
@@ -3528,8 +3528,8 @@ media-type:image_x-dcm a skos:Concept ;
   skos:prefLabel "Слика за дигиталну фотографију и комуникацију у медицини"@sr ;
   skos:prefLabel "의료 사진용 디지털 이미지 및 통신"@ko .
 
-media-type:image_x-dib a skos:Concept ;
-  media-type:hasMediaType "image/x-dib" ;
+mediatype:image_x-dib a skos:Concept ;
+  mediatype:hasMediaType "image/x-dib" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Apparaat onafhankelijke bitmap"@nl ;
   skos:prefLabel "Avadanlıqdan Müstəqil Bitmap"@az ;
@@ -3546,8 +3546,8 @@ media-type:image_x-dib a skos:Concept ;
   skos:prefLabel "Битмапа независна од уређаја"@sr ;
   skos:prefLabel "장치 독립 비트맵"@ko .
 
-media-type:image_x-eps a skos:Concept ;
-  media-type:hasMediaType "image/x-eps" ;
+mediatype:image_x-eps a skos:Concept ;
+  mediatype:hasMediaType "image/x-eps" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PostScript wedi ei chrisialu"@cy ;
   skos:prefLabel "EPS-Bild"@de ;
@@ -3564,8 +3564,8 @@ media-type:image_x-eps a skos:Concept ;
   skos:prefLabel "Угњеждена ПостСкрипт слика (EPS)"@sr ;
   skos:prefLabel "캡슐화된 포스트스크립트 이미지"@ko .
 
-media-type:image_x-fits a skos:Concept ;
-  media-type:hasMediaType "image/x-fits" ;
+mediatype:image_x-fits a skos:Concept ;
+  mediatype:hasMediaType "image/x-fits" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "FITS-Dokument"@de ;
   skos:prefLabel "Fleksibelt bildetransportsystem"@no ;
@@ -3582,8 +3582,8 @@ media-type:image_x-fits a skos:Concept ;
   skos:prefLabel "système de transport « Flexible Image »"@fr ;
   skos:prefLabel "Флексибилни транспортни систем слика"@sr .
 
-media-type:image_x-fpx a skos:Concept ;
-  media-type:hasMediaType "image/x-fpx" ;
+mediatype:image_x-fpx a skos:Concept ;
+  mediatype:hasMediaType "image/x-fpx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "FlashPix image"@en ;
   skos:prefLabel "FlashPix-Bild"@de ;
@@ -3591,8 +3591,8 @@ media-type:image_x-fpx a skos:Concept ;
   skos:prefLabel "FlashPix-kuva"@fi ;
   skos:prefLabel "Εικόνα FlashPix"@el .
 
-media-type:image_x-icb a skos:Concept ;
-  media-type:hasMediaType "image/x-icb" ;
+mediatype:image_x-icb a skos:Concept ;
+  mediatype:hasMediaType "image/x-icb" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Targa Truevision"@cy ;
   skos:prefLabel "Obrázek Truevision Targa"@cs ;
@@ -3610,8 +3610,8 @@ media-type:image_x-icb a skos:Concept ;
   skos:prefLabel "image Truevision Targa"@fr ;
   skos:prefLabel "Εικόνα Truevision Targa"@el .
 
-media-type:image_x-ico a skos:Concept ;
-  media-type:hasMediaType "image/x-ico" ;
+mediatype:image_x-ico a skos:Concept ;
+  mediatype:hasMediaType "image/x-ico" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft Windows -kuvake"@fi ;
   skos:prefLabel "Microsoft Windows icon"@en ;
@@ -3619,8 +3619,8 @@ media-type:image_x-ico a skos:Concept ;
   skos:prefLabel "Microsoft Windows-ikon"@no ;
   skos:prefLabel "Εικονίδιο Microsoft Windows"@el .
 
-media-type:image_x-iff a skos:Concept ;
-  media-type:hasMediaType "image/x-iff" ;
+mediatype:image_x-iff a skos:Concept ;
+  mediatype:hasMediaType "image/x-iff" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd IFF"@cy ;
   skos:prefLabel "IFF afbeelding"@nl ;
@@ -3638,8 +3638,8 @@ media-type:image_x-iff a skos:Concept ;
   skos:prefLabel "image IFF"@fr ;
   skos:prefLabel "Εικόνα IFF"@el .
 
-media-type:image_x-ilbm a skos:Concept ;
-  media-type:hasMediaType "image/x-ilbm" ;
+mediatype:image_x-ilbm a skos:Concept ;
+  mediatype:hasMediaType "image/x-ilbm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd ILBM"@cy ;
   skos:prefLabel "ILBM afbeelding"@nl ;
@@ -3657,8 +3657,8 @@ media-type:image_x-ilbm a skos:Concept ;
   skos:prefLabel "image ILBM"@fr ;
   skos:prefLabel "Εικόνα ILBM"@el .
 
-media-type:image_x-jng a skos:Concept ;
-  media-type:hasMediaType "image/x-jng" ;
+mediatype:image_x-jng a skos:Concept ;
+  mediatype:hasMediaType "image/x-jng" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd JNG"@cy ;
   skos:prefLabel "JNG afbeelding"@nl ;
@@ -3676,8 +3676,8 @@ media-type:image_x-jng a skos:Concept ;
   skos:prefLabel "image JNG"@fr ;
   skos:prefLabel "Εικόνα JNG"@el .
 
-media-type:image_x-lwo a skos:Concept ;
-  media-type:hasMediaType "image/x-lwo" ;
+mediatype:image_x-lwo a skos:Concept ;
+  mediatype:hasMediaType "image/x-lwo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Gwrthrych LightWave"@cy ;
   skos:prefLabel "LightWave cismi"@az ;
@@ -3695,8 +3695,8 @@ media-type:image_x-lwo a skos:Concept ;
   skos:prefLabel "objet LightWave"@fr ;
   skos:prefLabel "Αντικείμενο LightWave"@el .
 
-media-type:image_x-lws a skos:Concept ;
-  media-type:hasMediaType "image/x-lws" ;
+mediatype:image_x-lws a skos:Concept ;
+  mediatype:hasMediaType "image/x-lws" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Golygfa LightWave"@cy ;
   skos:prefLabel "LightWave scene"@en ;
@@ -3714,24 +3714,24 @@ media-type:image_x-lws a skos:Concept ;
   skos:prefLabel "scène LightWave"@fr ;
   skos:prefLabel "Σκηνή LightWave"@el .
 
-media-type:image_x-msod a skos:Concept ;
-  media-type:hasMediaType "image/x-msod" ;
+mediatype:image_x-msod a skos:Concept ;
+  mediatype:hasMediaType "image/x-msod" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft Office -piirros"@fi ;
   skos:prefLabel "Microsoft Office drawing"@en ;
   skos:prefLabel "Microsoft Office-Zeichnung"@de ;
   skos:prefLabel "Microsoft Office-tegning"@no .
 
-media-type:image_x-niff a skos:Concept ;
-  media-type:hasMediaType "image/x-niff" ;
+mediatype:image_x-niff a skos:Concept ;
+  mediatype:hasMediaType "image/x-niff" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:image_x-pcx a skos:Concept ;
-  media-type:hasMediaType "image/x-pcx" ;
+mediatype:image_x-pcx a skos:Concept ;
+  mediatype:hasMediaType "image/x-pcx" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:image_x-photo-cd a skos:Concept ;
-  media-type:hasMediaType "image/x-photo-cd" ;
+mediatype:image_x-photo-cd a skos:Concept ;
+  mediatype:hasMediaType "image/x-photo-cd" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PhotoCD"@cy ;
   skos:prefLabel "Obrázek PhotoCD"@cs ;
@@ -3749,15 +3749,15 @@ media-type:image_x-photo-cd a skos:Concept ;
   skos:prefLabel "Εικόνα PhotoCD"@el ;
   skos:prefLabel "Фото Це-Де слика"@sr .
 
-media-type:image_x-pict a skos:Concept ;
-  media-type:hasMediaType "image/x-pict" ;
+mediatype:image_x-pict a skos:Concept ;
+  mediatype:hasMediaType "image/x-pict" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Macintosh Quickdraw/PICT -piirros"@fi ;
   skos:prefLabel "Macintosh Quickdraw/PICT drawing"@en ;
   skos:prefLabel "Macintosh Quickdraw/PICT-Zeichnung"@de .
 
-media-type:image_x-portable-anymap a skos:Concept ;
-  media-type:hasMediaType "image/x-portable-anymap" ;
+mediatype:image_x-portable-anymap a skos:Concept ;
+  mediatype:hasMediaType "image/x-portable-anymap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PNM"@cy ;
   skos:prefLabel "Obrázek PNM"@cs ;
@@ -3775,8 +3775,8 @@ media-type:image_x-portable-anymap a skos:Concept ;
   skos:prefLabel "image PNM"@fr ;
   skos:prefLabel "Εικόνα PNM"@el .
 
-media-type:image_x-portable-bitmap a skos:Concept ;
-  media-type:hasMediaType "image/x-portable-bitmap" ;
+mediatype:image_x-portable-bitmap a skos:Concept ;
+  mediatype:hasMediaType "image/x-portable-bitmap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeiliau Fformat Pixfap Cludadwy"@cy ;
   skos:prefLabel "Formát souborů Portable Bitmap"@cs ;
@@ -3791,8 +3791,8 @@ media-type:image_x-portable-bitmap a skos:Concept ;
   skos:prefLabel "Портабилни запис битмапираних датотека"@sr ;
   skos:prefLabel "이식 가능한 비트맵 파일 형식"@ko .
 
-media-type:image_x-portable-graymap a skos:Concept ;
-  media-type:hasMediaType "image/x-portable-graymap" ;
+mediatype:image_x-portable-graymap a skos:Concept ;
+  mediatype:hasMediaType "image/x-portable-graymap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeiliau Fformat Llwydfap Cludadwy"@cy ;
   skos:prefLabel "Formát souborů Portable Graymap"@cs ;
@@ -3807,8 +3807,8 @@ media-type:image_x-portable-graymap a skos:Concept ;
   skos:prefLabel "Портабилни запис слика у сивим нијансама"@sr ;
   skos:prefLabel "이식 가능한 그레이맵 파일 형식"@ko .
 
-media-type:image_x-portable-pixmap a skos:Concept ;
-  media-type:hasMediaType "image/x-portable-pixmap" ;
+mediatype:image_x-portable-pixmap a skos:Concept ;
+  mediatype:hasMediaType "image/x-portable-pixmap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Pixmap Cludadwy"@cy ;
   skos:prefLabel "Formát souboru Portable Pixmap"@cs ;
@@ -3824,8 +3824,8 @@ media-type:image_x-portable-pixmap a skos:Concept ;
   skos:prefLabel "Портабилни запис пиксмапа"@sr ;
   skos:prefLabel "이식 가능한 픽스맵 파일 형식"@ko .
 
-media-type:image_x-psd a skos:Concept ;
-  media-type:hasMediaType "image/x-psd" ;
+mediatype:image_x-psd a skos:Concept ;
+  mediatype:hasMediaType "image/x-psd" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Photoshop image"@en ;
   skos:prefLabel "Photoshop-Bild"@de ;
@@ -3833,8 +3833,8 @@ media-type:image_x-psd a skos:Concept ;
   skos:prefLabel "Photoshop-kuva"@fi ;
   skos:prefLabel "Εικόνα Photoshop"@el .
 
-media-type:image_x-rgb a skos:Concept ;
-  media-type:hasMediaType "image/x-rgb" ;
+mediatype:image_x-rgb a skos:Concept ;
+  mediatype:hasMediaType "image/x-rgb" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd RGB"@cy ;
   skos:prefLabel "Obrázek RGB"@cs ;
@@ -3852,23 +3852,23 @@ media-type:image_x-rgb a skos:Concept ;
   skos:prefLabel "image RGB"@fr ;
   skos:prefLabel "Εικόνα RGB"@el .
 
-media-type:image_x-sgi a skos:Concept ;
-  media-type:hasMediaType "image/x-sgi" ;
+mediatype:image_x-sgi a skos:Concept ;
+  mediatype:hasMediaType "image/x-sgi" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Silicon Graphics IRIS -kuva"@fi ;
   skos:prefLabel "Silicon Graphics IRIS image"@en ;
   skos:prefLabel "Silicon Graphics-IRIS-Bild"@de .
 
-media-type:image_x-sun-raster a skos:Concept ;
-  media-type:hasMediaType "image/x-sun-raster" ;
+mediatype:image_x-sun-raster a skos:Concept ;
+  mediatype:hasMediaType "image/x-sun-raster" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "SUN Rasterfile image"@en ;
   skos:prefLabel "SUN rasterfil-bilde"@no ;
   skos:prefLabel "SUN-Rasterfile-Bild"@de ;
   skos:prefLabel "SUN-rasterikuva"@fi .
 
-media-type:image_x-tga a skos:Concept ;
-  media-type:hasMediaType "image/x-tga" ;
+mediatype:image_x-tga a skos:Concept ;
+  mediatype:hasMediaType "image/x-tga" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd TarGA"@cy ;
   skos:prefLabel "Obrázek TarGA"@cs ;
@@ -3886,15 +3886,15 @@ media-type:image_x-tga a skos:Concept ;
   skos:prefLabel "image TarGA"@fr ;
   skos:prefLabel "Εικόνα TarGA"@el .
 
-media-type:image_x-win-bitmap a skos:Concept ;
-  media-type:hasMediaType "image/x-win-bitmap" ;
+mediatype:image_x-win-bitmap a skos:Concept ;
+  mediatype:hasMediaType "image/x-win-bitmap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Windows cursor"@en ;
   skos:prefLabel "Windows-Cursor"@de ;
   skos:prefLabel "Windows-kursori"@fi .
 
-media-type:image_x-wmf a skos:Concept ;
-  media-type:hasMediaType "image/x-wmf" ;
+mediatype:image_x-wmf a skos:Concept ;
+  mediatype:hasMediaType "image/x-wmf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft WMF -tiedosto"@fi ;
   skos:prefLabel "Microsoft WMF file"@en ;
@@ -3902,8 +3902,8 @@ media-type:image_x-wmf a skos:Concept ;
   skos:prefLabel "Microsoft-WMF-Datei"@de ;
   skos:prefLabel "Αρχείο Microsoft WMF"@el .
 
-media-type:image_x-xbitmap a skos:Concept ;
-  media-type:hasMediaType "image/x-xbitmap" ;
+mediatype:image_x-xbitmap a skos:Concept ;
+  mediatype:hasMediaType "image/x-xbitmap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bilete i X Bitmap-format"@nn ;
   skos:prefLabel "Delwedd didfap X"@cy ;
@@ -3920,8 +3920,8 @@ media-type:image_x-xbitmap a skos:Concept ;
   skos:prefLabel "X-bitmappbild"@sv ;
   skos:prefLabel "image X BitMap"@fr .
 
-media-type:image_x-xcf a skos:Concept ;
-  media-type:hasMediaType "image/x-xcf" ;
+mediatype:image_x-xcf a skos:Concept ;
+  mediatype:hasMediaType "image/x-xcf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "GIF-kuva"@fi ;
   skos:prefLabel "GIMP image"@en ;
@@ -3930,8 +3930,8 @@ media-type:image_x-xcf a skos:Concept ;
   skos:prefLabel "GIMP-bilde"@no ;
   skos:prefLabel "Εικόνα GIMP"@el .
 
-media-type:image_x-xfig a skos:Concept ;
-  media-type:hasMediaType "image/x-xfig" ;
+mediatype:image_x-xfig a skos:Concept ;
+  mediatype:hasMediaType "image/x-xfig" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "XFig image"@en ;
   skos:prefLabel "XFig-Bild"@de ;
@@ -3939,8 +3939,8 @@ media-type:image_x-xfig a skos:Concept ;
   skos:prefLabel "XFig-tiedosto"@fi ;
   skos:prefLabel "Εικόνα XFig"@el .
 
-media-type:image_x-xpixmap a skos:Concept ;
-  media-type:hasMediaType "image/x-xpixmap" ;
+mediatype:image_x-xpixmap a skos:Concept ;
+  mediatype:hasMediaType "image/x-xpixmap" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bilete i X Bitmap-format"@nn ;
   skos:prefLabel "Delwedd picsfap X"@cy ;
@@ -3957,8 +3957,8 @@ media-type:image_x-xpixmap a skos:Concept ;
   skos:prefLabel "X-pixmapbilde"@no ;
   skos:prefLabel "image X PixMap"@fr .
 
-media-type:image_x-xwindowdump a skos:Concept ;
-  media-type:hasMediaType "image/x-xwindowdump" ;
+mediatype:image_x-xwindowdump a skos:Concept ;
+  mediatype:hasMediaType "image/x-xwindowdump" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Delwedd ffenest X"@cy ;
   skos:prefLabel "Obrázek X window"@cs ;
@@ -3975,34 +3975,34 @@ media-type:image_x-xwindowdump a skos:Concept ;
   skos:prefLabel "X-ikkunakuva"@fi ;
   skos:prefLabel "image X window"@fr .
 
-media-type:inode skos:member media-type:inode_blockdevice ;
-  skos:member media-type:inode_chardevice ;
-  skos:member media-type:inode_directory ;
-  skos:member media-type:inode_fifo ;
-  skos:member media-type:inode_mount-point ;
-  skos:member media-type:inode_socket ;
-  skos:member media-type:inode_symlink .
+mediatype:inode skos:member mediatype:inode_blockdevice ;
+  skos:member mediatype:inode_chardevice ;
+  skos:member mediatype:inode_directory ;
+  skos:member mediatype:inode_fifo ;
+  skos:member mediatype:inode_mount-point ;
+  skos:member mediatype:inode_socket ;
+  skos:member mediatype:inode_symlink .
 
-media-type:inode_blockdevice a skos:Concept ;
-  media-type:hasMediaType "inode/blockdevice" ;
+mediatype:inode_blockdevice a skos:Concept ;
+  mediatype:hasMediaType "inode/blockdevice" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Blockgerät"@de ;
   skos:prefLabel "block device"@en ;
   skos:prefLabel "blokkenhet"@no ;
   skos:prefLabel "laitetiedosto"@fi .
 
-media-type:inode_chardevice a skos:Concept ;
-  media-type:hasMediaType "inode/chardevice" ;
+mediatype:inode_chardevice a skos:Concept ;
+  mediatype:hasMediaType "inode/chardevice" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Character-Device"@de ;
   skos:prefLabel "character device"@en ;
   skos:prefLabel "merkkilaite"@fi ;
   skos:prefLabel "tegnenhet"@no .
 
-media-type:inode_directory a skos:Concept ;
-  media-type:hasMediaType "inode/directory" ;
+mediatype:inode_directory a skos:Concept ;
+  mediatype:hasMediaType "inode/directory" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
-  skos:narrower media-type:inode_mount-point ;
+  skos:narrower mediatype:inode_mount-point ;
   skos:prefLabel "Ordner"@de ;
   skos:prefLabel "folder"@en ;
   skos:prefLabel "kansio"@fi ;
@@ -4010,8 +4010,8 @@ media-type:inode_directory a skos:Concept ;
   skos:prefLabel "mappe"@no ;
   skos:prefLabel "φάκελος"@el .
 
-media-type:inode_fifo a skos:Concept ;
-  media-type:hasMediaType "inode/fifo" ;
+mediatype:inode_fifo a skos:Concept ;
+  mediatype:hasMediaType "inode/fifo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Pipe"@de ;
   skos:prefLabel "pipe"@en ;
@@ -4019,9 +4019,9 @@ media-type:inode_fifo a skos:Concept ;
   skos:prefLabel "rör"@sv ;
   skos:prefLabel "rør"@no .
 
-media-type:inode_mount-point a skos:Concept ;
-  media-type:hasMediaType "inode/mount-point" ;
-  skos:broader media-type:inode_directory ;
+mediatype:inode_mount-point a skos:Concept ;
+  mediatype:hasMediaType "inode/mount-point" ;
+  skos:broader mediatype:inode_directory ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Einbindepunkt"@de ;
   skos:prefLabel "liitospiste"@fi ;
@@ -4029,16 +4029,16 @@ media-type:inode_mount-point a skos:Concept ;
   skos:prefLabel "mount point"@en ;
   skos:prefLabel "σημείο προσάρτησης"@el .
 
-media-type:inode_socket a skos:Concept ;
-  media-type:hasMediaType "inode/socket" ;
+mediatype:inode_socket a skos:Concept ;
+  mediatype:hasMediaType "inode/socket" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Socket"@de ;
   skos:prefLabel "pistoke"@fi ;
   skos:prefLabel "plugg"@no ;
   skos:prefLabel "socket"@en .
 
-media-type:inode_symlink a skos:Concept ;
-  media-type:hasMediaType "inode/symlink" ;
+mediatype:inode_symlink a skos:Concept ;
+  mediatype:hasMediaType "inode/symlink" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Symbolický odkaz"@cs ;
   skos:prefLabel "Symbolischer Link"@de ;
@@ -4056,21 +4056,21 @@ media-type:inode_symlink a skos:Concept ;
   skos:prefLabel "симболичка веза"@sr ;
   skos:prefLabel "심볼릭 링크"@ko .
 
-media-type:message a skos:Collection ;
+mediatype:message a skos:Collection ;
   rdfs:label "Message types"@en ;
   dct:description "The collection of message types"@en ;
   dct:title "Message types"@en ;
-  skos:member media-type:message_delivery-status ;
-  skos:member media-type:message_disposition-notification ;
-  skos:member media-type:message_external-body ;
-  skos:member media-type:message_news ;
-  skos:member media-type:message_partial ;
-  skos:member media-type:message_rfc822 ;
-  skos:member media-type:message_x-gnu-rmail .
+  skos:member mediatype:message_delivery-status ;
+  skos:member mediatype:message_disposition-notification ;
+  skos:member mediatype:message_external-body ;
+  skos:member mediatype:message_news ;
+  skos:member mediatype:message_partial ;
+  skos:member mediatype:message_rfc822 ;
+  skos:member mediatype:message_x-gnu-rmail .
 
-media-type:message_delivery-status a skos:Concept ;
-  media-type:hasMediaType "message/delivery-status" ;
-  skos:broader media-type:text_plain ;
+mediatype:message_delivery-status a skos:Concept ;
+  mediatype:hasMediaType "message/delivery-status" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Adroddiad trosgludo post"@cy ;
   skos:prefLabel "E-Mail-Zustellungsbericht"@de ;
@@ -4087,8 +4087,8 @@ media-type:message_delivery-status a skos:Concept ;
   skos:prefLabel "извештај доставе поруке"@sr ;
   skos:prefLabel "메일 배달 보고서"@ko .
 
-media-type:message_disposition-notification a skos:Concept ;
-  media-type:hasMediaType "message/disposition-notification" ;
+mediatype:message_disposition-notification a skos:Concept ;
+  mediatype:hasMediaType "message/disposition-notification" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Übertragungsbericht"@de ;
   skos:prefLabel "Zpráva o předání pošty"@cs ;
@@ -4105,8 +4105,8 @@ media-type:message_disposition-notification a skos:Concept ;
   skos:prefLabel "извештај слања поруке"@sr ;
   skos:prefLabel "메일 처리 보고서"@ko .
 
-media-type:message_external-body a skos:Concept ;
-  media-type:hasMediaType "message/external-body" ;
+mediatype:message_external-body a skos:Concept ;
+  mediatype:hasMediaType "message/external-body" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Odkaz na vzdálený soubor"@cs ;
   skos:prefLabel "Verweis auf entfernte Datei"@de ;
@@ -4123,9 +4123,9 @@ media-type:message_external-body a skos:Concept ;
   skos:prefLabel "референца на удаљену датотеку"@sr ;
   skos:prefLabel "원격 파일 참조"@ko .
 
-media-type:message_news a skos:Concept ;
-  media-type:hasMediaType "message/news" ;
-  skos:broader media-type:text_plain ;
+mediatype:message_news a skos:Concept ;
+  mediatype:hasMediaType "message/news" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Neges newyddion Usenet"@cy ;
   skos:prefLabel "Příspěvek do diskusních skupin Usenet"@cs ;
@@ -4142,9 +4142,9 @@ media-type:message_news a skos:Concept ;
   skos:prefLabel "Порука са дискусионе групе"@sr ;
   skos:prefLabel "유즈넷 새소식 메세지"@ko .
 
-media-type:message_partial a skos:Concept ;
-  media-type:hasMediaType "message/partial" ;
-  skos:broader media-type:text_plain ;
+mediatype:message_partial a skos:Concept ;
+  mediatype:hasMediaType "message/partial" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Nachrichtenfragment"@de ;
   skos:prefLabel "darn o neges e-bost"@cy ;
@@ -4161,9 +4161,9 @@ media-type:message_partial a skos:Concept ;
   skos:prefLabel "делимична е-порука"@sr ;
   skos:prefLabel "부분적인 이메일 메세지"@ko .
 
-media-type:message_rfc822 a skos:Concept ;
-  media-type:hasMediaType "message/rfc822" ;
-  skos:broader media-type:text_plain ;
+mediatype:message_rfc822 a skos:Concept ;
+  mediatype:hasMediaType "message/rfc822" ;
+  skos:broader mediatype:text_plain ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Nachricht"@de ;
   skos:prefLabel "e-postmeddelande"@sv ;
@@ -4172,8 +4172,8 @@ media-type:message_rfc822 a skos:Concept ;
   skos:prefLabel "sähköpostiviesti"@fi ;
   skos:prefLabel "μήνυμα email"@el .
 
-media-type:message_x-gnu-rmail a skos:Concept ;
-  media-type:hasMediaType "message/x-gnu-rmail" ;
+mediatype:message_x-gnu-rmail a skos:Concept ;
+  mediatype:hasMediaType "message/x-gnu-rmail" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-mailová zpráva GNU"@cs ;
   skos:prefLabel "GNU e-mail bericht"@nl ;
@@ -4191,14 +4191,14 @@ media-type:message_x-gnu-rmail a skos:Concept ;
   skos:prefLabel "Μήνυμα αλληλογραφίας GNU"@el ;
   skos:prefLabel "ГНУ е-писмо"@sr .
 
-media-type:model a skos:Collection ;
+mediatype:model a skos:Collection ;
   rdfs:label "Model types"@en ;
   dct:description "The collection of model types"@en ;
   dct:title "Model types"@en ;
-  skos:member media-type:model_vrml .
+  skos:member mediatype:model_vrml .
 
-media-type:model_vrml a skos:Concept ;
-  media-type:hasMediaType "model/vrml" ;
+mediatype:model_vrml a skos:Concept ;
+  mediatype:hasMediaType "model/vrml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen VRML"@cy ;
   skos:prefLabel "Dokument VRML"@cs ;
@@ -4216,22 +4216,22 @@ media-type:model_vrml a skos:Concept ;
   skos:prefLabel "document VRML"@fr ;
   skos:prefLabel "Έγγραφο VRML"@el .
 
-media-type:multipart a skos:Collection ;
+mediatype:multipart a skos:Collection ;
   rdfs:label "Multipart types"@en ;
   dct:description "The collection of multipart types"@en ;
   dct:title "Multipart types"@en ;
-  skos:member media-type:multipart_alternative ;
-  skos:member media-type:multipart_appledouble ;
-  skos:member media-type:multipart_digest ;
-  skos:member media-type:multipart_encrypted ;
-  skos:member media-type:multipart_mixed ;
-  skos:member media-type:multipart_related ;
-  skos:member media-type:multipart_report ;
-  skos:member media-type:multipart_signed ;
-  skos:member media-type:multipart_x-mixed-replace .
+  skos:member mediatype:multipart_alternative ;
+  skos:member mediatype:multipart_appledouble ;
+  skos:member mediatype:multipart_digest ;
+  skos:member mediatype:multipart_encrypted ;
+  skos:member mediatype:multipart_mixed ;
+  skos:member mediatype:multipart_related ;
+  skos:member mediatype:multipart_report ;
+  skos:member mediatype:multipart_signed ;
+  skos:member mediatype:multipart_x-mixed-replace .
 
-media-type:multipart_alternative a skos:Concept ;
-  media-type:hasMediaType "multipart/alternative" ;
+mediatype:multipart_alternative a skos:Concept ;
+  mediatype:hasMediaType "multipart/alternative" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Nachricht in mehreren Formaten"@de ;
   skos:prefLabel "Zpráva v několika formátech"@cs ;
@@ -4248,8 +4248,8 @@ media-type:multipart_alternative a skos:Concept ;
   skos:prefLabel "поруке у више записа"@sr ;
   skos:prefLabel "몇몇형식의 메세지"@ko .
 
-media-type:multipart_appledouble a skos:Concept ;
-  media-type:hasMediaType "multipart/appledouble" ;
+mediatype:multipart_appledouble a skos:Concept ;
+  mediatype:hasMediaType "multipart/appledouble" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil AppleDouble-amgodedig Macintosh"@cy ;
   skos:prefLabel "Macintosh AppleDouble -koodattu tiedosto"@fi ;
@@ -4267,8 +4267,8 @@ media-type:multipart_appledouble a skos:Concept ;
   skos:prefLabel "Мекинтош AppleDouble-encoded датотека"@sr ;
   skos:prefLabel "맥킨토시 AppleDouble-encoded 파일"@ko .
 
-media-type:multipart_digest a skos:Concept ;
-  media-type:hasMediaType "multipart/digest" ;
+mediatype:multipart_digest a skos:Concept ;
+  mediatype:hasMediaType "multipart/digest" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Digest zpráv"@cs ;
   skos:prefLabel "Nachrichtensammlung"@de ;
@@ -4285,8 +4285,8 @@ media-type:multipart_digest a skos:Concept ;
   skos:prefLabel "гомила порука"@sr ;
   skos:prefLabel "메세지 묶음"@ko .
 
-media-type:multipart_encrypted a skos:Concept ;
-  media-type:hasMediaType "multipart/encrypted" ;
+mediatype:multipart_encrypted a skos:Concept ;
+  mediatype:hasMediaType "multipart/encrypted" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Neges wedi ei hamgryptio"@cy ;
   skos:prefLabel "Zašifrovaná zpráva"@cs ;
@@ -4304,16 +4304,16 @@ media-type:multipart_encrypted a skos:Concept ;
   skos:prefLabel "шифрована порука"@sr ;
   skos:prefLabel "암호화된 메세지"@ko .
 
-media-type:multipart_mixed a skos:Concept ;
-  media-type:hasMediaType "multipart/mixed" ;
+mediatype:multipart_mixed a skos:Concept ;
+  mediatype:hasMediaType "multipart/mixed" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Verbunddokumente"@de ;
   skos:prefLabel "compound documents"@en ;
   skos:prefLabel "sammensatte dokumenter"@no ;
   skos:prefLabel "yhdisteasiakirja"@fi .
 
-media-type:multipart_related a skos:Concept ;
-  media-type:hasMediaType "multipart/related" ;
+mediatype:multipart_related a skos:Concept ;
+  mediatype:hasMediaType "multipart/related" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Složený dokument"@cs ;
   skos:prefLabel "Verbunddokument"@de ;
@@ -4330,8 +4330,8 @@ media-type:multipart_related a skos:Concept ;
   skos:prefLabel "сједињени документ"@sr ;
   skos:prefLabel "복합 문서"@ko .
 
-media-type:multipart_report a skos:Concept ;
-  media-type:hasMediaType "multipart/report" ;
+mediatype:multipart_report a skos:Concept ;
+  mediatype:hasMediaType "multipart/report" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Systembericht"@de ;
   skos:prefLabel "Zpráva poštovního systému"@cs ;
@@ -4348,8 +4348,8 @@ media-type:multipart_report a skos:Concept ;
   skos:prefLabel "извештај поштанског система"@sr ;
   skos:prefLabel "메일 시스템 보고서"@ko .
 
-media-type:multipart_signed a skos:Concept ;
-  media-type:hasMediaType "multipart/signed" ;
+mediatype:multipart_signed a skos:Concept ;
+  mediatype:hasMediaType "multipart/signed" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Podepsaná zpráva"@cs ;
   skos:prefLabel "allekirjoitettu viesti"@fi ;
@@ -4366,87 +4366,87 @@ media-type:multipart_signed a skos:Concept ;
   skos:prefLabel "потписана порука"@sr ;
   skos:prefLabel "서명된 메세지"@ko .
 
-media-type:multipart_x-mixed-replace a skos:Concept ;
-  media-type:hasMediaType "multipart/x-mixed-replace" ;
+mediatype:multipart_x-mixed-replace a skos:Concept ;
+  mediatype:hasMediaType "multipart/x-mixed-replace" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Datenstrom (Server-Push)"@de ;
   skos:prefLabel "datastrøm (server push)"@no ;
   skos:prefLabel "stream of data (server push)"@en ;
   skos:prefLabel "tietovirta (palvelin työntää)"@fi .
 
-media-type:text a skos:Collection ;
+mediatype:text a skos:Collection ;
   rdfs:label "Text types"@en ;
   dct:description "The collection of text types"@en ;
   dct:title "Text types"@en ;
-  skos:member media-type:text_calendar ;
-  skos:member media-type:text_css ;
-  skos:member media-type:text_directory ;
-  skos:member media-type:text_enriched ;
-  skos:member media-type:text_html ;
-  skos:member media-type:text_htmlh ;
-  skos:member media-type:text_mathml ;
-  skos:member media-type:text_plain ;
-  skos:member media-type:text_rdf ;
-  skos:member media-type:text_rfc822-headers ;
-  skos:member media-type:text_richtext ;
-  skos:member media-type:text_rss ;
-  skos:member media-type:text_sgml ;
-  skos:member media-type:text_spreadsheet ;
-  skos:member media-type:text_tab-separated-values ;
-  skos:member media-type:text_vndwapwml ;
-  skos:member media-type:text_x-adasrc ;
-  skos:member media-type:text_x-authors ;
-  skos:member media-type:text_x-bibtex ;
-  skos:member media-type:text_x-chdr ;
-  skos:member media-type:text_x-comma-separated-values ;
-  skos:member media-type:text_x-copying ;
-  skos:member media-type:text_x-credits ;
-  skos:member media-type:text_x-csharp ;
-  skos:member media-type:text_x-csrc ;
-  skos:member media-type:text_x-dcl ;
-  skos:member media-type:text_x-dsl ;
-  skos:member media-type:text_x-dtd ;
-  skos:member media-type:text_x-emacs-lisp ;
-  skos:member media-type:text_x-fortran ;
-  skos:member media-type:text_x-gettext-translation ;
-  skos:member media-type:text_x-gettext-translation-template ;
-  skos:member media-type:text_x-gtkrc ;
-  skos:member media-type:text_x-haskell ;
-  skos:member media-type:text_x-idl ;
-  skos:member media-type:text_x-install ;
-  skos:member media-type:text_x-java ;
-  skos:member media-type:text_x-ksh ;
-  skos:member media-type:text_x-ksysv-log ;
-  skos:member media-type:text_x-literate-haskell ;
-  skos:member media-type:text_x-log ;
-  skos:member media-type:text_x-makefile ;
-  skos:member media-type:text_x-moc ;
-  skos:member media-type:text_x-objcsrc ;
-  skos:member media-type:text_x-pascal ;
-  skos:member media-type:text_x-patch ;
-  skos:member media-type:text_x-readme ;
-  skos:member media-type:text_x-scheme ;
-  skos:member media-type:text_x-setext ;
-  skos:member media-type:text_x-speech ;
-  skos:member media-type:text_x-sql ;
-  skos:member media-type:text_x-tcl ;
-  skos:member media-type:text_x-tex ;
-  skos:member media-type:text_x-texinfo ;
-  skos:member media-type:text_x-troff-me ;
-  skos:member media-type:text_x-troff-mm ;
-  skos:member media-type:text_x-troff-ms ;
-  skos:member media-type:text_x-uil ;
-  skos:member media-type:text_x-uri ;
-  skos:member media-type:text_x-vcalendar ;
-  skos:member media-type:text_x-vcard ;
-  skos:member media-type:text_x-xmi ;
-  skos:member media-type:text_x-xslfo ;
-  skos:member media-type:text_x-xslt ;
-  skos:member media-type:text_xmcd ;
-  skos:member media-type:text_xml .
+  skos:member mediatype:text_calendar ;
+  skos:member mediatype:text_css ;
+  skos:member mediatype:text_directory ;
+  skos:member mediatype:text_enriched ;
+  skos:member mediatype:text_html ;
+  skos:member mediatype:text_htmlh ;
+  skos:member mediatype:text_mathml ;
+  skos:member mediatype:text_plain ;
+  skos:member mediatype:text_rdf ;
+  skos:member mediatype:text_rfc822-headers ;
+  skos:member mediatype:text_richtext ;
+  skos:member mediatype:text_rss ;
+  skos:member mediatype:text_sgml ;
+  skos:member mediatype:text_spreadsheet ;
+  skos:member mediatype:text_tab-separated-values ;
+  skos:member mediatype:text_vndwapwml ;
+  skos:member mediatype:text_x-adasrc ;
+  skos:member mediatype:text_x-authors ;
+  skos:member mediatype:text_x-bibtex ;
+  skos:member mediatype:text_x-chdr ;
+  skos:member mediatype:text_x-comma-separated-values ;
+  skos:member mediatype:text_x-copying ;
+  skos:member mediatype:text_x-credits ;
+  skos:member mediatype:text_x-csharp ;
+  skos:member mediatype:text_x-csrc ;
+  skos:member mediatype:text_x-dcl ;
+  skos:member mediatype:text_x-dsl ;
+  skos:member mediatype:text_x-dtd ;
+  skos:member mediatype:text_x-emacs-lisp ;
+  skos:member mediatype:text_x-fortran ;
+  skos:member mediatype:text_x-gettext-translation ;
+  skos:member mediatype:text_x-gettext-translation-template ;
+  skos:member mediatype:text_x-gtkrc ;
+  skos:member mediatype:text_x-haskell ;
+  skos:member mediatype:text_x-idl ;
+  skos:member mediatype:text_x-install ;
+  skos:member mediatype:text_x-java ;
+  skos:member mediatype:text_x-ksh ;
+  skos:member mediatype:text_x-ksysv-log ;
+  skos:member mediatype:text_x-literate-haskell ;
+  skos:member mediatype:text_x-log ;
+  skos:member mediatype:text_x-makefile ;
+  skos:member mediatype:text_x-moc ;
+  skos:member mediatype:text_x-objcsrc ;
+  skos:member mediatype:text_x-pascal ;
+  skos:member mediatype:text_x-patch ;
+  skos:member mediatype:text_x-readme ;
+  skos:member mediatype:text_x-scheme ;
+  skos:member mediatype:text_x-setext ;
+  skos:member mediatype:text_x-speech ;
+  skos:member mediatype:text_x-sql ;
+  skos:member mediatype:text_x-tcl ;
+  skos:member mediatype:text_x-tex ;
+  skos:member mediatype:text_x-texinfo ;
+  skos:member mediatype:text_x-troff-me ;
+  skos:member mediatype:text_x-troff-mm ;
+  skos:member mediatype:text_x-troff-ms ;
+  skos:member mediatype:text_x-uil ;
+  skos:member mediatype:text_x-uri ;
+  skos:member mediatype:text_x-vcalendar ;
+  skos:member mediatype:text_x-vcard ;
+  skos:member mediatype:text_x-xmi ;
+  skos:member mediatype:text_x-xslfo ;
+  skos:member mediatype:text_x-xslt ;
+  skos:member mediatype:text_xmcd ;
+  skos:member mediatype:text_xml .
 
-media-type:text_calendar a skos:Concept ;
-  media-type:hasMediaType "text/calendar" ;
+mediatype:text_calendar a skos:Concept ;
+  mediatype:hasMediaType "text/calendar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil iCalendar"@cy ;
   skos:prefLabel "Soubor iCalendar"@cs ;
@@ -4464,8 +4464,8 @@ media-type:text_calendar a skos:Concept ;
   skos:prefLabel "iCalender-fil"@no ;
   skos:prefLabel "Αρχείο iCalendar"@el .
 
-media-type:text_css a skos:Concept ;
-  media-type:hasMediaType "text/css" ;
+mediatype:text_css a skos:Concept ;
+  mediatype:hasMediaType "text/css" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CSS-Stylesheet"@de ;
   skos:prefLabel "CSS-stíluslap"@hu ;
@@ -4482,18 +4482,18 @@ media-type:text_css a skos:Concept ;
   skos:prefLabel "Каскадна стилска страна (CSS)"@sr ;
   skos:prefLabel "다단 스타일시트"@ko .
 
-media-type:text_csv a skos:Concept ;
-  media-type:hasMediaType "text/csv" ;
+mediatype:text_csv a skos:Concept ;
+  mediatype:hasMediaType "text/csv" ;
   rdfs:seeAlso <https://www.rfc-editor.org/rfc/rfc7111> ;
   skos:altLabel "CSV"@en ;
-  skos:exactMatch media-type:text_x-comma-separated-values ;
+  skos:exactMatch mediatype:text_x-comma-separated-values ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "CSV (valeurs séparées par des virgules)"@fr ;
   skos:prefLabel "Comma Separated Values"@en ;
   skos:prefLabel "Werte durch Komma getrennt"@de .
 
-media-type:text_directory a skos:Concept ;
-  media-type:hasMediaType "text/directory" ;
+mediatype:text_directory a skos:Concept ;
+  mediatype:hasMediaType "text/directory" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gwybodaeth cyfeiriadur"@cy ;
   skos:prefLabel "Soubor informací o adresáři"@cs ;
@@ -4510,8 +4510,8 @@ media-type:text_directory a skos:Concept ;
   skos:prefLabel "датотека са подацима о директоријуму"@sr ;
   skos:prefLabel "디렉토리 정보 파일"@ko .
 
-media-type:text_enriched a skos:Concept ;
-  media-type:hasMediaType "text/enriched" ;
+mediatype:text_enriched a skos:Concept ;
+  mediatype:hasMediaType "text/enriched" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen testun wedi ei gyfoethogi"@cy ;
   skos:prefLabel "Rozšířený textový dokument"@cs ;
@@ -4528,8 +4528,8 @@ media-type:text_enriched a skos:Concept ;
   skos:prefLabel "zəngin mətn sənədi"@az ;
   skos:prefLabel "обогаћени текстуални документ"@sr .
 
-media-type:text_html a skos:Concept ;
-  media-type:hasMediaType "text/html" ;
+mediatype:text_html a skos:Concept ;
+  mediatype:hasMediaType "text/html" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "HTML page"@en ;
   skos:prefLabel "HTML-Seite"@de ;
@@ -4538,8 +4538,8 @@ media-type:text_html a skos:Concept ;
   skos:prefLabel "HTML-sivu"@fi ;
   skos:prefLabel "Σελίδα HTML"@el .
 
-media-type:text_htmlh a skos:Concept ;
-  media-type:hasMediaType "text/htmlh" ;
+mediatype:text_htmlh a skos:Concept ;
+  mediatype:hasMediaType "text/htmlh" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Hilfeseite"@de ;
   skos:prefLabel "Stránka nápovědy"@cs ;
@@ -4557,8 +4557,8 @@ media-type:text_htmlh a skos:Concept ;
   skos:prefLabel "страна помоћи"@sr ;
   skos:prefLabel "도움말 페이지"@ko .
 
-media-type:text_mathml a skos:Concept ;
-  media-type:hasMediaType "text/mathml" ;
+mediatype:text_mathml a skos:Concept ;
+  mediatype:hasMediaType "text/mathml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen MathML"@cy ;
   skos:prefLabel "Dokument MathML"@cs ;
@@ -4576,46 +4576,46 @@ media-type:text_mathml a skos:Concept ;
   skos:prefLabel "document MathML"@fr ;
   skos:prefLabel "Έγγραφο MathML"@el .
 
-media-type:text_plain a skos:Concept ;
-  media-type:hasMediaType "text/plain" ;
+mediatype:text_plain a skos:Concept ;
+  mediatype:hasMediaType "text/plain" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
-  skos:narrower media-type:application_rtf ;
-  skos:narrower media-type:application_smil ;
-  skos:narrower media-type:application_x-asp ;
-  skos:narrower media-type:application_x-awk ;
-  skos:narrower media-type:application_x-cgi ;
-  skos:narrower media-type:application_x-csh ;
-  skos:narrower media-type:application_x-desktop ;
-  skos:narrower media-type:application_x-glade ;
-  skos:narrower media-type:application_x-javascript ;
-  skos:narrower media-type:application_x-magicpoint ;
-  skos:narrower media-type:application_x-nautilus-link ;
-  skos:narrower media-type:application_x-netscape-bookmarks ;
-  skos:narrower media-type:application_x-perl ;
-  skos:narrower media-type:application_x-php ;
-  skos:narrower media-type:application_x-profile ;
-  skos:narrower media-type:application_x-python ;
-  skos:narrower media-type:application_x-reject ;
-  skos:narrower media-type:application_x-ruby ;
-  skos:narrower media-type:application_x-shar ;
-  skos:narrower media-type:application_x-shellscript ;
-  skos:narrower media-type:application_x-theme ;
-  skos:narrower media-type:application_x-troff ;
-  skos:narrower media-type:application_x-troff-man ;
-  skos:narrower media-type:application_x-xbel ;
-  skos:narrower media-type:application_xhtmlxml ;
-  skos:narrower media-type:message_delivery-status ;
-  skos:narrower media-type:message_news ;
-  skos:narrower media-type:message_partial ;
-  skos:narrower media-type:message_rfc822 ;
+  skos:narrower mediatype:application_rtf ;
+  skos:narrower mediatype:application_smil ;
+  skos:narrower mediatype:application_x-asp ;
+  skos:narrower mediatype:application_x-awk ;
+  skos:narrower mediatype:application_x-cgi ;
+  skos:narrower mediatype:application_x-csh ;
+  skos:narrower mediatype:application_x-desktop ;
+  skos:narrower mediatype:application_x-glade ;
+  skos:narrower mediatype:application_x-javascript ;
+  skos:narrower mediatype:application_x-magicpoint ;
+  skos:narrower mediatype:application_x-nautilus-link ;
+  skos:narrower mediatype:application_x-netscape-bookmarks ;
+  skos:narrower mediatype:application_x-perl ;
+  skos:narrower mediatype:application_x-php ;
+  skos:narrower mediatype:application_x-profile ;
+  skos:narrower mediatype:application_x-python ;
+  skos:narrower mediatype:application_x-reject ;
+  skos:narrower mediatype:application_x-ruby ;
+  skos:narrower mediatype:application_x-shar ;
+  skos:narrower mediatype:application_x-shellscript ;
+  skos:narrower mediatype:application_x-theme ;
+  skos:narrower mediatype:application_x-troff ;
+  skos:narrower mediatype:application_x-troff-man ;
+  skos:narrower mediatype:application_x-xbel ;
+  skos:narrower mediatype:application_xhtmlxml ;
+  skos:narrower mediatype:message_delivery-status ;
+  skos:narrower mediatype:message_news ;
+  skos:narrower mediatype:message_partial ;
+  skos:narrower mediatype:message_rfc822 ;
   skos:prefLabel "einfaches Textdokument"@de ;
   skos:prefLabel "plain text document"@en ;
   skos:prefLabel "tekstitiedosto"@fi ;
   skos:prefLabel "vanlig tekstdokument"@no ;
   skos:prefLabel "έγγραφο απλού κειμένου"@el .
 
-media-type:text_rdf a skos:Concept ;
-  media-type:hasMediaType "text/rdf" ;
+mediatype:text_rdf a skos:Concept ;
+  mediatype:hasMediaType "text/rdf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil RDF (Resource Description Framework)"@cy ;
   skos:prefLabel "Mənbə İzahat Çərçivəsi (RDF) faylı"@az ;
@@ -4631,8 +4631,8 @@ media-type:text_rdf a skos:Concept ;
   skos:prefLabel "fichier Resource Description Framework (RDF)"@fr ;
   skos:prefLabel "자원 기술 프레임워크 (RDF) 파일"@ko .
 
-media-type:text_rfc822-headers a skos:Concept ;
-  media-type:hasMediaType "text/rfc822-headers" ;
+mediatype:text_rfc822-headers a skos:Concept ;
+  mediatype:hasMediaType "text/rfc822-headers" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Kopfzeilen"@de ;
   skos:prefLabel "Hlavičky E-mailu"@cs ;
@@ -4649,8 +4649,8 @@ media-type:text_rfc822-headers a skos:Concept ;
   skos:prefLabel "заглавља е-порука"@sr ;
   skos:prefLabel "이메일 헤더"@ko .
 
-media-type:text_richtext a skos:Concept ;
-  media-type:hasMediaType "text/richtext" ;
+mediatype:text_richtext a skos:Concept ;
+  mediatype:hasMediaType "text/richtext" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bohatý textový dokument"@cs ;
   skos:prefLabel "RTF-Textdokument"@de ;
@@ -4667,8 +4667,8 @@ media-type:text_richtext a skos:Concept ;
   skos:prefLabel "zəngin mətn sənədi"@az ;
   skos:prefLabel "обогаћени текстуални документ"@sr .
 
-media-type:text_rss a skos:Concept ;
-  media-type:hasMediaType "text/rss" ;
+mediatype:text_rss a skos:Concept ;
+  mediatype:hasMediaType "text/rss" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Crynodeb Safle RDF"@cy ;
   skos:prefLabel "RDF Sayt İcmalı"@az ;
@@ -4685,8 +4685,8 @@ media-type:text_rss a skos:Concept ;
   skos:prefLabel "Sourhn serveru RDF"@cs ;
   skos:prefLabel "sommaire RDF Site"@fr .
 
-media-type:text_sgml a skos:Concept ;
-  media-type:hasMediaType "text/sgml" ;
+mediatype:text_sgml a skos:Concept ;
+  mediatype:hasMediaType "text/sgml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen SGML"@cy ;
   skos:prefLabel "SGML document"@en ;
@@ -4698,24 +4698,24 @@ media-type:text_sgml a skos:Concept ;
   skos:prefLabel "SGML-dokument"@sv ;
   skos:prefLabel "Έγγραφο SGML"@el .
 
-media-type:text_spreadsheet a skos:Concept ;
-  media-type:hasMediaType "text/spreadsheet" ;
+mediatype:text_spreadsheet a skos:Concept ;
+  mediatype:hasMediaType "text/spreadsheet" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dokument for regnearkutveksling"@no ;
   skos:prefLabel "Spreadsheet interchange document"@en ;
   skos:prefLabel "Tabellenkalkulations-Austauschdokument"@de ;
   skos:prefLabel "taulukkovälitysasiakirja"@fi .
 
-media-type:text_tab-separated-values a skos:Concept ;
-  media-type:hasMediaType "text/tab-separated-values" ;
+mediatype:text_tab-separated-values a skos:Concept ;
+  mediatype:hasMediaType "text/tab-separated-values" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Textdokument·(Werte·durch·Tabulatorzeichen·unterteilt)"@de ;
   skos:prefLabel "sarkaimella eroteltuja arvoja tekstitiedostossa"@fi ;
   skos:prefLabel "tekstdokument (med tabulatorseparerte verdier)"@no ;
   skos:prefLabel "text document (with tab-separated values)"@en .
 
-media-type:text_vndwapwml a skos:Concept ;
-  media-type:hasMediaType "text/vnd.wap.wml" ;
+mediatype:text_vndwapwml a skos:Concept ;
+  mediatype:hasMediaType "text/vnd.wap.wml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen WML"@cy ;
   skos:prefLabel "Dokument WML"@cs ;
@@ -4733,8 +4733,8 @@ media-type:text_vndwapwml a skos:Concept ;
   skos:prefLabel "document WML"@fr ;
   skos:prefLabel "Έγγραφο WML"@el .
 
-media-type:text_x-adasrc a skos:Concept ;
-  media-type:hasMediaType "text/x-adasrc" ;
+mediatype:text_x-adasrc a skos:Concept ;
+  mediatype:hasMediaType "text/x-adasrc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ada source code"@en ;
   skos:prefLabel "Ada-Quelltext"@de ;
@@ -4742,25 +4742,25 @@ media-type:text_x-adasrc a skos:Concept ;
   skos:prefLabel "Ada-lähdekoodi"@fi ;
   skos:prefLabel "Πηγαίος κώδικας Ada"@el .
 
-media-type:text_x-authors a skos:Concept ;
-  media-type:hasMediaType "text/x-authors" ;
+mediatype:text_x-authors a skos:Concept ;
+  mediatype:hasMediaType "text/x-authors" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Autorenliste"@de ;
   skos:prefLabel "author list"@en ;
   skos:prefLabel "forfatterliste"@no ;
   skos:prefLabel "tekijäluettelo"@fi .
 
-media-type:text_x-bibtex a skos:Concept ;
-  media-type:hasMediaType "text/x-bibtex" ;
+mediatype:text_x-bibtex a skos:Concept ;
+  mediatype:hasMediaType "text/x-bibtex" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Bibtex bibliografiske data"@no ;
   skos:prefLabel "Bibtex bibliographic data"@en ;
   skos:prefLabel "bibliographische Bibitex-Daten"@de ;
   skos:prefLabel "kirjallisuusviittaustiedot (bibtex)"@fi .
 
-media-type:text_x-chdr a skos:Concept ;
-  media-type:hasMediaType "text/x-c++hdr" ;
-  media-type:hasMediaType "text/x-chdr" ;
+mediatype:text_x-chdr a skos:Concept ;
+  mediatype:hasMediaType "text/x-c++hdr" ;
+  mediatype:hasMediaType "text/x-chdr" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "C source code header"@en ;
   skos:prefLabel "C заглавља изворног кôда"@sr ;
@@ -4773,16 +4773,16 @@ media-type:text_x-chdr a skos:Concept ;
   skos:prefLabel "C-källkodshuvud"@sv ;
   skos:prefLabel "Penawd Rhaglen C"@cy .
 
-media-type:text_x-comma-separated-values a skos:Concept ;
-  media-type:hasMediaType "text/x-comma-separated-values" ;
+mediatype:text_x-comma-separated-values a skos:Concept ;
+  mediatype:hasMediaType "text/x-comma-separated-values" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Textdokument (Werte durch Kommata unterteilt)"@de ;
   skos:prefLabel "pilkulla eroteltuja arvoja tekstitiedostossa"@fi ;
   skos:prefLabel "tekstdokument (med kommaseparerte verdier)"@no ;
   skos:prefLabel "text document (with comma-separated values)"@en .
 
-media-type:text_x-copying a skos:Concept ;
-  media-type:hasMediaType "text/x-copying" ;
+mediatype:text_x-copying a skos:Concept ;
+  mediatype:hasMediaType "text/x-copying" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Podmínky licence na software"@cs ;
   skos:prefLabel "Software-Lizenzbedingungen"@de ;
@@ -4799,8 +4799,8 @@ media-type:text_x-copying a skos:Concept ;
   skos:prefLabel "лиценца за програм"@sr ;
   skos:prefLabel "소프트웨어 라이센스 조항"@ko .
 
-media-type:text_x-credits a skos:Concept ;
-  media-type:hasMediaType "text/x-credits" ;
+mediatype:text_x-credits a skos:Concept ;
+  mediatype:hasMediaType "text/x-credits" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Informace o autorovi software"@cs ;
   skos:prefLabel "Software-Impressum"@de ;
@@ -4817,17 +4817,17 @@ media-type:text_x-credits a skos:Concept ;
   skos:prefLabel "заслуге аутора програма"@sr ;
   skos:prefLabel "소프트웨어 저작자 크레디트"@ko .
 
-media-type:text_x-csharp a skos:Concept ;
-  media-type:hasMediaType "text/x-csharp" ;
+mediatype:text_x-csharp a skos:Concept ;
+  mediatype:hasMediaType "text/x-csharp" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "C# source code"@en ;
   skos:prefLabel "C#-Quelltext"@de ;
   skos:prefLabel "C#-lähdekoodi"@fi ;
   skos:prefLabel "Πηγαίος κώδικας C#"@el .
 
-media-type:text_x-csrc a skos:Concept ;
-  media-type:hasMediaType "text/x-c++src" ;
-  media-type:hasMediaType "text/x-csrc" ;
+mediatype:text_x-csrc a skos:Concept ;
+  mediatype:hasMediaType "text/x-c++src" ;
+  mediatype:hasMediaType "text/x-csrc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "C source code"@en ;
   skos:prefLabel "C++ source code"@en ;
@@ -4840,8 +4840,8 @@ media-type:text_x-csrc a skos:Concept ;
   skos:prefLabel "Πηγαίος κώδικας C++"@el ;
   skos:prefLabel "Πηγαίος κώδικας C"@el .
 
-media-type:text_x-dcl a skos:Concept ;
-  media-type:hasMediaType "text/x-dcl" ;
+mediatype:text_x-dcl a skos:Concept ;
+  mediatype:hasMediaType "text/x-dcl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DCL script"@en ;
   skos:prefLabel "DCL script"@nl ;
@@ -4859,8 +4859,8 @@ media-type:text_x-dcl a skos:Concept ;
   skos:prefLabel "script DCL"@fr ;
   skos:prefLabel "Πρόγραμμα εντολών DCL"@el .
 
-media-type:text_x-dsl a skos:Concept ;
-  media-type:hasMediaType "text/x-dsl" ;
+mediatype:text_x-dsl a skos:Concept ;
+  mediatype:hasMediaType "text/x-dsl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "DSSSL document"@en ;
   skos:prefLabel "DSSSL document"@nl ;
@@ -4878,8 +4878,8 @@ media-type:text_x-dsl a skos:Concept ;
   skos:prefLabel "document DSSSL"@fr ;
   skos:prefLabel "Έγγραφο DSSSL"@el .
 
-media-type:text_x-dtd a skos:Concept ;
-  media-type:hasMediaType "text/x-dtd" ;
+mediatype:text_x-dtd a skos:Concept ;
+  mediatype:hasMediaType "text/x-dtd" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Definice typu dokumentu"@cs ;
   skos:prefLabel "Diffiniad math dogfen"@cy ;
@@ -4896,8 +4896,8 @@ media-type:text_x-dtd a skos:Concept ;
   skos:prefLabel "дефиниција типа датотеке"@sr ;
   skos:prefLabel "문서 형식 정의"@ko .
 
-media-type:text_x-emacs-lisp a skos:Concept ;
-  media-type:hasMediaType "text/x-emacs-lisp" ;
+mediatype:text_x-emacs-lisp a skos:Concept ;
+  mediatype:hasMediaType "text/x-emacs-lisp" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Emacs Lisp -lähdekoodi"@fi ;
   skos:prefLabel "Emacs Lisp broncode"@nl ;
@@ -4915,8 +4915,8 @@ media-type:text_x-emacs-lisp a skos:Concept ;
   skos:prefLabel "Πηγαίος κώδικας Emacs Lisp"@el ;
   skos:prefLabel "Емакс Лисп изворни кôд"@sr .
 
-media-type:text_x-fortran a skos:Concept ;
-  media-type:hasMediaType "text/x-fortran" ;
+mediatype:text_x-fortran a skos:Concept ;
+  mediatype:hasMediaType "text/x-fortran" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell rhaglen FORTRAN"@cy ;
   skos:prefLabel "Fortran broncode"@nl ;
@@ -4934,8 +4934,8 @@ media-type:text_x-fortran a skos:Concept ;
   skos:prefLabel "Фортран изворни кôд"@sr ;
   skos:prefLabel "포트란 소스 코드"@ko .
 
-media-type:text_x-gettext-translation a skos:Concept ;
-  media-type:hasMediaType "text/x-gettext-translation" ;
+mediatype:text_x-gettext-translation a skos:Concept ;
+  mediatype:hasMediaType "text/x-gettext-translation" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "käännettyjä viestejä"@fi ;
   skos:prefLabel "oversatte meldinger"@no ;
@@ -4943,14 +4943,14 @@ media-type:text_x-gettext-translation a skos:Concept ;
   skos:prefLabel "übersetzte Meldungen"@de ;
   skos:prefLabel "μεταφρασμένα μηνύματα"@el .
 
-media-type:text_x-gettext-translation-template a skos:Concept ;
-  media-type:hasMediaType "text/x-gettext-translation-template" ;
+mediatype:text_x-gettext-translation-template a skos:Concept ;
+  mediatype:hasMediaType "text/x-gettext-translation-template" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Vorlage zur Nachrichtenübersetzung"@de ;
   skos:prefLabel "message translation template"@en .
 
-media-type:text_x-gtkrc a skos:Concept ;
-  media-type:hasMediaType "text/x-gtkrc" ;
+mediatype:text_x-gtkrc a skos:Concept ;
+  mediatype:hasMediaType "text/x-gtkrc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffurfosodiad GTK"@cy ;
   skos:prefLabel "GTK configuratie"@nl ;
@@ -4968,8 +4968,8 @@ media-type:text_x-gtkrc a skos:Concept ;
   skos:prefLabel "Ρυθμίσεις GTK"@el ;
   skos:prefLabel "Гтк подешавања"@sr .
 
-media-type:text_x-haskell a skos:Concept ;
-  media-type:hasMediaType "text/x-haskell" ;
+mediatype:text_x-haskell a skos:Concept ;
+  mediatype:hasMediaType "text/x-haskell" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell rhaglen Haskell"@cy ;
   skos:prefLabel "Haskell broncode"@nl ;
@@ -4987,8 +4987,8 @@ media-type:text_x-haskell a skos:Concept ;
   skos:prefLabel "code source Haskell"@fr ;
   skos:prefLabel "Πηγαίος κώδικας Haskell"@el .
 
-media-type:text_x-idl a skos:Concept ;
-  media-type:hasMediaType "text/x-idl" ;
+mediatype:text_x-idl a skos:Concept ;
+  mediatype:hasMediaType "text/x-idl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen IDL"@cy ;
   skos:prefLabel "Dokument IDL"@cs ;
@@ -5006,8 +5006,8 @@ media-type:text_x-idl a skos:Concept ;
   skos:prefLabel "document IDL"@fr ;
   skos:prefLabel "Έγγραφο IDL"@el .
 
-media-type:text_x-install a skos:Concept ;
-  media-type:hasMediaType "text/x-install" ;
+mediatype:text_x-install a skos:Concept ;
+  mediatype:hasMediaType "text/x-install" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Návod k instalaci software"@cs ;
   skos:prefLabel "Software-Installationsanleitung"@de ;
@@ -5024,8 +5024,8 @@ media-type:text_x-install a skos:Concept ;
   skos:prefLabel "упутство за инсталацију програма"@sr ;
   skos:prefLabel "소프트웨어 설치 방법"@ko .
 
-media-type:text_x-java a skos:Concept ;
-  media-type:hasMediaType "text/x-java" ;
+mediatype:text_x-java a skos:Concept ;
+  mediatype:hasMediaType "text/x-java" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Java source code"@en ;
   skos:prefLabel "Java-Quelltext"@de ;
@@ -5033,8 +5033,8 @@ media-type:text_x-java a skos:Concept ;
   skos:prefLabel "Java-lähdekoodi"@fi ;
   skos:prefLabel "Πηγαίος κώδικας Java"@el .
 
-media-type:text_x-ksh a skos:Concept ;
-  media-type:hasMediaType "text/x-ksh" ;
+mediatype:text_x-ksh a skos:Concept ;
+  mediatype:hasMediaType "text/x-ksh" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Korn qabıq skripti"@az ;
   skos:prefLabel "Korn shell script"@en ;
@@ -5052,12 +5052,12 @@ media-type:text_x-ksh a skos:Concept ;
   skos:prefLabel "Πρόγραμμα εντολών φλοιού Korn"@el ;
   skos:prefLabel "콘쉘 스크립트"@ko .
 
-media-type:text_x-ksysv-log a skos:Concept ;
-  media-type:hasMediaType "text/x-ksysv-log" ;
+mediatype:text_x-ksysv-log a skos:Concept ;
+  mediatype:hasMediaType "text/x-ksysv-log" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:text_x-literate-haskell a skos:Concept ;
-  media-type:hasMediaType "text/x-literate-haskell" ;
+mediatype:text_x-literate-haskell a skos:Concept ;
+  mediatype:hasMediaType "text/x-literate-haskell" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Haskell llenyddol"@cy ;
   skos:prefLabel "Literate Haskell-Quelltext"@de ;
@@ -5074,16 +5074,16 @@ media-type:text_x-literate-haskell a skos:Concept ;
   skos:prefLabel "code source Literate haskell"@fr ;
   skos:prefLabel "Πηγαίος κώδικας Literate haskell"@el .
 
-media-type:text_x-log a skos:Concept ;
-  media-type:hasMediaType "text/x-log" ;
+mediatype:text_x-log a skos:Concept ;
+  mediatype:hasMediaType "text/x-log" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Anwendungsprotokoll"@de ;
   skos:prefLabel "application log"@en ;
   skos:prefLabel "applikasjonslogg"@no ;
   skos:prefLabel "sovelluksen lokitiedosto"@fi .
 
-media-type:text_x-makefile a skos:Concept ;
-  media-type:hasMediaType "text/x-makefile" ;
+mediatype:text_x-makefile a skos:Concept ;
+  mediatype:hasMediaType "text/x-makefile" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil 'make'"@cy ;
   skos:prefLabel "Makefil"@sv ;
@@ -5101,16 +5101,16 @@ media-type:text_x-makefile a skos:Concept ;
   skos:prefLabel "İnşa faylı"@az ;
   skos:prefLabel "Производна датотека"@sr .
 
-media-type:text_x-moc a skos:Concept ;
-  media-type:hasMediaType "text/x-moc" ;
+mediatype:text_x-moc a skos:Concept ;
+  mediatype:hasMediaType "text/x-moc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "QT-Meta-Objektdatei"@de ;
   skos:prefLabel "Qt Meta Object -tiedosto"@fi ;
   skos:prefLabel "Qt Meta Object file"@en ;
   skos:prefLabel "Qt metaobjektfil"@no .
 
-media-type:text_x-objcsrc a skos:Concept ;
-  media-type:hasMediaType "text/x-objcsrc" ;
+mediatype:text_x-objcsrc a skos:Concept ;
+  mediatype:hasMediaType "text/x-objcsrc" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Objective-C -lähdekoodi"@fi ;
   skos:prefLabel "Objective-C source code"@en ;
@@ -5118,8 +5118,8 @@ media-type:text_x-objcsrc a skos:Concept ;
   skos:prefLabel "Objective-C-kildekode"@no ;
   skos:prefLabel "Πηγαίος κώδικας Objective-C"@el .
 
-media-type:text_x-pascal a skos:Concept ;
-  media-type:hasMediaType "text/x-pascal" ;
+mediatype:text_x-pascal a skos:Concept ;
+  mediatype:hasMediaType "text/x-pascal" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Pascal source code"@en ;
   skos:prefLabel "Pascal-Quelltext"@de ;
@@ -5127,16 +5127,16 @@ media-type:text_x-pascal a skos:Concept ;
   skos:prefLabel "Pascal-lähdekoodi"@fi ;
   skos:prefLabel "Πηγαίος κώδικας Pascal "@el .
 
-media-type:text_x-patch a skos:Concept ;
-  media-type:hasMediaType "text/x-patch" ;
+mediatype:text_x-patch a skos:Concept ;
+  mediatype:hasMediaType "text/x-patch" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Unterschied zwischen Dateien"@de ;
   skos:prefLabel "differences between files"@en ;
   skos:prefLabel "forskjeller mellom filer"@no ;
   skos:prefLabel "tiedostojen väliset erot"@fi .
 
-media-type:text_x-readme a skos:Concept ;
-  media-type:hasMediaType "text/x-readme" ;
+mediatype:text_x-readme a skos:Concept ;
+  mediatype:hasMediaType "text/x-readme" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen README"@cy ;
   skos:prefLabel "Dokument README"@cs ;
@@ -5154,8 +5154,8 @@ media-type:text_x-readme a skos:Concept ;
   skos:prefLabel "Έγγραφο README"@el ;
   skos:prefLabel "ПРОЧИТАЈМЕ документ"@sr .
 
-media-type:text_x-scheme a skos:Concept ;
-  media-type:hasMediaType "text/x-scheme" ;
+mediatype:text_x-scheme a skos:Concept ;
+  mediatype:hasMediaType "text/x-scheme" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Rhaglen Scheme"@cy ;
   skos:prefLabel "Scheme broncode"@nl ;
@@ -5173,8 +5173,8 @@ media-type:text_x-scheme a skos:Concept ;
   skos:prefLabel "code source Scheme"@fr ;
   skos:prefLabel "Πηγαίος κώδικας Scheme"@el .
 
-media-type:text_x-setext a skos:Concept ;
-  media-type:hasMediaType "text/x-setext" ;
+mediatype:text_x-setext a skos:Concept ;
+  mediatype:hasMediaType "text/x-setext" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Setext"@cy ;
   skos:prefLabel "Dokument Setext"@cs ;
@@ -5192,8 +5192,8 @@ media-type:text_x-setext a skos:Concept ;
   skos:prefLabel "document Setext"@fr ;
   skos:prefLabel "Έγγραφο Setext"@el .
 
-media-type:text_x-speech a skos:Concept ;
-  media-type:hasMediaType "text/x-speech" ;
+mediatype:text_x-speech a skos:Concept ;
+  mediatype:hasMediaType "text/x-speech" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Danışıq sənədi"@az ;
   skos:prefLabel "Dogfen leferydd"@cy ;
@@ -5211,8 +5211,8 @@ media-type:text_x-speech a skos:Concept ;
   skos:prefLabel "puheasiakirja"@fi ;
   skos:prefLabel "Έγγραφο ομιλίας"@el .
 
-media-type:text_x-sql a skos:Concept ;
-  media-type:hasMediaType "text/x-sql" ;
+mediatype:text_x-sql a skos:Concept ;
+  mediatype:hasMediaType "text/x-sql" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Côd SQL"@cy ;
   skos:prefLabel "Kód SQL"@cs ;
@@ -5230,8 +5230,8 @@ media-type:text_x-sql a skos:Concept ;
   skos:prefLabel "code SQL"@fr ;
   skos:prefLabel "Κώδικας SQL"@el .
 
-media-type:text_x-tcl a skos:Concept ;
-  media-type:hasMediaType "text/x-tcl" ;
+mediatype:text_x-tcl a skos:Concept ;
+  mediatype:hasMediaType "text/x-tcl" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Tcl script"@en ;
   skos:prefLabel "Tcl-Skript"@de ;
@@ -5240,8 +5240,8 @@ media-type:text_x-tcl a skos:Concept ;
   skos:prefLabel "Tcl-skripti"@fi ;
   skos:prefLabel "Πρόγραμμα εντολών Tcl"@el .
 
-media-type:text_x-tex a skos:Concept ;
-  media-type:hasMediaType "text/x-tex" ;
+mediatype:text_x-tex a skos:Concept ;
+  mediatype:hasMediaType "text/x-tex" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen TeX "@cy ;
   skos:prefLabel "TeX document"@en ;
@@ -5253,8 +5253,8 @@ media-type:text_x-tex a skos:Concept ;
   skos:prefLabel "TeX-dokument"@sv ;
   skos:prefLabel "Έγγραφο TeX"@el .
 
-media-type:text_x-texinfo a skos:Concept ;
-  media-type:hasMediaType "text/x-texinfo" ;
+mediatype:text_x-texinfo a skos:Concept ;
+  mediatype:hasMediaType "text/x-texinfo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen TeXInfo"@cy ;
   skos:prefLabel "Dokument TeXInfo"@cs ;
@@ -5272,46 +5272,46 @@ media-type:text_x-texinfo a skos:Concept ;
   skos:prefLabel "Έγγραφο TeXInfo"@el ;
   skos:prefLabel "ТеХинфо документ"@sr .
 
-media-type:text_x-troff-me a skos:Concept ;
-  media-type:hasMediaType "text/x-troff-me" ;
+mediatype:text_x-troff-me a skos:Concept ;
+  mediatype:hasMediaType "text/x-troff-me" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Troff ME -syöteasiakirja"@fi ;
   skos:prefLabel "Troff ME input document"@en ;
   skos:prefLabel "Troff ME-inndatadokument"@no ;
   skos:prefLabel "Troff-ME-Eingabedokument"@de .
 
-media-type:text_x-troff-mm a skos:Concept ;
-  media-type:hasMediaType "text/x-troff-mm" ;
+mediatype:text_x-troff-mm a skos:Concept ;
+  mediatype:hasMediaType "text/x-troff-mm" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Troff MM -syöteasiakirja"@fi ;
   skos:prefLabel "Troff MM input document"@en ;
   skos:prefLabel "Troff MM-inndatadokument"@no ;
   skos:prefLabel "Troff-MM-Eingabedokument"@de .
 
-media-type:text_x-troff-ms a skos:Concept ;
-  media-type:hasMediaType "text/x-troff-ms" ;
+mediatype:text_x-troff-ms a skos:Concept ;
+  mediatype:hasMediaType "text/x-troff-ms" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Troff MS -syöteasiakirja"@fi ;
   skos:prefLabel "Troff MS input document"@en ;
   skos:prefLabel "Troff MS-inndatadokument"@no ;
   skos:prefLabel "Troff-MS-Eingabedokument"@de .
 
-media-type:text_x-uil a skos:Concept ;
-  media-type:hasMediaType "text/x-uil" ;
+mediatype:text_x-uil a skos:Concept ;
+  mediatype:hasMediaType "text/x-uil" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "X-Motif UIL -taulukko"@fi ;
   skos:prefLabel "X-Motif UIL table"@en ;
   skos:prefLabel "X-Motif-UIL-Tabelle"@de .
 
-media-type:text_x-uri a skos:Concept ;
-  media-type:hasMediaType "text/x-uri" ;
+mediatype:text_x-uri a skos:Concept ;
+  mediatype:hasMediaType "text/x-uri" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ressourcenort"@de ;
   skos:prefLabel "resource location"@en ;
   skos:prefLabel "ressurslokasjon"@no .
 
-media-type:text_x-vcalendar a skos:Concept ;
-  media-type:hasMediaType "text/x-vcalendar" ;
+mediatype:text_x-vcalendar a skos:Concept ;
+  mediatype:hasMediaType "text/x-vcalendar" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gyfnewid vCalendar"@cy ;
   skos:prefLabel "Soubor výměny vCalendar"@cs ;
@@ -5327,8 +5327,8 @@ media-type:text_x-vcalendar a skos:Concept ;
   skos:prefLabel "vCalendar-välitystiedosto"@fi ;
   skos:prefLabel "Датотека за vCalendar размену"@sr .
 
-media-type:text_x-vcard a skos:Concept ;
-  media-type:hasMediaType "text/x-vcard" ;
+mediatype:text_x-vcard a skos:Concept ;
+  mediatype:hasMediaType "text/x-vcard" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "electronic business card"@en ;
   skos:prefLabel "elektronische Visitenkarte"@de ;
@@ -5336,14 +5336,14 @@ media-type:text_x-vcard a skos:Concept ;
   skos:prefLabel "elektroniskt visitkort"@sv ;
   skos:prefLabel "sähköinen käyntikortti"@fi .
 
-media-type:text_x-xmi a skos:Concept ;
-  media-type:hasMediaType "text/x-xmi" ;
+mediatype:text_x-xmi a skos:Concept ;
+  mediatype:hasMediaType "text/x-xmi" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "XML Metadata Interchange file"@en ;
   skos:prefLabel "XML-Metadaten-Austauschdatei"@de .
 
-media-type:text_x-xslfo a skos:Concept ;
-  media-type:hasMediaType "text/x-xslfo" ;
+mediatype:text_x-xslfo a skos:Concept ;
+  mediatype:hasMediaType "text/x-xslfo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gwrthrych ffurfwedd XSL"@cy ;
   skos:prefLabel "Soubor objektu formátování XSL"@cs ;
@@ -5359,20 +5359,20 @@ media-type:text_x-xslfo a skos:Concept ;
   skos:prefLabel "fichier objet XSL Formating"@fr ;
   skos:prefLabel "Датотека XSL објеката форматирања"@sr .
 
-media-type:text_x-xslt a skos:Concept ;
-  media-type:hasMediaType "text/x-xslt" ;
+mediatype:text_x-xslt a skos:Concept ;
+  mediatype:hasMediaType "text/x-xslt" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "XSLT stylesheet"@en ;
   skos:prefLabel "XSLT-Stylesheet"@de ;
   skos:prefLabel "XSLT-stilark"@no ;
   skos:prefLabel "XSLT-tyylitiedosto"@fi .
 
-media-type:text_xmcd a skos:Concept ;
-  media-type:hasMediaType "text/xmcd" ;
+mediatype:text_xmcd a skos:Concept ;
+  mediatype:hasMediaType "text/xmcd" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
 
-media-type:text_xml a skos:Concept ;
-  media-type:hasMediaType "text/xml" ;
+mediatype:text_xml a skos:Concept ;
+  mediatype:hasMediaType "text/xml" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Dogfen XML (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language)"@cy ;
   skos:prefLabel "Dokument eXtensible Markup Language"@cs ;
@@ -5388,28 +5388,28 @@ media-type:text_xml a skos:Concept ;
   skos:prefLabel "документ проширивог језика за означавање (XML)"@sr ;
   skos:prefLabel "확장 마크업 언어 문서"@ko .
 
-media-type:video a skos:Collection ;
+mediatype:video a skos:Collection ;
   rdfs:label "Video types"@en ;
   dct:description "The collection of video types"@en ;
   dct:title "Video types"@en ;
-  skos:member media-type:video_isivideo ;
-  skos:member media-type:video_mpeg ;
-  skos:member media-type:video_quicktime ;
-  skos:member media-type:video_vivo ;
-  skos:member media-type:video_wavelet ;
-  skos:member media-type:video_x-anim ;
-  skos:member media-type:video_x-avi ;
-  skos:member media-type:video_x-flic ;
-  skos:member media-type:video_x-mng ;
-  skos:member media-type:video_x-ms-asf ;
-  skos:member media-type:video_x-ms-wmv ;
-  skos:member media-type:video_x-msvideo ;
-  skos:member media-type:video_x-nsv ;
-  skos:member media-type:video_x-real-video ;
-  skos:member media-type:video_x-sgi-movie .
+  skos:member mediatype:video_isivideo ;
+  skos:member mediatype:video_mpeg ;
+  skos:member mediatype:video_quicktime ;
+  skos:member mediatype:video_vivo ;
+  skos:member mediatype:video_wavelet ;
+  skos:member mediatype:video_x-anim ;
+  skos:member mediatype:video_x-avi ;
+  skos:member mediatype:video_x-flic ;
+  skos:member mediatype:video_x-mng ;
+  skos:member mediatype:video_x-ms-asf ;
+  skos:member mediatype:video_x-ms-wmv ;
+  skos:member mediatype:video_x-msvideo ;
+  skos:member mediatype:video_x-nsv ;
+  skos:member mediatype:video_x-real-video ;
+  skos:member mediatype:video_x-sgi-movie .
 
-media-type:video_isivideo a skos:Concept ;
-  media-type:hasMediaType "video/isivideo" ;
+mediatype:video_isivideo a skos:Concept ;
+  mediatype:hasMediaType "video/isivideo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Fideo ISI"@cy ;
   skos:prefLabel "ISI video faylı"@az ;
@@ -5427,8 +5427,8 @@ media-type:video_isivideo a skos:Concept ;
   skos:prefLabel "vidéo ISI"@fr ;
   skos:prefLabel "Βίντεο ISI"@el .
 
-media-type:video_mpeg a skos:Concept ;
-  media-type:hasMediaType "video/mpeg" ;
+mediatype:video_mpeg a skos:Concept ;
+  mediatype:hasMediaType "video/mpeg" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MPEG video"@en ;
   skos:prefLabel "MPEG-Video"@de ;
@@ -5437,8 +5437,8 @@ media-type:video_mpeg a skos:Concept ;
   skos:prefLabel "MPEG-video"@sv ;
   skos:prefLabel "Βίντεο MPEG"@el .
 
-media-type:video_quicktime a skos:Concept ;
-  media-type:hasMediaType "video/quicktime" ;
+mediatype:video_quicktime a skos:Concept ;
+  mediatype:hasMediaType "video/quicktime" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "QuickTime video"@en ;
   skos:prefLabel "QuickTime-Video"@de ;
@@ -5446,8 +5446,8 @@ media-type:video_quicktime a skos:Concept ;
   skos:prefLabel "Quicktime-film"@no ;
   skos:prefLabel "Βίντεο QuickTime"@el .
 
-media-type:video_vivo a skos:Concept ;
-  media-type:hasMediaType "video/vivo" ;
+mediatype:video_vivo a skos:Concept ;
+  mediatype:hasMediaType "video/vivo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Fideo Vivo"@cy ;
   skos:prefLabel "Video Vivo"@cs ;
@@ -5465,8 +5465,8 @@ media-type:video_vivo a skos:Concept ;
   skos:prefLabel "vidéo Vivo"@fr ;
   skos:prefLabel "Βίντεο Vivo"@el .
 
-media-type:video_wavelet a skos:Concept ;
-  media-type:hasMediaType "video/wavelet" ;
+mediatype:video_wavelet a skos:Concept ;
+  mediatype:hasMediaType "video/wavelet" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Fideo Wavelet"@cy ;
   skos:prefLabel "Video Wavelet"@cs ;
@@ -5484,8 +5484,8 @@ media-type:video_wavelet a skos:Concept ;
   skos:prefLabel "vidéo Wavelet"@fr ;
   skos:prefLabel "Βίντεο Wavelet"@el .
 
-media-type:video_x-anim a skos:Concept ;
-  media-type:hasMediaType "video/x-anim" ;
+mediatype:video_x-anim a skos:Concept ;
+  mediatype:hasMediaType "video/x-anim" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "ANIM animasiyası"@az ;
   skos:prefLabel "ANIM animatie"@nl ;
@@ -5503,8 +5503,8 @@ media-type:video_x-anim a skos:Concept ;
   skos:prefLabel "animation ANIM"@fr ;
   skos:prefLabel "Κινούμενο σχέδιο ANIM"@el .
 
-media-type:video_x-avi a skos:Concept ;
-  media-type:hasMediaType "video/x-avi" ;
+mediatype:video_x-avi a skos:Concept ;
+  mediatype:hasMediaType "video/x-avi" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AVI video faylı"@az ;
   skos:prefLabel "AVI video"@en ;
@@ -5522,24 +5522,24 @@ media-type:video_x-avi a skos:Concept ;
   skos:prefLabel "vidéo AVI"@fr ;
   skos:prefLabel "Βίντεο AVI"@el .
 
-media-type:video_x-flic a skos:Concept ;
-  media-type:hasMediaType "video/x-flic" ;
+mediatype:video_x-flic a skos:Concept ;
+  mediatype:hasMediaType "video/x-flic" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "AutoDesk FLIC -animaatio"@fi ;
   skos:prefLabel "AutoDesk FLIC animation"@en ;
   skos:prefLabel "AutoDesk FLIC-animasjon"@no ;
   skos:prefLabel "AutoDesk-FLIC-Animation"@de .
 
-media-type:video_x-mng a skos:Concept ;
-  media-type:hasMediaType "video/x-mng" ;
+mediatype:video_x-mng a skos:Concept ;
+  mediatype:hasMediaType "video/x-mng" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "MNG animation"@en ;
   skos:prefLabel "MNG-Animation"@de ;
   skos:prefLabel "MNG-animaatio"@fi ;
   skos:prefLabel "MNG-animasjon"@no .
 
-media-type:video_x-ms-asf a skos:Concept ;
-  media-type:hasMediaType "video/x-ms-asf" ;
+mediatype:video_x-ms-asf a skos:Concept ;
+  mediatype:hasMediaType "video/x-ms-asf" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft ASF -video"@fi ;
   skos:prefLabel "Microsoft ASF video"@en ;
@@ -5547,8 +5547,8 @@ media-type:video_x-ms-asf a skos:Concept ;
   skos:prefLabel "Microsoft-ASF-Video"@de ;
   skos:prefLabel "Βίντεο Microsoft ASF"@el .
 
-media-type:video_x-ms-wmv a skos:Concept ;
-  media-type:hasMediaType "video/x-ms-wmv" ;
+mediatype:video_x-ms-wmv a skos:Concept ;
+  mediatype:hasMediaType "video/x-ms-wmv" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft WMV -video"@fi ;
   skos:prefLabel "Microsoft WMV video faylı"@az ;
@@ -5566,8 +5566,8 @@ media-type:video_x-ms-wmv a skos:Concept ;
   skos:prefLabel "Микрософт WMV видео"@sr ;
   skos:prefLabel "마이크로소프트 WMV 비디오"@ko .
 
-media-type:video_x-msvideo a skos:Concept ;
-  media-type:hasMediaType "video/x-msvideo" ;
+mediatype:video_x-msvideo a skos:Concept ;
+  mediatype:hasMediaType "video/x-msvideo" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Microsoft AVI -video"@fi ;
   skos:prefLabel "Microsoft AVI video"@en ;
@@ -5576,8 +5576,8 @@ media-type:video_x-msvideo a skos:Concept ;
   skos:prefLabel "Microsoft-AVI-Video"@de ;
   skos:prefLabel "Βίντεο Microsoft AVI"@el .
 
-media-type:video_x-nsv a skos:Concept ;
-  media-type:hasMediaType "video/x-nsv" ;
+mediatype:video_x-nsv a skos:Concept ;
+  mediatype:hasMediaType "video/x-nsv" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Fideo Nullsoft"@cy ;
   skos:prefLabel "Nullsoft video faylı"@az ;
@@ -5595,8 +5595,8 @@ media-type:video_x-nsv a skos:Concept ;
   skos:prefLabel "Βίντεο Nullsoft"@el ;
   skos:prefLabel "널소프트 비디오"@ko .
 
-media-type:video_x-real-video a skos:Concept ;
-  media-type:hasMediaType "video/x-real-video" ;
+mediatype:video_x-real-video a skos:Concept ;
+  mediatype:hasMediaType "video/x-real-video" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "Fideo RealVideo"@cy ;
   skos:prefLabel "RealVideo film"@no ;
@@ -5614,8 +5614,8 @@ media-type:video_x-real-video a skos:Concept ;
   skos:prefLabel "Βίντεο RealVideo"@el ;
   skos:prefLabel "리얼비디오 비디오"@ko .
 
-media-type:video_x-sgi-movie a skos:Concept ;
-  media-type:hasMediaType "video/x-sgi-movie" ;
+mediatype:video_x-sgi-movie a skos:Concept ;
+  mediatype:hasMediaType "video/x-sgi-movie" ;
   skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
   skos:prefLabel "SGI video faylı"@az ;
   skos:prefLabel "SGI video"@en ;


### PR DESCRIPTION
This Pr fixes the wrong `media-type` prefix as listed in this [issue](https://github.com/okp4/ontology/issues/185).
Instead of pointing to `license`, it is now pointing to `media-type`.

Additionally, the prefix has been modified to camel case to remain consistent with its naming in the datasets examples and to adhere to SPARQL naming conventions.
