### PR TITLE
Feat/add mediatype format

### DIFF
--- a/example/rhizome/dataset/142dacec-eb0f-4cd3-ab2b-d2095b8552b3.ttl
+++ b/example/rhizome/dataset/142dacec-eb0f-4cd3-ab2b-d2095b8552b3.ttl
@@ -15,7 +15,7 @@
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
     core:hasDescription "ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a \"COG\" edition, in accordance with the official geographic code published each year by INSEE."@en ;
     core:hasDescription "ADMIN EXPRESS ermöglicht es, Kreuzungen mit anderen Datenquellen vorzunehmen, um thematische Darstellungen des Gebiets nach administrativer Granularität (Gemeinde, Departementsbezirke, Departement, Region) zu erstellen. ADMIN EXPRESS ist in einer \"COG\"-Ausgabe erhältlich, die dem offiziellen geografischen Code entspricht, der jedes Jahr vom INSEE veröffentlicht wird."@de ;
-    core:hasFormat mediatype:application_vnd-shp ;
+    core:hasFormat mediatype:application_vndshp ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/example/rhizome/dataset/3545ec2f-13cd-4909-a52f-df938e8c7a61.ttl
+++ b/example/rhizome/dataset/3545ec2f-13cd-4909-a52f-df938e8c7a61.ttl
@@ -23,7 +23,7 @@
     core:hasDescription "Le registre parcellaire graphique est une base de données géographiques servant de référence à l'instruction des aides de la politique agricole commune (PAC). La version anonymisée diffusée ici dans le cadre du service public de mise à disposition des données de référence contient les données graphiques des parcelles (depuis 2015) munis de leur culture principale. Ces données sont produites par l'agence de services et de paiement (ASP) depuis 2007"@fr ;
     core:hasDescription "The graphical parcel register is a geographic database used as a reference for the instruction of Common Agricultural Policy (CAP) subsidies. The anonymized version distributed here as part of the public service for making reference data available contains the graphic data of parcels (since 2015) with their main crop. These data are produced by the Agency of Services and Payment (ASP) since 2007"@en ;
     core:hasDescription "Das grafische Parzellenregister ist eine geografische Datenbank, die als Referenz für die Bearbeitung von Beihilfen im Rahmen der Gemeinsamen Agrarpolitik (GAP) dient. Die anonymisierte Version, die hier im Rahmen des öffentlichen Dienstes zur Bereitstellung von Referenzdaten verbreitet wird, enthält die grafischen Daten der Parzellen (seit 2015), die mit ihrer Hauptkultur versehen sind. Diese Daten werden seit 2007 von der Agence de services et de paiement (ASP) erstellt."@de ;
-    core:hasFormat mediatype:application_geopackage-sqlite3 ;
+    core:hasFormat mediatype:application_geopackagesqlite3 ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/example/rhizome/dataset/5a5def4d-8328-4830-b71e-b19d9e2394bc.ttl
+++ b/example/rhizome/dataset/5a5def4d-8328-4830-b71e-b19d9e2394bc.ttl
@@ -23,7 +23,7 @@
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
     core:hasDescription "ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a \"COG\" edition, in accordance with the official geographic code published each year by INSEE."@en ;
     core:hasDescription "ADMIN EXPRESS ermöglicht es, Kreuzungen mit anderen Datenquellen vorzunehmen, um thematische Darstellungen des Gebiets nach administrativer Granularität (Gemeinde, Departementsbezirke, Departement, Region) zu erstellen. ADMIN EXPRESS ist in einer \"COG\"-Ausgabe erhältlich, die dem offiziellen geografischen Code entspricht, der jedes Jahr vom INSEE veröffentlicht wird."@de ;
-    core:hasFormat mediatype:application_vnd-shp ;
+    core:hasFormat mediatype:application_vndshp ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/example/rhizome/dataset/79ec2986-0d71-4e92-a48d-95379b3da9ed.ttl
+++ b/example/rhizome/dataset/79ec2986-0d71-4e92-a48d-95379b3da9ed.ttl
@@ -15,7 +15,7 @@
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
     core:hasDescription "ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a \"COG\" edition, in accordance with the official geographic code published each year by INSEE."@en ;
     core:hasDescription "ADMIN EXPRESS ermöglicht es, Kreuzungen mit anderen Datenquellen vorzunehmen, um thematische Darstellungen des Gebiets nach administrativer Granularität (Gemeinde, Departementsbezirke, Departement, Region) zu erstellen. ADMIN EXPRESS ist in einer \"COG\"-Ausgabe erhältlich, die dem offiziellen geografischen Code entspricht, der jedes Jahr vom INSEE veröffentlicht wird."@de ;
-    core:hasFormat mediatype:application_vnd-shp ;
+    core:hasFormat mediatype:application_vndshp ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/example/rhizome/dataset/7ff3d2a4-e6b2-4b06-8619-4fc8740dad86.ttl
+++ b/example/rhizome/dataset/7ff3d2a4-e6b2-4b06-8619-4fc8740dad86.ttl
@@ -23,7 +23,7 @@
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
     core:hasDescription "ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a \"COG\" edition, in accordance with the official geographic code published each year by INSEE."@en ;
     core:hasDescription "ADMIN EXPRESS ermöglicht es, Kreuzungen mit anderen Datenquellen vorzunehmen, um thematische Darstellungen des Gebiets nach administrativer Granularität (Gemeinde, Departementsbezirke, Departement, Region) zu erstellen. ADMIN EXPRESS ist in einer \"COG\"-Ausgabe erhältlich, die dem offiziellen geografischen Code entspricht, der jedes Jahr vom INSEE veröffentlicht wird."@de ;
-    core:hasFormat mediatype:application_vnd-shp ;
+    core:hasFormat mediatype:application_vndshp ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/example/rhizome/dataset/cb6ea0aa-e32d-4d79-8492-a6ebcc80b897.ttl
+++ b/example/rhizome/dataset/cb6ea0aa-e32d-4d79-8492-a6ebcc80b897.ttl
@@ -15,7 +15,7 @@
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
     core:hasDescription "ADMIN EXPRESS allows cross-referencing with other data sources in order to build thematic representations of the territory according to an administrative granularity (commune, departmental district, department, region). ADMIN EXPRESS is available in a \"COG\" edition, in accordance with the official geographic code published each year by INSEE."@en ;
     core:hasDescription "ADMIN EXPRESS ermöglicht es, Kreuzungen mit anderen Datenquellen vorzunehmen, um thematische Darstellungen des Gebiets nach administrativer Granularität (Gemeinde, Departementsbezirke, Departement, Region) zu erstellen. ADMIN EXPRESS ist in einer \"COG\"-Ausgabe erhältlich, die dem offiziellen geografischen Code entspricht, der jedes Jahr vom INSEE veröffentlicht wird."@de ;
-    core:hasFormat mediatype:application_vnd-shp ;
+    core:hasFormat mediatype:application_vndshp ;
     core:hasImage <https://images.unsplash.com/photo-1537721664796-76f77222a5d0> ;
     core:hasLicense license:LO-FR-2_0 ;
     core:hasPublisher "OKP4" ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -4380,6 +4380,7 @@ mediatype:text a skos:Collection ;
   dct:title "Text types"@en ;
   skos:member mediatype:text_calendar ;
   skos:member mediatype:text_css ;
+  skos:member mediatype:text_csv ;
   skos:member mediatype:text_directory ;
   skos:member mediatype:text_enriched ;
   skos:member mediatype:text_html ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -33,6 +33,7 @@ mediatype:application a skos:Collection ;
   dct:title "Application types"@en ;
   skos:member mediatype:application_andrew-inset ;
   skos:member mediatype:application_illustrator ;
+  skos:member mediatype:application_geopackagesqlite3 ;
   skos:member mediatype:application_mac-binhex40 ;
   skos:member mediatype:application_octet-stream ;
   skos:member mediatype:application_oda ;
@@ -258,6 +259,19 @@ mediatype:application_illustrator a skos:Concept ;
   skos:prefLabel "Adobe Illustrator-dokument"@no ;
   skos:prefLabel "Adobe Illustrator-dokument"@sv ;
   skos:prefLabel "Έγγραφο Adobe Illustrator"@el .
+
+mediatype:geopackagesqlite3 a skos:Concept ;
+  mediatype:hasMediaType "application/geopackage+sqlite3" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "GeoPackage SQLite3 Database"@en ;
+  skos:prefLabel "Base de données GeoPackage SQLite3"@fr ;
+  skos:prefLabel "GeoPackage SQLite3-Datenbank"@de ;
+  skos:prefLabel "Base de datos GeoPackage SQLite3"@es ;
+  skos:prefLabel "Database GeoPackage SQLite3"@it ;
+  skos:prefLabel "GeoPackage SQLite3 Database"@nl ;
+  skos:prefLabel "Base de Dados GeoPackage SQLite3"@pt ;
+  skos:prefLabel "GeoPackage SQLite3 データベース"@ja ;
+  skos:prefLabel "GeoPackage SQLite3 数据库"@zh .
 
 mediatype:application_mac-binhex40 a skos:Concept ;
   mediatype:hasMediaType "application/mac-binhex40" ;

--- a/src/vocab-mediatype.ttl
+++ b/src/vocab-mediatype.ttl
@@ -56,6 +56,7 @@ mediatype:application a skos:Collection ;
   skos:member mediatype:application_vndms-word ;
   skos:member mediatype:application_vndpalm ;
   skos:member mediatype:application_vndrn-realmedia ;
+  skos:member mediatype:application_vndshp ;
   skos:member mediatype:application_vndstardivisioncalc ;
   skos:member mediatype:application_vndstardivisionchart ;
   skos:member mediatype:application_vndstardivisiondraw ;
@@ -600,6 +601,19 @@ mediatype:application_vndrn-realmedia a skos:Concept ;
   skos:prefLabel "Document RealAudio/Video"@fr ;
   skos:prefLabel "Έγγραφο RealAudio/Video"@el ;
   skos:prefLabel "리얼오디오/비디오 문서"@ko .
+
+mediatype:shapefile a skos:Concept ;
+  mediatype:hasMediaType "application/vndshp" ;
+  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:prefLabel "Shapefile"@en ;
+  skos:prefLabel "Shapefile"@fr ;
+  skos:prefLabel "Shapefile"@de ;
+  skos:prefLabel "Shapefile"@es ;
+  skos:prefLabel "Shapefile"@it ;
+  skos:prefLabel "Shapefile"@nl ;
+  skos:prefLabel "Shapefile"@pt ;
+  skos:prefLabel "Shapefile"@ja ;
+  skos:prefLabel "Shapefile"@zh .
 
 mediatype:application_vndstardivisioncalc a skos:Concept ;
   mediatype:hasMediaType "application/vnd.stardivision.calc" ;


### PR DESCRIPTION
@lolottetheclash noticed certain inconsistencies regarding the MediaTypes that were present in the format of a dataset, but not necessarily in the collection `vocab-mediatype.ttl` :

- `text_csv`
-  `application_vndshp`
-  `application_vnd-shp`
-  `application_geopackage-sqlite3`

I have taken the following actions:

- Added `text_csv` to the collection
- Replaced `application_vnd-shp` with `application_vndshp` in the datasets, and added `application_vndshp` to the collection.
- Replaced `application_geopackage-sqlite3` with `application_geopackagesqlite3` in the datasets, and added `geopackage+sqlite3` to the collection

This was based on the MIME types found at https://www.digipres.org/formats/sources/fdd/formats/