### PR TITLE
Refactor/update uri scheme

### DIFF
--- a/.github/gh-home/index.html
+++ b/.github/gh-home/index.html
@@ -2,7 +2,7 @@
 <html>
    <head>
       <title>OKP4 ontology</title>
-      <meta http-equiv = "refresh" content = "1; url = https://ontology.okp4.space/versions/{{release_version}}/index-en.html" />
+      <meta http-equiv = "refresh" content = "1; url = https://w3id.org/okp4/ontology/versions/{{release_version}}/index-en.html" />
    </head>
    <body> </body>
 </html>

--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -18,5 +18,5 @@ jobs:
             {
               "avatar_url": "https://avatars.githubusercontent.com/u/98603954?v=4",
               "username": "Bot Anik",
-              "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 Documentation: https://ontology.okp4.space"
+              "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 Documentation: https://w3id.org/okp4/ontology"
             }

--- a/example_old/appelagri/appelagri.ttl
+++ b/example_old/appelagri/appelagri.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/8de73f45-cd3d-4194-b52d-81c98f78fecf> a owl:NamedIndividual, 
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/8de73f45-cd3d-4194-b52d-81c98f78fecf> a owl:NamedIndividual, 
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:ababcf97-a85f-4bf2-b890-34624928452c ;  
     core:hasDescription "Le calcul de l'empreinte carbone d'une exploitation agricole nécessite de nombreuses données (consommation d'électricité, taille du cheptel, produits phytosanitaires utilisés, etc.) La collecte de ces données prend beaucoup de temps (en moyenne 1 jour par exploitation) alors que toutes ces données existent dans différents systèmes d'information. O2M développe un outil numérique pour le calcul des crédits carbone. L'objectif de cette Zone est d'automatiser la collecte des open data agricoles."@fr ;
     core:hasDescription "Calculating the carbon footprint of a farm requires a lot of data (electricity consumption, livestock size, plant protection products used, etc.). The collection of these data is very time consuming (on average 1 day) while all these data exist in various information systems. O2M is developing a digital tool for the calculation of carbon credits. The objective of this Zone is to automate the collection of agricultural open data."@en ;
@@ -18,8 +18,8 @@
     core:hasTitle "APPEL AGRI"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/4574dd4a-2a12-4608-bdb3-fa8193be49fa> a owl:NamedIndividual,   
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/4574dd4a-2a12-4608-bdb3-fa8193be49fa> a owl:NamedIndividual,   
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-08-28T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:ababcf97-a85f-4bf2-b890-34624928452c ;  

--- a/example_old/appelagri/governance.ttl
+++ b/example_old/appelagri/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:cc8076d7-2db5-4436-a508-7251b10daf51 a owl:NamedIndividual,    
         metagov:GovernanceMetadata ;

--- a/example_old/cads/cads.ttl
+++ b/example_old/cads/cads.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/5da6d183-8f96-4a00-bbc9-bc08c4ca3b81> a owl:NamedIndividual,   
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/5da6d183-8f96-4a00-bbc9-bc08c4ca3b81> a owl:NamedIndividual,   
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:fdfde6f6-b5d8-4c6b-ae4c-3451b92d5314 ; 
     core:hasDescription "Dans le cadre du projet CADS, cette zone a pour objectif de calculer un indicateur agro environnemental à partir d'un composant de l'architecture i4trust."@fr ;
     core:hasDescription "As part of the CADS project, the aim of this zone is to calculate an agri-environmental indicator based on the i4trust architecture context broker."@en ;
@@ -16,8 +16,8 @@
     core:hasTitle "CADS"@en ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/f93819f4-241f-464e-9298-a16f21be3dc0> a owl:NamedIndividual,    
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/f93819f4-241f-464e-9298-a16f21be3dc0> a owl:NamedIndividual,    
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-08-25T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:fdfde6f6-b5d8-4c6b-ae4c-3451b92d5314 ;  

--- a/example_old/cads/governance.ttl
+++ b/example_old/cads/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:e5cc7028-bd3f-4298-b209-8783e65962d1 a owl:NamedIndividual,   
         metagov:GovernanceMetadata ;

--- a/example_old/crop/crop.ttl
+++ b/example_old/crop/crop.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/d0c63b88-44f8-4518-b62d-e141dd8fb624> a owl:NamedIndividual,   
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/d0c63b88-44f8-4518-b62d-e141dd8fb624> a owl:NamedIndividual,   
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:a19fec74-d428-46ac-ad3b-730e520fef86 ; 
     core:hasDescription "Aujourd'hui, les coopératives et les négociants ont besoin d'une connaissance fine de leur territoire pour optimiser leurs activités d'approvisionnement et de collecte, mais aussi pour accompagner les agriculteurs dans la transition agro-écologique. Le projet CROP répond à ces enjeux en proposant un outil de visualisation des données agro-économiques des territoires. CROP permet de croiser différentes sources de données pour obtenir une meilleure connaissance à l'échelle de l'exploitation mais aussi de son territoire."@fr ;
     core:hasDescription "Today, cooperatives and traders need to have a detailed knowledge of their territory to optimize their supply and collection activities, but also to support farmers in the agro-ecological transition. The CROP project responds to these challenges by proposing an agro-economic data visualization tool for territories. CROP allows to cross different data sources to get a better knowledge at the scale of the farm but also of its territory."@en ;
@@ -18,8 +18,8 @@
     core:hasTitle "CROP"@en ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/ac2548f8-106c-4802-9d51-0aa3c8754842> a owl:NamedIndividual,    
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/ac2548f8-106c-4802-9d51-0aa3c8754842> a owl:NamedIndividual,    
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-07-03T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:a19fec74-d428-46ac-ad3b-730e520fef86 ;  

--- a/example_old/crop/governance.ttl
+++ b/example_old/crop/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:149e5b0b-25f7-4bb7-9b7a-9894c7b701ad a owl:NamedIndividual, 
         metagov:GovernanceMetadata ;

--- a/example_old/ddp/ddp.ttl
+++ b/example_old/ddp/ddp.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/86500dd6-080c-4565-8779-8a0aa052f166> a owl:NamedIndividual,  
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/86500dd6-080c-4565-8779-8a0aa052f166> a owl:NamedIndividual,  
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:d74127ac-d411-4fef-9d65-73c6fc22315d ;  
     core:hasDescription "Porté par CERFRANCE Bretagne, la data est dans le pré (ou DDP) est une Zone dont l'objectif est de valoriser les données agricoles (techniques et comptables) au travers d’un mécanisme de fixation du prix juste pour les produits laitiers, pour ensuite fournir des conseils spécifiques à chaque agriculteur."@fr ;
     core:hasDescription "Supported by CERFRANCE Bretagne, la data est dans le pré (or DDP) is a Zone whose aim is to enhance the value of agricultural data (technical and accounting) through a mechanism for setting the right price for dairy products, and then providing specific advice to each farmer."@en ;
@@ -19,8 +19,8 @@
     core:hasTitle "DDP"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/3e2b1391-088e-4516-af0b-8d0f62c2c7ac> a owl:NamedIndividual,    
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/3e2b1391-088e-4516-af0b-8d0f62c2c7ac> a owl:NamedIndividual,    
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-07-03T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:d74127ac-d411-4fef-9d65-73c6fc22315d ;  

--- a/example_old/ddp/governance.ttl
+++ b/example_old/ddp/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:3ec30d52-02c7-4245-a9a6-8219774d38c4 a owl:NamedIndividual,
         metagov:GovernanceMetadata ;

--- a/example_old/ds4i/ds4i.ttl
+++ b/example_old/ds4i/ds4i.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/dcf48417-01c5-4b43-9bc7-49e54c028473> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:97ff7e16-c08d-47be-8475-211016c82e33 ;
     core:hasDescription "Data Space for Investors (DS4I) est une zone privée créée et maintenue par l'équipe OKP4. L'objectif de DS4I est de présenter une preuve de concept simple et conviviale pour démontrer aux investisseurs potentiels comment le protocole OKP4 fonctionne sur la base de règles de gouvernance simples."@fr ;
     core:hasDescription "Data Space for Investors (DS4I) is a private Zone created and maintained by OKP4 Team. DS4I's purpose is to present a simple and user-friendly Proof of Concept to demonstrate for potential investors how OKP4 protocol works based on simple governance rules."@en ;
@@ -20,8 +20,8 @@
     core:hasTitle "Datenraum für Investoren"@de ;
     core:hasTopic topic:BusinessAndPurchase .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/1f10aa9c-67da-4254-972d-a0d619d6bf95> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/1f10aa9c-67da-4254-972d-a0d619d6bf95> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2023-03-30T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:97ff7e16-c08d-47be-8475-211016c82e33 ;

--- a/example_old/ds4i/governance.ttl
+++ b/example_old/ds4i/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:58f368ee-fbc6-11ed-be56-0242ac120002 a owl:NamedIndividual,
         metagov:GovernanceMetadata ;

--- a/example_old/rhizome/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde.ttl
+++ b/example_old/rhizome/dataset/0ea1fc7a-dd97-4adc-a10e-169c6597bcde.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:d1615703-4ee1-4e2f-997e-15aecf1eea4e a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/10ca8ff2-f0c3-47ba-b37a-8560b2e41ae7.ttl
+++ b/example_old/rhizome/dataset/10ca8ff2-f0c3-47ba-b37a-8560b2e41ae7.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:99fa4dda-08a5-4145-9fef-15d78e35de80 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/142dacec-eb0f-4cd3-ab2b-d2095b8552b3.ttl
+++ b/example_old/rhizome/dataset/142dacec-eb0f-4cd3-ab2b-d2095b8552b3.ttl
@@ -1,15 +1,15 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/08dfb35e-604e-4409-b052-31d7412ac35d> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/08dfb35e-604e-4409-b052-31d7412ac35d> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:142dacec-eb0f-4cd3-ab2b-d2095b8552b3 ;
     core:hasCreator "IGN" ;
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
@@ -33,8 +33,8 @@
     core:hasTitle "ADMIN EXPRESS COG 2022 DEPARTEMENT"@de ;
     core:hasTopic topic:Other .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/ab1d3821-3b74-4281-8c46-f1b10ec15050> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/ab1d3821-3b74-4281-8c46-f1b10ec15050> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-08-27T14:11:45+00:00"^^xsd:dateTime ;
     core:describes dataset:142dacec-eb0f-4cd3-ab2b-d2095b8552b3 ;

--- a/example_old/rhizome/dataset/1a4c5896-b13e-40f7-a603-5a5b3ed996a1.ttl
+++ b/example_old/rhizome/dataset/1a4c5896-b13e-40f7-a603-5a5b3ed996a1.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:d37d4917-549a-434d-9dc5-68eb685f9a88 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/1ef341e8-de34-4561-95b6-29c834901c1f.ttl
+++ b/example_old/rhizome/dataset/1ef341e8-de34-4561-95b6-29c834901c1f.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:5187bd9c-289f-4e2d-9b7f-f481d6f84c18 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/2c039dd5-6cc6-41bb-88eb-ab39e9f2ea81.ttl
+++ b/example_old/rhizome/dataset/2c039dd5-6cc6-41bb-88eb-ab39e9f2ea81.ttl
@@ -1,22 +1,22 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/06d22e39-7efa-442e-ae0c-819751473313> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/06d22e39-7efa-442e-ae0c-819751473313> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-08-22T00:09:03+00:00"^^xsd:dateTime ;
     core:describes dataset:2c039dd5-6cc6-41bb-88eb-ab39e9f2ea81 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-08-22T00:09:03+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/6e54750a-8161-4297-a6db-c42c3595f345> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/6e54750a-8161-4297-a6db-c42c3595f345> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:2c039dd5-6cc6-41bb-88eb-ab39e9f2ea81 ;
     core:hasCreator "IGN" ;
     core:hasDescription "Table propre à la diffusion du RPG : La notion de groupe de culture dans cette table ne correspond pas à la notion de groupe de cultures du règlement PAC ni à celle des référentiels ISIS. Dans cette table, chaque code culture est expliqué par un libellé et lié à un code de groupe de culture et son libellé."@fr ;

--- a/example_old/rhizome/dataset/3545ec2f-13cd-4909-a52f-df938e8c7a61.ttl
+++ b/example_old/rhizome/dataset/3545ec2f-13cd-4909-a52f-df938e8c7a61.ttl
@@ -1,23 +1,23 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/8a6f91c1-25d3-4a08-bb47-05992d8a7971> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/8a6f91c1-25d3-4a08-bb47-05992d8a7971> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-04-27T00:07:18+00:00"^^xsd:dateTime ;
     core:describes dataset:3545ec2f-13cd-4909-a52f-df938e8c7a61 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-04-27T00:07:18+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/e6444502-3b2b-4d6b-ab43-b4dca11b2bab> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/e6444502-3b2b-4d6b-ab43-b4dca11b2bab> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:3545ec2f-13cd-4909-a52f-df938e8c7a61 ;
     core:hasCreator "IGN" ;
     core:hasDescription "Le registre parcellaire graphique est une base de données géographiques servant de référence à l'instruction des aides de la politique agricole commune (PAC). La version anonymisée diffusée ici dans le cadre du service public de mise à disposition des données de référence contient les données graphiques des parcelles (depuis 2015) munis de leur culture principale. Ces données sont produites par l'agence de services et de paiement (ASP) depuis 2007"@fr ;

--- a/example_old/rhizome/dataset/3ed871dc-72d0-499f-b8c2-7edcad56a76e.ttl
+++ b/example_old/rhizome/dataset/3ed871dc-72d0-499f-b8c2-7edcad56a76e.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:b353e7a7-8708-438d-8288-1345e10b39d7 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/441bb5ec-6c00-428f-938f-720e5e918a50.ttl
+++ b/example_old/rhizome/dataset/441bb5ec-6c00-428f-938f-720e5e918a50.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:75aea3ba-17a9-428a-8f50-a0059e2f0672 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/46f75dd8-0b13-4762-bde3-bf31f85810f6.ttl
+++ b/example_old/rhizome/dataset/46f75dd8-0b13-4762-bde3-bf31f85810f6.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:01ab3423-ac4c-4402-8554-22472ac55566 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/49c66bf2-8cda-4b87-9430-ad4a65ff5793.ttl
+++ b/example_old/rhizome/dataset/49c66bf2-8cda-4b87-9430-ad4a65ff5793.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:92094624-aaa3-46b1-a59a-af6ebfcf204d a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/552382cb-9043-455d-b155-fc738930fe28.ttl
+++ b/example_old/rhizome/dataset/552382cb-9043-455d-b155-fc738930fe28.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:529c7b7c-4f94-4e95-84c1-c2b3bb0394bf a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/55421f8d-b36a-48a4-961a-dc18ed5088b5.ttl
+++ b/example_old/rhizome/dataset/55421f8d-b36a-48a4-961a-dc18ed5088b5.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:acc3a664-0787-48d3-9f6b-5f98f251de39 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/5626b242-0c02-45a7-98ca-34c9f4d42b04.ttl
+++ b/example_old/rhizome/dataset/5626b242-0c02-45a7-98ca-34c9f4d42b04.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:2815ce79-100e-49a9-940e-f806fcf4f034 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/5a5def4d-8328-4830-b71e-b19d9e2394bc.ttl
+++ b/example_old/rhizome/dataset/5a5def4d-8328-4830-b71e-b19d9e2394bc.ttl
@@ -1,23 +1,23 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/de83ab3d-2847-4b6b-a8da-ed07eba1a7fd> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/de83ab3d-2847-4b6b-a8da-ed07eba1a7fd> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-05-17T19:49:58+00:00"^^xsd:dateTime ;
     core:describes dataset:5a5def4d-8328-4830-b71e-b19d9e2394bc ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-05-17T19:49:58+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/f1aa0171-9c5e-4604-b8f0-1e098ba3f5d6> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/f1aa0171-9c5e-4604-b8f0-1e098ba3f5d6> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:5a5def4d-8328-4830-b71e-b19d9e2394bc ;
     core:hasCreator "IGN" ;
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;

--- a/example_old/rhizome/dataset/5aeba752-dfb2-48c1-a90d-c0edd0738c0d.ttl
+++ b/example_old/rhizome/dataset/5aeba752-dfb2-48c1-a90d-c0edd0738c0d.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:cb78a6b9-b39e-43f7-89f4-22f55ab6de8d a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/5da01b5b-af91-4ecd-9458-c885a248417e.ttl
+++ b/example_old/rhizome/dataset/5da01b5b-af91-4ecd-9458-c885a248417e.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:ebcb28c0-0751-403f-85f7-a185b913c6d9 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/6377fcb1-21a1-4f28-bebc-20f065c3000a.ttl
+++ b/example_old/rhizome/dataset/6377fcb1-21a1-4f28-bebc-20f065c3000a.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:9413c4db-8102-4c02-8035-5c7cc55f9605 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/65eda3f4-ecb6-4322-90e7-1832ed3178e9.ttl
+++ b/example_old/rhizome/dataset/65eda3f4-ecb6-4322-90e7-1832ed3178e9.ttl
@@ -1,15 +1,15 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/6ef5a35f-d02f-44cc-a5f8-1ddff1903942> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/6ef5a35f-d02f-44cc-a5f8-1ddff1903942> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:65eda3f4-ecb6-4322-90e7-1832ed3178e9 ;
     core:hasCreator "INSEE" ;
     core:hasDescription "Ensemble des établissements actifs et fermés dans leur état courant au répertoire."@fr ;
@@ -32,8 +32,8 @@
     core:hasTitle "BASE SIRENE - STOCK ÉTABLISSEMENT - OKTOBER 2022"@de ;
     core:hasTopic topic:BusinessAndPurchase .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/bde62859-d5a3-4703-845b-d06e7ac71867> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/bde62859-d5a3-4703-845b-d06e7ac71867> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-08-05T15:37:43+00:00"^^xsd:dateTime ;
     core:describes dataset:65eda3f4-ecb6-4322-90e7-1832ed3178e9 ;

--- a/example_old/rhizome/dataset/6be4c7c2-c749-40dc-ac27-2653fa591356.ttl
+++ b/example_old/rhizome/dataset/6be4c7c2-c749-40dc-ac27-2653fa591356.ttl
@@ -1,22 +1,22 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/0240d606-e158-4b90-9685-a7fe422c92b9> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/0240d606-e158-4b90-9685-a7fe422c92b9> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-06-15T21:25:21+00:00"^^xsd:dateTime ;
     core:describes dataset:6be4c7c2-c749-40dc-ac27-2653fa591356 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-06-15T21:25:21+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/66f75853-212c-40f4-b441-c796f0755560> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/66f75853-212c-40f4-b441-c796f0755560> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:6be4c7c2-c749-40dc-ac27-2653fa591356 ;
     core:hasCreator "INSEE" ;
     core:hasDescription "Ce jeu de données est obtenu à l'aide de la jointure entre 3 jeux de données de l'ADMIN EXPRESS contenant les différentes couches du territoire Français : Région, Département et Commune."@fr ;

--- a/example_old/rhizome/dataset/79ec2986-0d71-4e92-a48d-95379b3da9ed.ttl
+++ b/example_old/rhizome/dataset/79ec2986-0d71-4e92-a48d-95379b3da9ed.ttl
@@ -1,15 +1,15 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/0d51248d-d0f8-4e1f-84f4-4f31508f3490> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/0d51248d-d0f8-4e1f-84f4-4f31508f3490> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:79ec2986-0d71-4e92-a48d-95379b3da9ed ;
     core:hasCreator "IGN" ;
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
@@ -33,8 +33,8 @@
     core:hasTitle "ADMIN EXPRESS COG 2020 DEPARTEMENT"@de ;
     core:hasTopic topic:Other .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/379bc821-417f-4fed-9380-0f9a14968f4f> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/379bc821-417f-4fed-9380-0f9a14968f4f> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-08-01T06:38:27+00:00"^^xsd:dateTime ;
     core:describes dataset:79ec2986-0d71-4e92-a48d-95379b3da9ed ;

--- a/example_old/rhizome/dataset/7ff3d2a4-e6b2-4b06-8619-4fc8740dad86.ttl
+++ b/example_old/rhizome/dataset/7ff3d2a4-e6b2-4b06-8619-4fc8740dad86.ttl
@@ -1,23 +1,23 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/40f5ce41-1f6f-428b-ba67-7b6848b191c8> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/40f5ce41-1f6f-428b-ba67-7b6848b191c8> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-05-27T04:12:40+00:00"^^xsd:dateTime ;
     core:describes dataset:7ff3d2a4-e6b2-4b06-8619-4fc8740dad86 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-05-27T04:12:40+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/80b1f84e-86dc-4730-b54f-701ad9b1888a> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:7ff3d2a4-e6b2-4b06-8619-4fc8740dad86 ;
     core:hasCreator "IGN" ;
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;

--- a/example_old/rhizome/dataset/8ad881d8-f350-4cc0-bab3-8e694aa63cd3.ttl
+++ b/example_old/rhizome/dataset/8ad881d8-f350-4cc0-bab3-8e694aa63cd3.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:cb9e9dd2-b84f-4dde-bb54-de9476b16162 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/957df710-4e35-45fb-add8-34d49904a77a.ttl
+++ b/example_old/rhizome/dataset/957df710-4e35-45fb-add8-34d49904a77a.ttl
@@ -1,15 +1,15 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/5ed4d7d3-a4ae-4d46-8b68-59399ccf6268> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/5ed4d7d3-a4ae-4d46-8b68-59399ccf6268> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:957df710-4e35-45fb-add8-34d49904a77a ;
     core:hasCreator "AGRESTE" ;
     core:hasDescription "Statistique agricole annuelle (SAA), constitué des superficies, des rendements et de la production du territoire français."@fr ;
@@ -35,8 +35,8 @@
     core:hasTitle "AGRESTE 2020"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/e672e90e-1c5b-4a46-bf4b-ce3026cf3b9e> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/e672e90e-1c5b-4a46-bf4b-ce3026cf3b9e> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-04-24T01:21:49+00:00"^^xsd:dateTime ;
     core:describes dataset:957df710-4e35-45fb-add8-34d49904a77a ;

--- a/example_old/rhizome/dataset/965dae6f-19ad-4a2b-93f3-05e2d09d7496.ttl
+++ b/example_old/rhizome/dataset/965dae6f-19ad-4a2b-93f3-05e2d09d7496.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:6274df8d-2492-443a-80a7-9791372bf8b8 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/96a562a9-5feb-4a41-bcf2-cc8610af9f78.ttl
+++ b/example_old/rhizome/dataset/96a562a9-5feb-4a41-bcf2-cc8610af9f78.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:69db3c60-29eb-46f5-a600-c64e46a4b4cf a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/9cda6da3-c587-41d1-96a1-7435f90d7492.ttl
+++ b/example_old/rhizome/dataset/9cda6da3-c587-41d1-96a1-7435f90d7492.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:76eee7b6-789b-4793-830e-daa0d096fd66 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/aec18920-43ca-464e-bea9-1a642ba56dda.ttl
+++ b/example_old/rhizome/dataset/aec18920-43ca-464e-bea9-1a642ba56dda.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:5ce9674c-0b59-427e-94cc-7c44f6683713 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/c0cc2228-c88b-40a9-9afd-fe0204774abe.ttl
+++ b/example_old/rhizome/dataset/c0cc2228-c88b-40a9-9afd-fe0204774abe.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:19f854f3-d945-49c4-8026-13abf6eb0786 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/ca752b42-9740-4436-a86f-cd3c5e084d33.ttl
+++ b/example_old/rhizome/dataset/ca752b42-9740-4436-a86f-cd3c5e084d33.ttl
@@ -1,23 +1,23 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/1c125fff-787b-44d3-bb41-03d811c574cd> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/1c125fff-787b-44d3-bb41-03d811c574cd> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-10-16T16:51:28+00:00"^^xsd:dateTime ;
     core:describes dataset:ca752b42-9740-4436-a86f-cd3c5e084d33 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-10-16T16:51:28+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/7ca741b4-ab57-451e-bb8a-a6e8868c9ea9> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/7ca741b4-ab57-451e-bb8a-a6e8868c9ea9> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:ca752b42-9740-4436-a86f-cd3c5e084d33 ;
     core:hasCreator "OKP4" ;
     core:hasDescription "Jeu de données issu de la jointure entre les données du RPG et de l'AGRESTE. Obtenu grâce à un enchainement de traitements de la donnée à l'aide du protocole OKP4."@fr ;

--- a/example_old/rhizome/dataset/cb6ea0aa-e32d-4d79-8492-a6ebcc80b897.ttl
+++ b/example_old/rhizome/dataset/cb6ea0aa-e32d-4d79-8492-a6ebcc80b897.ttl
@@ -1,15 +1,15 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/15592590-adf8-4ee7-b1ff-453f5a40256f> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/15592590-adf8-4ee7-b1ff-453f5a40256f> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:cb6ea0aa-e32d-4d79-8492-a6ebcc80b897 ;
     core:hasCreator "IGN" ;
     core:hasDescription "ADMIN EXPRESS permet d'effectuer des croisements avec d'autres sources de données dans le but de construire des représentations thématiques du territoire selon une granularité administrative (commune, arrondissement départementaux, département, région). ADMIN EXPRESS est décliné dans une édition \"COG\", conforme au code officiel géographique publié chaque année par l'INSEE."@fr ;
@@ -33,8 +33,8 @@
     core:hasTitle "ADMIN EXPRESS COG 2020 REGION"@de ;
     core:hasTopic topic:Other .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/bf57a8ce-71d8-4c46-b068-4384f2bf190f> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/bf57a8ce-71d8-4c46-b068-4384f2bf190f> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-06-03T17:22:35+00:00"^^xsd:dateTime ;
     core:describes dataset:cb6ea0aa-e32d-4d79-8492-a6ebcc80b897 ;

--- a/example_old/rhizome/dataset/d22f0f6c-669d-4837-ba91-111d519b6f56.ttl
+++ b/example_old/rhizome/dataset/d22f0f6c-669d-4837-ba91-111d519b6f56.ttl
@@ -1,22 +1,22 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/2f6a2898-7311-4472-805e-51f144c59375> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/2f6a2898-7311-4472-805e-51f144c59375> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-06-15T21:25:21+00:00"^^xsd:dateTime ;
     core:describes dataset:d22f0f6c-669d-4837-ba91-111d519b6f56 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-06-15T21:25:21+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/3028c5ae-444b-4827-b56e-ef52dbe1ddba> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/3028c5ae-444b-4827-b56e-ef52dbe1ddba> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:d22f0f6c-669d-4837-ba91-111d519b6f56 ;
     core:hasCreator "INSEE" ;
     core:hasDescription "La Nomenclature d'activités française (NAF), est une nomenclature des activités économiques productives, principalement élaborée pour faciliter l'organisation de l'information économique et sociale."@fr ;

--- a/example_old/rhizome/dataset/d23f0f6c-780d-4897-ba91-111d519b6f56.ttl
+++ b/example_old/rhizome/dataset/d23f0f6c-780d-4897-ba91-111d519b6f56.ttl
@@ -1,14 +1,14 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/597b0be8-0f76-42ee-8d3c-898a6334a32e> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/597b0be8-0f76-42ee-8d3c-898a6334a32e> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:d23f0f6c-780d-4897-ba91-111d519b6f56 ;
     core:hasCreator "INSEE" ;
     core:hasDescription "Ce jeu de données est obtenu à l'aide de la jointure entre la BASE SIRENE et la Table référentielle des codes NAF afin d'obtenir des informations sur l'activité des établissements."@fr ;
@@ -27,8 +27,8 @@
     core:hasTitle "BASE SIRENE - NAF"@de ;
     core:hasTopic topic:BusinessAndPurchase .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/c685b0c2-f108-49c2-9853-288b7069f91d> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/c685b0c2-f108-49c2-9853-288b7069f91d> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-06-15T21:25:21+00:00"^^xsd:dateTime ;
     core:describes dataset:d23f0f6c-780d-4897-ba91-111d519b6f56 ;

--- a/example_old/rhizome/dataset/d41e0628-e77a-446f-a3f9-624d5b061762.ttl
+++ b/example_old/rhizome/dataset/d41e0628-e77a-446f-a3f9-624d5b061762.ttl
@@ -1,22 +1,22 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/4f085bb3-da4b-43b0-b3eb-2c4d8014b9eb> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/4f085bb3-da4b-43b0-b3eb-2c4d8014b9eb> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-05-14T20:03:47+00:00"^^xsd:dateTime ;
     core:describes dataset:d41e0628-e77a-446f-a3f9-624d5b061762 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-05-14T20:03:47+00:00"^^xsd:dateTime .
 
-<https://ontology.okp4.space/dataverse/dataset/metadata/53314a52-ba8c-4ae7-b883-38c1911725a1> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/dataset/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/dataset/metadata/53314a52-ba8c-4ae7-b883-38c1911725a1> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/dataset/GeneralMetadata> ;
     core:describes dataset:d41e0628-e77a-446f-a3f9-624d5b061762 ;
     core:hasCreator "OKP4" ;
     core:hasDescription "Ce jeu de données référence toutes les entreprises de l'agriculture, de la sylviculture et de la pêche en France en activité. Obtenu grâce à un enchainement de traitements de la donnée à l'aide du protocole OKP4."@fr ;

--- a/example_old/rhizome/dataset/e3fb5ffc-31fd-45e5-a60b-1bf1c3e317e5.ttl
+++ b/example_old/rhizome/dataset/e3fb5ffc-31fd-45e5-a60b-1bf1c3e317e5.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:ccd18b27-8059-4602-a263-5afaf9e78551 a owl:NamedIndividual,

--- a/example_old/rhizome/dataset/f047abf0-cbad-49d7-985e-7171b9b0e619.ttl
+++ b/example_old/rhizome/dataset/f047abf0-cbad-49d7-985e-7171b9b0e619.ttl
@@ -1,14 +1,14 @@
-@prefix area: <https://ontology.okp4.space/thesaurus/area/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix dataset: <https://ontology.okp4.space/dataverse/dataset/> .
-@prefix dstmeta: <https://ontology.okp4.space/dataverse/dataset/metadata/> .
-@prefix license: <https://ontology.okp4.space/thesaurus/license/> .
-@prefix mediatype: <https://ontology.okp4.space/thesaurus/media-type/> .
-@prefix meta: <https://ontology.okp4.space/metadata/> .
-@prefix metadst: <https://ontology.okp4.space/metadata/dataset/> .
+@prefix area: <https://w3id.org/okp4/ontology/thesaurus/area/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix dataset: <https://w3id.org/okp4/ontology/dataverse/dataset/> .
+@prefix dstmeta: <https://w3id.org/okp4/ontology/dataverse/dataset/metadata/> .
+@prefix license: <https://w3id.org/okp4/ontology/thesaurus/license/> .
+@prefix mediatype: <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/> .
+@prefix metadst: <https://w3id.org/okp4/ontology/metadata/dataset/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dstmeta:af77412b-487f-48b7-ae38-63a1198ce449 a owl:NamedIndividual,

--- a/example_old/rhizome/governance.ttl
+++ b/example_old/rhizome/governance.ttl
@@ -1,10 +1,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix metagov: <https://ontology.okp4.space/metadata/governance/> .
-@prefix govmeta: <https://ontology.okp4.space/dataverse/governance/metadata/> .
-@prefix governance: <https://ontology.okp4.space/dataverse/governance/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix metagov: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix govmeta: <https://w3id.org/okp4/ontology/dataverse/governance/metadata/> .
+@prefix governance: <https://w3id.org/okp4/ontology/dataverse/governance/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 
 govmeta:495560a4-76a6-4bbc-80e2-5f4dac17d5ef a owl:NamedIndividual,
         metagov:GovernanceMetadata ;

--- a/example_old/rhizome/rhizome.ttl
+++ b/example_old/rhizome/rhizome.ttl
@@ -1,11 +1,11 @@
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix zone: <https://ontology.okp4.space/dataverse/zone/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix zone: <https://w3id.org/okp4/ontology/dataverse/zone/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/56827e28-0a27-40ee-803e-76a57cd7de07> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/zone/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/56827e28-0a27-40ee-803e-76a57cd7de07> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/zone/GeneralMetadata> ;
     core:describes zone:ef347285-e52a-430d-9679-dcb76b962ce7 ;
     core:hasDescription "Rhizome est une zone exploitée par OKP4, actuellement en cours de développement sur la base de la technologie OKP4. Rhizome démontre la puissance du traitement et du partage des données, et la valeur que nous pouvons obtenir en connectant efficacement différentes sources de données agricoles en libre accès sous différents formats de données. Rhizome vise à connecter autant de données que possible et à fournir des visuels et métriques de grande valeur dans différents domaines liés à l'agriculture, tels que l'utilisation des terres et la gestion du territoire, la gestion des cultures et du bétail, ainsi que les ressources forestières et l'industrie du bois."@fr ;
     core:hasDescription "Rhizome is a zone operated by OKP4, currently under development based on OKP4 technology. Rhizome demonstrates the power of data processing and sharing, and the value we can achieve by effectively connecting different sources of open access agricultural data in different data formats. Rhizome aims to connect as much data as possible and provide valuable visuals and metrics in various agriculture-related areas, such as land use and land management, crop and livestock management, and forest resources and timber industry."@en ;
@@ -20,8 +20,8 @@
     core:hasTitle "Rhizom"@de ;
     core:hasTopic topic:AgricultureFoodEnvironmentAndForestry .
 
-<https://ontology.okp4.space/dataverse/zone/metadata/e33f7ab8-4f8d-4588-a3fe-43e5e77b189e> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/zone/metadata/e33f7ab8-4f8d-4588-a3fe-43e5e77b189e> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-10-30T15:29:16.507000+00:00"^^xsd:dateTime ;
     core:describes zone:ef347285-e52a-430d-9679-dcb76b962ce7 ;

--- a/example_old/rhizome/service/03230ce7-d8cb-410e-919e-19c480c1dd75.ttl
+++ b/example_old/rhizome/service/03230ce7-d8cb-410e-919e-19c480c1dd75.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/be67f7df-ff02-47c8-b55f-865b387c68ca> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/be67f7df-ff02-47c8-b55f-865b387c68ca> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:03230ce7-d8cb-410e-919e-19c480c1dd75 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Service de stockage de données"@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Clever Cloud Data Storage"@fr ;
     core:hasTitle "Clever Cloud Data Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/ae18aa63-bbfc-44e4-bc4a-29f3fab3bec0> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/ae18aa63-bbfc-44e4-bc4a-29f3fab3bec0> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6Mkg6zUc9QFnHtfSnawoXVB269ko7wgmZXLHVJDwweDqL3y> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:03230ce7-d8cb-410e-919e-19c480c1dd75 ;

--- a/example_old/rhizome/service/06fd0de2-8be8-436d-9d91-3aa5972c2209.ttl
+++ b/example_old/rhizome/service/06fd0de2-8be8-436d-9d91-3aa5972c2209.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/d6e403d1-816d-4d23-86c3-9fa279829b29> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/d6e403d1-816d-4d23-86c3-9fa279829b29> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:06fd0de2-8be8-436d-9d91-3aa5972c2209 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Cloud Storage est un service géré permettant de stocker des données non structurées. Stockez n'importe quelle quantité de données et récupérez-les quand vous le souhaitez."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Google Cloud Storage"@fr ;
     core:hasTitle "Google Cloud Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/6f008dfb-e743-456f-a6d8-8847a323a116> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/6f008dfb-e743-456f-a6d8-8847a323a116> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkhkU5Zh9RWLB9QMkHwmryUfKZotaqCTW5dnQTsbdFp3T7> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:06fd0de2-8be8-436d-9d91-3aa5972c2209 ;

--- a/example_old/rhizome/service/16c4cd10-521a-4829-b1bd-a1e2ac60459a.ttl
+++ b/example_old/rhizome/service/16c4cd10-521a-4829-b1bd-a1e2ac60459a.ttl
@@ -1,19 +1,19 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/96f696a0-4b3d-471c-b533-e1989a455b0f> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/96f696a0-4b3d-471c-b533-e1989a455b0f> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-09-16T03:54:18Z"^^xsd:dateTimeStamp ;
     core:describes service:16c4cd10-521a-4829-b1bd-a1e2ac60459a ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-09-16T03:54:18Z"^^xsd:dateTimeStamp .
 
-<https://ontology.okp4.space/dataverse/service/metadata/a4333358-fdf3-4e7b-a415-4b67a4d3ee72> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/a4333358-fdf3-4e7b-a415-4b67a4d3ee72> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:16c4cd10-521a-4829-b1bd-a1e2ac60459a ;
     core:hasCategory category:DataIntegration ;
     core:hasDescription "Ce service permet d'injecter des fichiers de données dans OpenSearch afin de pouvoir connsommer la connaisance créée à l'aide de visualisation."@fr ;

--- a/example_old/rhizome/service/455d0f5e-6279-42e2-9290-e0507210f5dd.ttl
+++ b/example_old/rhizome/service/455d0f5e-6279-42e2-9290-e0507210f5dd.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/4922fd04-ce5a-4477-a906-5ddbda90d9ab> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/4922fd04-ce5a-4477-a906-5ddbda90d9ab> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:455d0f5e-6279-42e2-9290-e0507210f5dd ;
     core:hasCategory category:Storage ;
     core:hasDescription "Le stockage d'objets de Qiniu Cloud (KODO), une technologie de base ayant fait l'objet de recherches totalement indépendantes et prouvée par l'expérience répétée des clients, occupe une position de leader absolu sur le marché. KODO peut être largement appliqué à la gestion des données de masse."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Kodo"@fr ;
     core:hasTitle "Kodo"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/c36a41b0-ff67-4841-bc7f-e613e14a1fc8> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/c36a41b0-ff67-4841-bc7f-e613e14a1fc8> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6Mkjm9GJqB4KKzcPiiDkNX5c56enxNRc5JGdpWeRS6q5ahu> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:455d0f5e-6279-42e2-9290-e0507210f5dd ;

--- a/example_old/rhizome/service/4a7c09eb-62b4-4f32-a5e3-aea123a4b923.ttl
+++ b/example_old/rhizome/service/4a7c09eb-62b4-4f32-a5e3-aea123a4b923.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/57705515-d101-4f78-9ec2-d6e8ca34a4f0> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/57705515-d101-4f78-9ec2-d6e8ca34a4f0> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:4a7c09eb-62b4-4f32-a5e3-aea123a4b923 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Amazon Simple Storage Service (Amazon S3) est un service de stockage d'objets qui offre une capacité de mise à l'échelle, une disponibilité des données, une sécurité et des performances de pointe."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Amazon S3"@fr ;
     core:hasTitle "Amazon S3"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/0fceaaf9-1cab-40dc-9eb1-52ff190d4408> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/0fceaaf9-1cab-40dc-9eb1-52ff190d4408> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkipfxAzxFqxvk1ksPTgeUNniqd2ZwFLHFnM51zxs5dmis> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:4a7c09eb-62b4-4f32-a5e3-aea123a4b923 ;

--- a/example_old/rhizome/service/57b76dd7-25d9-4fad-87e0-b228faf97e8b.ttl
+++ b/example_old/rhizome/service/57b76dd7-25d9-4fad-87e0-b228faf97e8b.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/aa3c8d28-99bb-4db9-b802-31c744638143> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/aa3c8d28-99bb-4db9-b802-31c744638143> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:57b76dd7-25d9-4fad-87e0-b228faf97e8b ;
     core:hasCategory category:Storage ;
     core:hasDescription "IBM Cloud Object Storage, grâce à sa présence mondiale et à ses options de résilience souples, prend en charge la croissance exponentielle des données pour vos charges de travail natives du cloud avec la meilleure optimisation des coûts de sa catégorie, une sécurité des données robuste et une gouvernance des données facile à utiliser."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "IBM Cloud Object Storage"@fr ;
     core:hasTitle "IBM Cloud Object Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/81773848-e532-4d98-a7b1-0493bf0324c6> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/81773848-e532-4d98-a7b1-0493bf0324c6> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MksTcABXL3Ro7M15Gcm26K1fnriqiHZaXX9Z4wRZAjN8WD> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:57b76dd7-25d9-4fad-87e0-b228faf97e8b ;

--- a/example_old/rhizome/service/60ac66b6-ed76-4504-bdde-de5901d2b482.ttl
+++ b/example_old/rhizome/service/60ac66b6-ed76-4504-bdde-de5901d2b482.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/a17aa376-ae53-45a8-abff-cc95170caf9c> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/a17aa376-ae53-45a8-abff-cc95170caf9c> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:60ac66b6-ed76-4504-bdde-de5901d2b482 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Dropbox est un service de stockage et de partage de copies de fichiers locaux en ligne."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Dropbox"@fr ;
     core:hasTitle "Dropbox"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/230f54ec-5510-4347-b692-beae2c616d77> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/230f54ec-5510-4347-b692-beae2c616d77> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6Mkq66auaGba46TMPxNYoAkV5AQ33tXkBFXzU1j93Aw5qik> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:60ac66b6-ed76-4504-bdde-de5901d2b482 ;

--- a/example_old/rhizome/service/6272c8d0-f5ed-4394-8f54-a7b429faec13.ttl
+++ b/example_old/rhizome/service/6272c8d0-f5ed-4394-8f54-a7b429faec13.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/27c1fbf8-038e-4002-a48d-1de142b41ebe> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/27c1fbf8-038e-4002-a48d-1de142b41ebe> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:6272c8d0-f5ed-4394-8f54-a7b429faec13 ;
     core:hasCategory category:DataCleaning ;
     core:hasDescription "L'outil Data Refactor permet d'éditer, de modifier un jeu de données afin de le standardiser."@fr ;
@@ -19,8 +19,8 @@
     core:hasTitle "Data Refactor"@en ;
     core:hasTitle "Data Refactor"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/ea1c97e1-3b79-4c1a-9d07-6caa347d25eb> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/ea1c97e1-3b79-4c1a-9d07-6caa347d25eb> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-03-18T08:55:31Z"^^xsd:dateTimeStamp ;
     core:describes service:6272c8d0-f5ed-4394-8f54-a7b429faec13 ;

--- a/example_old/rhizome/service/6636b94a-b2f7-4139-9227-6838de9d3ef3.ttl
+++ b/example_old/rhizome/service/6636b94a-b2f7-4139-9227-6838de9d3ef3.ttl
@@ -1,19 +1,19 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/2eb089a5-c388-4411-b451-afd05b8a128a> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/2eb089a5-c388-4411-b451-afd05b8a128a> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-10-10T01:09:39Z"^^xsd:dateTimeStamp ;
     core:describes service:6636b94a-b2f7-4139-9227-6838de9d3ef3 ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-10-10T01:09:39Z"^^xsd:dateTimeStamp .
 
-<https://ontology.okp4.space/dataverse/service/metadata/90359e65-5685-4721-9298-f457a47787ff> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/90359e65-5685-4721-9298-f457a47787ff> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:6636b94a-b2f7-4139-9227-6838de9d3ef3 ;
     core:hasCategory category:DataTransformation ;
     core:hasDescription "L'outil Data Join Tabular permet de joindre deux jeux de données contenant des valeurs communes afin d'apporter de nouvelles informations."@fr ;

--- a/example_old/rhizome/service/803cd033-2eed-4db7-847b-f46715a42a70.ttl
+++ b/example_old/rhizome/service/803cd033-2eed-4db7-847b-f46715a42a70.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/8e8777c2-cf44-480b-9629-72519bdfe1b4> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/8e8777c2-cf44-480b-9629-72519bdfe1b4> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:803cd033-2eed-4db7-847b-f46715a42a70 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Service d'hébergement de fichiers."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Mega"@fr ;
     core:hasTitle "Mega"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/d9cc5650-2690-490e-ba77-33bb62c95ac0> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/d9cc5650-2690-490e-ba77-33bb62c95ac0> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkrpCPVDHcsqi3aaqnemLC1aBTUwkfPwTyzc8sFWYwm1PA> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:803cd033-2eed-4db7-847b-f46715a42a70 ;

--- a/example_old/rhizome/service/987e1ffd-05e7-48e4-a429-1172689477ee.ttl
+++ b/example_old/rhizome/service/987e1ffd-05e7-48e4-a429-1172689477ee.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/32ef3b7a-9cbb-4e2a-bc9c-3916687775fa> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/32ef3b7a-9cbb-4e2a-bc9c-3916687775fa> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:987e1ffd-05e7-48e4-a429-1172689477ee ;
     core:hasCategory category:DataTransformation ;
     core:hasDescription "L'outil Data Grouping permet organiser des données identiques en groupes."@fr ;
@@ -18,8 +18,8 @@
     core:hasTitle "Data Grouping"@en ;
     core:hasTitle "Data Grouping"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/a65267da-98ec-4db6-a8ad-29aeb48efd5e> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/a65267da-98ec-4db6-a8ad-29aeb48efd5e> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-08-30T05:33:00Z"^^xsd:dateTimeStamp ;
     core:describes service:987e1ffd-05e7-48e4-a429-1172689477ee ;

--- a/example_old/rhizome/service/9c8809bd-de56-4003-bee4-4bcfbc4cb603.ttl
+++ b/example_old/rhizome/service/9c8809bd-de56-4003-bee4-4bcfbc4cb603.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/52549532-887d-409b-a9c0-fb68f9e521d2> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/52549532-887d-409b-a9c0-fb68f9e521d2> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:9c8809bd-de56-4003-bee4-4bcfbc4cb603 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Le service Stockage Blob Azure vous permet de créer des lacs de données pour répondre à vos besoins d’analyse, et vous fournit un espace de stockage pour créer de puissantes applications natives Cloud et mobiles."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Microsoft Azure Blob Storage"@fr ;
     core:hasTitle "Microsoft Azure Blob Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/cb3c4594-410e-4404-acbb-9dd426885e5b> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/cb3c4594-410e-4404-acbb-9dd426885e5b> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkjRHZHheNCZG6VYEhsri73S154YHSmjgGdSDRH7biQUGx> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:9c8809bd-de56-4003-bee4-4bcfbc4cb603 ;

--- a/example_old/rhizome/service/b866c23e-40aa-4597-9387-b4af649b77db.ttl
+++ b/example_old/rhizome/service/b866c23e-40aa-4597-9387-b4af649b77db.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/62d09598-de0d-442c-b880-1e19d43b5ec9> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/62d09598-de0d-442c-b880-1e19d43b5ec9> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:b866c23e-40aa-4597-9387-b4af649b77db ;
     core:hasCategory category:Storage ;
     core:hasDescription "Service de stockage de données"@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Deutsche Telekom Cloud Object Storage"@fr ;
     core:hasTitle "Deutsche Telekom Cloud Object Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/51ca1c69-c562-4b62-a22f-394a6e931811> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/51ca1c69-c562-4b62-a22f-394a6e931811> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkgB4UhcF16wHfVWA6KtYqrdcm5KQbVFnmuWbPFitCjKwr> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:b866c23e-40aa-4597-9387-b4af649b77db ;

--- a/example_old/rhizome/service/bca4aaa0-6c8d-497c-ba1f-9a7116a4ebf0.ttl
+++ b/example_old/rhizome/service/bca4aaa0-6c8d-497c-ba1f-9a7116a4ebf0.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/c7460a2c-6226-4817-8f92-16f1cece88b0> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/c7460a2c-6226-4817-8f92-16f1cece88b0> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:bca4aaa0-6c8d-497c-ba1f-9a7116a4ebf0 ;
     core:hasCategory category:Storage ;
     core:hasDescription "IONOS S3 Object Storage facilite la transformation numérique : stockez et gérez des données de volumes variables, facilement et à prix abordable."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "IONOS S3 Object Storage"@fr ;
     core:hasTitle "IONOS S3 Object Storage"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/5786fad7-a200-46c4-a902-06fc3b20c15e> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/5786fad7-a200-46c4-a902-06fc3b20c15e> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkhkWvGUxLntuCS7iUT4e1ztfBPaFAC6GN9idzid5V7xLA> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:bca4aaa0-6c8d-497c-ba1f-9a7116a4ebf0 ;

--- a/example_old/rhizome/service/d1b0b4d3-f9a6-4115-bcd8-ad97233a7b08.ttl
+++ b/example_old/rhizome/service/d1b0b4d3-f9a6-4115-bcd8-ad97233a7b08.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/7de927d4-b4ab-401f-bfef-3899132ea2f1> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/7de927d4-b4ab-401f-bfef-3899132ea2f1> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:d1b0b4d3-f9a6-4115-bcd8-ad97233a7b08 ;
     core:hasCategory category:Storage ;
     core:hasDescription "Service de stockage de données"@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "Storage"@en ;
     core:hasTitle "Speicherung"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/8f5a671d-ba50-4768-9354-4268bd4345e9> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/8f5a671d-ba50-4768-9354-4268bd4345e9> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkfBG9HjCRpnBiubdfgMfmHW3W66EMHbVKfaea2gDa8Vcc> ;
     core:createdOn "2023-03-14T13:33:00Z"^^xsd:dateTimeStamp ;
     core:describes service:d1b0b4d3-f9a6-4115-bcd8-ad97233a7b08 ;

--- a/example_old/rhizome/service/e4fa9cb1-59f8-4f40-9ba3-f00f8a18e3de.ttl
+++ b/example_old/rhizome/service/e4fa9cb1-59f8-4f40-9ba3-f00f8a18e3de.ttl
@@ -1,19 +1,19 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/e7f1468b-f7f6-42da-85cf-f562b337554a> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/e7f1468b-f7f6-42da-85cf-f562b337554a> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-03-03T16:49:46Z"^^xsd:dateTimeStamp ;
     core:describes service:e4fa9cb1-59f8-4f40-9ba3-f00f8a18e3de ;
     core:lastModifiedBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:updatedOn "2022-03-03T16:49:46Z"^^xsd:dateTimeStamp .
 
-<https://ontology.okp4.space/dataverse/service/metadata/f9a890a3-e1fa-46ba-897d-60e6e414c457> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/f9a890a3-e1fa-46ba-897d-60e6e414c457> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:e4fa9cb1-59f8-4f40-9ba3-f00f8a18e3de ;
     core:hasCategory category:DataTransformation ;
     core:hasDescription "L'outil Data Join Geospatial permet de joindre deux jeux de données géoréférencé."@fr ;

--- a/example_old/rhizome/service/f5ee2a3a-07e4-453c-a1a4-e721f1e2fa20.ttl
+++ b/example_old/rhizome/service/f5ee2a3a-07e4-453c-a1a4-e721f1e2fa20.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/da2f0a5d-d04f-48c8-bded-3012ea799b09> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/da2f0a5d-d04f-48c8-bded-3012ea799b09> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:f5ee2a3a-07e4-453c-a1a4-e721f1e2fa20 ;
     core:hasCategory category:Storage ;
     core:hasDescription "IPFS est un protocole décentralisé conçu pour faciliter le stockage, le partage et la récupération de fichiers à l'échelle mondiale."@fr ;
@@ -17,8 +17,8 @@
     core:hasTitle "IPFS"@fr ;
     core:hasTitle "IPFS"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/f6bd8a39-b5ce-47ea-8f03-038347319d79> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/f6bd8a39-b5ce-47ea-8f03-038347319d79> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:z6MkpoEv7sCWmD3SbXHEef5q16vaiFfKoXtFVyKmLuKzx72W> ;
     core:createdOn "2023-07-04T10:00:00Z"^^xsd:dateTimeStamp ;
     core:describes service:f5ee2a3a-07e4-453c-a1a4-e721f1e2fa20 ;

--- a/example_old/rhizome/service/fbe11a63-85da-4f82-97c4-f719ac1f4ce8.ttl
+++ b/example_old/rhizome/service/fbe11a63-85da-4f82-97c4-f719ac1f4ce8.ttl
@@ -1,11 +1,11 @@
-@prefix category: <https://ontology.okp4.space/thesaurus/service-category/> .
-@prefix core: <https://ontology.okp4.space/core/> .
+@prefix category: <https://w3id.org/okp4/ontology/thesaurus/service-category/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
-@prefix service: <https://ontology.okp4.space/dataverse/service/> .
+@prefix service: <https://w3id.org/okp4/ontology/dataverse/service/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<https://ontology.okp4.space/dataverse/service/metadata/37fb789f-23d8-41b3-900b-418147d115fd> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/service/GeneralMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/37fb789f-23d8-41b3-900b-418147d115fd> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/service/GeneralMetadata> ;
     core:describes service:fbe11a63-85da-4f82-97c4-f719ac1f4ce8 ;
     core:hasCategory category:DataTransformation ;
     core:hasDescription "L'outil Data Selector permet de sélectionner un échantillon de l'ensemble de données, en spécifiant un nombre de lignes. Il est possible de supprimer ou de conserver des colonnes. Un autre paramètre permet de sélectionner les données d'une colonne en fonction de sa (ses) valeur(s)."@fr ;
@@ -18,8 +18,8 @@
     core:hasTitle "Data Selector"@en ;
     core:hasTitle "Data Selector"@de .
 
-<https://ontology.okp4.space/dataverse/service/metadata/730f271e-022e-411c-9eb9-23d8140af611> a owl:NamedIndividual,
-        <https://ontology.okp4.space/metadata/AuditMetadata> ;
+<https://w3id.org/okp4/ontology/dataverse/service/metadata/730f271e-022e-411c-9eb9-23d8140af611> a owl:NamedIndividual,
+        <https://w3id.org/okp4/ontology/metadata/AuditMetadata> ;
     core:createdBy <did:key:0x04d1f1b8f8a7a28f9a5a254c326a963a22f5a5b5d5f5e5d5c5b5a5958575655> ;
     core:createdOn "2022-09-28T11:13:13Z"^^xsd:dateTimeStamp ;
     core:describes service:fbe11a63-85da-4f82-97c4-f719ac1f4ce8 ;

--- a/src/schema/digital-resource/credential-dataset-description.ttl
+++ b/src/schema/digital-resource/credential-dataset-description.ttl
@@ -1,9 +1,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-resource/dataset/description/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-resource/dataset/description/> .
 @prefix schema: <http://schema.org/> .
-@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+@prefix thesaurus: <https://w3id.org/okp4/ontology/thesaurus/> .
 
 :DatasetDescriptionCredential a rdfs:Class ;
   rdfs:label "Service Description Credential"@en ;

--- a/src/schema/digital-resource/credential-digital-resource-declaration.ttl
+++ b/src/schema/digital-resource/credential-digital-resource-declaration.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-resource/declaration/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-resource/declaration/> .
 @prefix schema: <http://schema.org/> .
 
 :DigitalResourceDeclarationCredential a rdfs:Class ;

--- a/src/schema/digital-resource/credential-digital-resource-rights.ttl
+++ b/src/schema/digital-resource/credential-digital-resource-rights.ttl
@@ -1,6 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-resource/rights/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-resource/rights/> .
 @prefix schema: <http://schema.org/> .
 
 :DigitalResourceRightsCredentials a rdfs:Class ;
@@ -29,7 +29,7 @@
   rdfs:label "has license"@en ;
   rdfs:comment "The licensing terms under which the Digital Resource is made available."@en ;
   schema:domainIncludes :DigitalResourceRightsCredentials ;
-  schema:rangeIncludes <https://ontology.okp4.space/thesaurus/license> .
+  schema:rangeIncludes <https://w3id.org/okp4/ontology/thesaurus/license> .
 
 :hasPublisher a rdf:Property ;
   rdfs:label "has publisher"@en ;

--- a/src/schema/digital-service/credential-digital-service-declaration.ttl
+++ b/src/schema/digital-service/credential-digital-service-declaration.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-service/declaration/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-service/declaration/> .
 @prefix schema: <http://schema.org/> .
 
 :DigitalServiceDeclarationCredential a rdfs:Class ;

--- a/src/schema/digital-service/credential-digital-service-description.ttl
+++ b/src/schema/digital-service/credential-digital-service-description.ttl
@@ -1,9 +1,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-service/description/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-service/description/> .
 @prefix schema: <http://schema.org/> .
-@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+@prefix thesaurus: <https://w3id.org/okp4/ontology/thesaurus/> .
 
 :DigitalServiceDescriptionCredential a rdfs:Class ;
   rdfs:label "Digital Service Description Credential"@en ;

--- a/src/schema/digital-service/credential-digital-service-execution-order.ttl
+++ b/src/schema/digital-service/credential-digital-service-execution-order.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-service/execution-order/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-service/execution-order/> .
 @prefix schema: <http://schema.org/> .
 
 :DigitalServiceExecutionOrder a rdfs:Class ;

--- a/src/schema/digital-service/credential-digital-service-execution-result.ttl
+++ b/src/schema/digital-service/credential-digital-service-execution-result.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-service/execution-proof/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-service/execution-proof/> .
 @prefix schema: <http://schema.org/> .
 
 :DigitalServiceExecutionResult a rdfs:Class ;
@@ -30,7 +30,7 @@
   Indicates the status of the service execution.
   """@en ;
   schema:domainIncludes :DigitalServiceExecutionResultCredential ;
-  schema:rangeIncludes <https://ontology.okp4.space/thesaurus/digital-service-execution-status> .
+  schema:rangeIncludes <https://w3id.org/okp4/ontology/thesaurus/digital-service-execution-status> .
 
 :hasExecutionTime a rdf:Property ;
   rdfs:label "has execution time"@en ;

--- a/src/schema/governance/credential-governance-text.ttl
+++ b/src/schema/governance/credential-governance-text.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/governance/text/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/governance/text/> .
 @prefix schema: <http://schema.org/> .
 
 :Article a rdfs:Class ;

--- a/src/schema/zone/credential-zone-declaration.ttl
+++ b/src/schema/zone/credential-zone-declaration.ttl
@@ -1,6 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/zone/declaration/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/zone/declaration/> .
 
 :ZoneDeclarationCredential a rdfs:Class ;
   rdfs:label "Zone Credential"@en ;

--- a/src/schema/zone/credential-zone-description.ttl
+++ b/src/schema/zone/credential-zone-description.ttl
@@ -1,9 +1,9 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/schema/credential/digital-resource/zone/description/> .
+@prefix : <https://w3id.org/okp4/ontology/schema/credential/digital-resource/zone/description/> .
 @prefix schema: <http://schema.org/> .
-@prefix thesaurus: <https://ontology.okp4.space/thesaurus/> .
+@prefix thesaurus: <https://w3id.org/okp4/ontology/thesaurus/> .
 
 :ZoneDescriptionCredential a rdfs:Class ;
   rdfs:label "Zone Description Credential"@en ;

--- a/src/thesaurus/area-code.ttl
+++ b/src/thesaurus/area-code.ttl
@@ -1,7 +1,7 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/area/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/area/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix schema: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -32,12 +32,12 @@
   skos:narrower :150 ;
   skos:prefLabel "Monde"@fr ;
   skos:prefLabel "World"@en ;
-  skos:topConceptOf <https://ontology.okp4.space/thesaurus/area> .
+  skos:topConceptOf <https://w3id.org/okp4/ontology/thesaurus/area> .
 
 :002 a skos:Concept ;
   :hasAreaCode 2 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :015 ;
   skos:narrower :202 ;
   skos:prefLabel "Africa"@en ;
@@ -48,14 +48,14 @@
   :hasAlpha3Code "AFG" ;
   :hasAreaCode 4 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Afghanistan"@en ;
   skos:prefLabel "Afghanistan"@fr .
 
 :005 a skos:Concept ;
   :hasAreaCode 5 ;
   skos:broader :419 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :032 ;
   skos:narrower :068 ;
   skos:narrower :074 ;
@@ -80,14 +80,14 @@
   :hasAlpha3Code "ALB" ;
   :hasAreaCode 8 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Albania"@en ;
   skos:prefLabel "Albanie"@fr .
 
 :009 a skos:Concept ;
   :hasAreaCode 9 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :053 ;
   skos:narrower :054 ;
   skos:narrower :057 ;
@@ -100,14 +100,14 @@
   :hasAlpha3Code "ATA" ;
   :hasAreaCode 10 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Antarctica"@en ;
   skos:prefLabel "Antarctique"@fr .
 
 :011 a skos:Concept ;
   :hasAreaCode 11 ;
   skos:broader :202 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :132 ;
   skos:narrower :204 ;
   skos:narrower :270 ;
@@ -133,14 +133,14 @@
   :hasAlpha3Code "DZA" ;
   :hasAreaCode 12 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Algeria"@en ;
   skos:prefLabel "Algérie"@fr .
 
 :013 a skos:Concept ;
   :hasAreaCode 13 ;
   skos:broader :419 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :084 ;
   skos:narrower :188 ;
   skos:narrower :222 ;
@@ -155,7 +155,7 @@
 :014 a skos:Concept ;
   :hasAreaCode 14 ;
   skos:broader :202 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :086 ;
   skos:narrower :108 ;
   skos:narrower :174 ;
@@ -184,7 +184,7 @@
 :015 a skos:Concept ;
   :hasAreaCode 15 ;
   skos:broader :002 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :012 ;
   skos:narrower :434 ;
   skos:narrower :504 ;
@@ -200,14 +200,14 @@
   :hasAlpha3Code "ASM" ;
   :hasAreaCode 16 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "American Samoa"@en ;
   skos:prefLabel "Samoa américaines"@fr .
 
 :017 a skos:Concept ;
   :hasAreaCode 17 ;
   skos:broader :202 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :024 ;
   skos:narrower :120 ;
   skos:narrower :140 ;
@@ -223,7 +223,7 @@
 :018 a skos:Concept ;
   :hasAreaCode 18 ;
   skos:broader :202 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :072 ;
   skos:narrower :426 ;
   skos:narrower :516 ;
@@ -235,7 +235,7 @@
 :019 a skos:Concept ;
   :hasAreaCode 19 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :021 ;
   skos:narrower :419 ;
   skos:prefLabel "Americas"@en ;
@@ -246,14 +246,14 @@
   :hasAlpha3Code "AND" ;
   :hasAreaCode 20 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Andorra"@en ;
   skos:prefLabel "Andorre"@fr .
 
 :021 a skos:Concept ;
   :hasAreaCode 21 ;
   skos:broader :019 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :060 ;
   skos:narrower :124 ;
   skos:narrower :304 ;
@@ -266,7 +266,7 @@
   :hasAlpha3Code "AGO" ;
   :hasAreaCode 24 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Angola"@en ;
   skos:prefLabel "Angola"@fr .
 
@@ -275,14 +275,14 @@
   :hasAlpha3Code "ATG" ;
   :hasAreaCode 28 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Antigua and Barbuda"@en ;
   skos:prefLabel "Antigua et Barbade"@fr .
 
 :029 a skos:Concept ;
   :hasAreaCode 29 ;
   skos:broader :419 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :028 ;
   skos:narrower :044 ;
   skos:narrower :052 ;
@@ -317,7 +317,7 @@
 :030 a skos:Concept ;
   :hasAreaCode 30 ;
   skos:broader :142 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :156 ;
   skos:narrower :344 ;
   skos:narrower :392 ;
@@ -333,7 +333,7 @@
   :hasAlpha3Code "AZE" ;
   :hasAreaCode 31 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Azerbaijan"@en ;
   skos:prefLabel "Azerbaijan"@fr .
 
@@ -342,14 +342,14 @@
   :hasAlpha3Code "ARG" ;
   :hasAreaCode 32 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Argentina"@en ;
   skos:prefLabel "Argentine"@fr .
 
 :034 a skos:Concept ;
   :hasAreaCode 34 ;
   skos:broader :142 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :004 ;
   skos:narrower :050 ;
   skos:narrower :064 ;
@@ -365,7 +365,7 @@
 :035 a skos:Concept ;
   :hasAreaCode 35 ;
   skos:broader :142 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :096 ;
   skos:narrower :104 ;
   skos:narrower :116 ;
@@ -385,14 +385,14 @@
   :hasAlpha3Code "AUS" ;
   :hasAreaCode 36 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Australia"@en ;
   skos:prefLabel "Australie"@fr .
 
 :039 a skos:Concept ;
   :hasAreaCode 39 ;
   skos:broader :150 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :008 ;
   skos:narrower :020 ;
   skos:narrower :070 ;
@@ -417,7 +417,7 @@
   :hasAlpha3Code "AUT" ;
   :hasAreaCode 40 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Austria"@en ;
   skos:prefLabel "Autriche"@fr .
 
@@ -426,7 +426,7 @@
   :hasAlpha3Code "BHS" ;
   :hasAreaCode 44 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bahamas"@en ;
   skos:prefLabel "Bahamas"@fr .
 
@@ -435,7 +435,7 @@
   :hasAlpha3Code "BHR" ;
   :hasAreaCode 48 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bahrain"@en ;
   skos:prefLabel "Bahrain"@fr .
 
@@ -444,7 +444,7 @@
   :hasAlpha3Code "BGD" ;
   :hasAreaCode 50 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bangladesh"@en ;
   skos:prefLabel "Bangladesh"@fr .
 
@@ -453,7 +453,7 @@
   :hasAlpha3Code "ARM" ;
   :hasAreaCode 51 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Armenia"@en ;
   skos:prefLabel "Armenie"@fr .
 
@@ -462,14 +462,14 @@
   :hasAlpha3Code "BRB" ;
   :hasAreaCode 52 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Barbades"@fr ;
   skos:prefLabel "Barbados"@en .
 
 :053 a skos:Concept ;
   :hasAreaCode 53 ;
   skos:broader :009 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :036 ;
   skos:narrower :162 ;
   skos:narrower :166 ;
@@ -482,7 +482,7 @@
 :054 a skos:Concept ;
   :hasAreaCode 54 ;
   skos:broader :009 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :090 ;
   skos:narrower :242 ;
   skos:narrower :540 ;
@@ -496,14 +496,14 @@
   :hasAlpha3Code "BEL" ;
   :hasAreaCode 56 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Belgique"@fr ;
   skos:prefLabel "Belgium"@en .
 
 :057 a skos:Concept ;
   :hasAreaCode 57 ;
   skos:broader :009 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :296 ;
   skos:narrower :316 ;
   skos:narrower :520 ;
@@ -519,14 +519,14 @@
   :hasAlpha3Code "BMU" ;
   :hasAreaCode 60 ;
   skos:broader :021 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bermuda"@en ;
   skos:prefLabel "Bermudes"@fr .
 
 :061 a skos:Concept ;
   :hasAreaCode 61 ;
   skos:broader :009 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :016 ;
   skos:narrower :184 ;
   skos:narrower :258 ;
@@ -545,7 +545,7 @@
   :hasAlpha3Code "BTN" ;
   :hasAreaCode 64 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bhutan"@en .
 
 :068 a skos:Concept ;
@@ -553,7 +553,7 @@
   :hasAlpha3Code "BOL" ;
   :hasAreaCode 68 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bolivia (Plurinational State of)"@en ;
   skos:prefLabel "Bolivie"@fr .
 
@@ -562,7 +562,7 @@
   :hasAlpha3Code "BIH" ;
   :hasAreaCode 70 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bosnia and Herzegovina"@en ;
   skos:prefLabel "Bosnie-Herzégovine"@fr .
 
@@ -571,7 +571,7 @@
   :hasAlpha3Code "BWA" ;
   :hasAreaCode 72 ;
   skos:broader :018 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Botswana"@en .
 
 :074 a skos:Concept ;
@@ -579,7 +579,7 @@
   :hasAlpha3Code "BVT" ;
   :hasAreaCode 74 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bouvet Island"@en .
 
 :076 a skos:Concept ;
@@ -587,7 +587,7 @@
   :hasAlpha3Code "BRA" ;
   :hasAreaCode 76 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Brazil"@en ;
   skos:prefLabel "Brésil"@fr .
 
@@ -596,7 +596,7 @@
   :hasAlpha3Code "BLZ" ;
   :hasAreaCode 84 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Belize"@en .
 
 :086 a skos:Concept ;
@@ -604,7 +604,7 @@
   :hasAlpha3Code "IOT" ;
   :hasAreaCode 86 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "British Indian Ocean Territory"@en .
 
 :090 a skos:Concept ;
@@ -612,7 +612,7 @@
   :hasAlpha3Code "SLB" ;
   :hasAreaCode 90 ;
   skos:broader :054 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Solomon Islands"@en ;
   skos:prefLabel "Îles Salomon"@fr .
 
@@ -621,7 +621,7 @@
   :hasAlpha3Code "VGB" ;
   :hasAreaCode 92 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "British Virgin Islands"@en ;
   skos:prefLabel "Îles Vierges britanniques"@fr .
 
@@ -630,7 +630,7 @@
   :hasAlpha3Code "BRN" ;
   :hasAreaCode 96 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Brunei Darussalam"@en .
 
 :100 a skos:Concept ;
@@ -638,7 +638,7 @@
   :hasAlpha3Code "BGR" ;
   :hasAreaCode 100 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bulgaria"@en ;
   skos:prefLabel "Bulgarie"@fr .
 
@@ -647,7 +647,7 @@
   :hasAlpha3Code "MMR" ;
   :hasAreaCode 104 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Myanmar"@en .
 
 :108 a skos:Concept ;
@@ -655,7 +655,7 @@
   :hasAlpha3Code "BDI" ;
   :hasAreaCode 108 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Burundi"@en .
 
 :112 a skos:Concept ;
@@ -663,7 +663,7 @@
   :hasAlpha3Code "BLR" ;
   :hasAreaCode 112 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Belarus"@en ;
   skos:prefLabel "Biélorussie"@fr .
 
@@ -672,7 +672,7 @@
   :hasAlpha3Code "KHM" ;
   :hasAreaCode 116 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cambodge"@fr ;
   skos:prefLabel "Cambodia"@en .
 
@@ -681,7 +681,7 @@
   :hasAlpha3Code "CMR" ;
   :hasAreaCode 120 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cameroon"@en .
 
 :124 a skos:Concept ;
@@ -689,7 +689,7 @@
   :hasAlpha3Code "CAN" ;
   :hasAreaCode 124 ;
   skos:broader :021 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Canada"@en .
 
 :132 a skos:Concept ;
@@ -697,7 +697,7 @@
   :hasAlpha3Code "CPV" ;
   :hasAreaCode 132 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cabo Verde"@en .
 
 :136 a skos:Concept ;
@@ -705,7 +705,7 @@
   :hasAlpha3Code "CYM" ;
   :hasAreaCode 136 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cayman Islands"@en ;
   skos:prefLabel "Îles Caïmans"@fr .
 
@@ -714,14 +714,14 @@
   :hasAlpha3Code "CAF" ;
   :hasAreaCode 140 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Central African Republic"@en ;
   skos:prefLabel "République centrafricaine"@fr .
 
 :142 a skos:Concept ;
   :hasAreaCode 142 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :030 ;
   skos:narrower :034 ;
   skos:narrower :035 ;
@@ -733,7 +733,7 @@
 :143 a skos:Concept ;
   :hasAreaCode 143 ;
   skos:broader :142 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :398 ;
   skos:narrower :417 ;
   skos:narrower :762 ;
@@ -747,13 +747,13 @@
   :hasAlpha3Code "LKA" ;
   :hasAreaCode 144 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Sri Lanka"@en .
 
 :145 a skos:Concept ;
   :hasAreaCode 145 ;
   skos:broader :142 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :031 ;
   skos:narrower :048 ;
   skos:narrower :051 ;
@@ -780,14 +780,14 @@
   :hasAlpha3Code "TCD" ;
   :hasAreaCode 148 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Chad"@en ;
   skos:prefLabel "Tchad"@fr .
 
 :150 a skos:Concept ;
   :hasAreaCode 150 ;
   skos:broader :001 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :039 ;
   skos:narrower :151 ;
   skos:narrower :154 ;
@@ -797,7 +797,7 @@
 :151 a skos:Concept ;
   :hasAreaCode 151 ;
   skos:broader :150 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :100 ;
   skos:narrower :112 ;
   skos:narrower :203 ;
@@ -816,14 +816,14 @@
   :hasAlpha3Code "CHL" ;
   :hasAreaCode 152 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Chile"@en ;
   skos:prefLabel "Chili"@fr .
 
 :154 a skos:Concept ;
   :hasAreaCode 154 ;
   skos:broader :150 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :208 ;
   skos:narrower :233 ;
   skos:narrower :234 ;
@@ -845,7 +845,7 @@
 :155 a skos:Concept ;
   :hasAreaCode 155 ;
   skos:broader :150 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :040 ;
   skos:narrower :056 ;
   skos:narrower :250 ;
@@ -863,7 +863,7 @@
   :hasAlpha3Code "CHN" ;
   :hasAreaCode 156 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "China"@en ;
   skos:prefLabel "Chine"@fr .
 
@@ -872,7 +872,7 @@
   :hasAlpha3Code "CXR" ;
   :hasAreaCode 162 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Christmas Island"@en .
 
 :166 a skos:Concept ;
@@ -880,7 +880,7 @@
   :hasAlpha3Code "CCK" ;
   :hasAreaCode 166 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cocos (Keeling) Islands"@en .
 
 :170 a skos:Concept ;
@@ -888,7 +888,7 @@
   :hasAlpha3Code "COL" ;
   :hasAreaCode 170 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Colombia"@en ;
   skos:prefLabel "Colombie"@fr .
 
@@ -897,7 +897,7 @@
   :hasAlpha3Code "COM" ;
   :hasAreaCode 174 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Comores"@fr ;
   skos:prefLabel "Comoros"@en .
 
@@ -906,7 +906,7 @@
   :hasAlpha3Code "MYT" ;
   :hasAreaCode 175 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mayotte"@en .
 
 :178 a skos:Concept ;
@@ -914,7 +914,7 @@
   :hasAlpha3Code "COG" ;
   :hasAreaCode 178 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Congo"@en .
 
 :180 a skos:Concept ;
@@ -922,7 +922,7 @@
   :hasAlpha3Code "COD" ;
   :hasAreaCode 180 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Democratic Republic of the Congo"@en ;
   skos:prefLabel "République démocratique du Congo"@fr .
 
@@ -931,7 +931,7 @@
   :hasAlpha3Code "COK" ;
   :hasAreaCode 184 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cook Islands"@en .
 
 :188 a skos:Concept ;
@@ -939,7 +939,7 @@
   :hasAlpha3Code "CRI" ;
   :hasAreaCode 188 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Costa Rica"@en .
 
 :191 a skos:Concept ;
@@ -947,7 +947,7 @@
   :hasAlpha3Code "HRV" ;
   :hasAreaCode 191 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Croatia"@en ;
   skos:prefLabel "Croatie"@fr .
 
@@ -956,7 +956,7 @@
   :hasAlpha3Code "CUB" ;
   :hasAreaCode 192 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Cuba"@en .
 
 :196 a skos:Concept ;
@@ -964,14 +964,14 @@
   :hasAlpha3Code "CYP" ;
   :hasAreaCode 196 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Chypre"@fr ;
   skos:prefLabel "Cyprus"@en .
 
 :202 a skos:Concept ;
   :hasAreaCode 202 ;
   skos:broader :002 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :011 ;
   skos:narrower :014 ;
   skos:narrower :017 ;
@@ -984,7 +984,7 @@
   :hasAlpha3Code "CZE" ;
   :hasAreaCode 203 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Czechia"@en ;
   skos:prefLabel "Tchéquie"@fr .
 
@@ -993,7 +993,7 @@
   :hasAlpha3Code "BEN" ;
   :hasAreaCode 204 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Benin"@en ;
   skos:prefLabel "Bénin"@fr .
 
@@ -1002,7 +1002,7 @@
   :hasAlpha3Code "DNK" ;
   :hasAreaCode 208 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Danemark"@fr ;
   skos:prefLabel "Denmark"@en .
 
@@ -1011,7 +1011,7 @@
   :hasAlpha3Code "DMA" ;
   :hasAreaCode 212 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Dominica"@en ;
   skos:prefLabel "Dominique"@fr .
 
@@ -1020,7 +1020,7 @@
   :hasAlpha3Code "DOM" ;
   :hasAreaCode 214 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Dominican Republic"@en ;
   skos:prefLabel "République dominicaine"@fr .
 
@@ -1029,7 +1029,7 @@
   :hasAlpha3Code "ECU" ;
   :hasAreaCode 218 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ecuador"@en ;
   skos:prefLabel "Équateur"@fr .
 
@@ -1038,7 +1038,7 @@
   :hasAlpha3Code "SLV" ;
   :hasAreaCode 222 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "El Salvador"@en ;
   skos:prefLabel "Salvador"@fr .
 
@@ -1047,7 +1047,7 @@
   :hasAlpha3Code "GNQ" ;
   :hasAreaCode 226 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Equatorial Guinea"@en ;
   skos:prefLabel "Guinée équatoriale"@fr .
 
@@ -1056,7 +1056,7 @@
   :hasAlpha3Code "ETH" ;
   :hasAreaCode 231 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ethiopia"@en ;
   skos:prefLabel "Éthiopie"@fr .
 
@@ -1065,7 +1065,7 @@
   :hasAlpha3Code "ERI" ;
   :hasAreaCode 232 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Eritrea"@en ;
   skos:prefLabel "Érythrée"@fr .
 
@@ -1074,7 +1074,7 @@
   :hasAlpha3Code "EST" ;
   :hasAreaCode 233 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Estonia"@en ;
   skos:prefLabel "Estonie"@fr .
 
@@ -1083,7 +1083,7 @@
   :hasAlpha3Code "FRO" ;
   :hasAreaCode 234 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Faroe Islands"@en .
 
 :238 a skos:Concept ;
@@ -1091,7 +1091,7 @@
   :hasAlpha3Code "FLK" ;
   :hasAreaCode 238 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Falkland Islands (Malvinas)"@en .
 
 :239 a skos:Concept ;
@@ -1099,7 +1099,7 @@
   :hasAlpha3Code "SGS" ;
   :hasAreaCode 239 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "South Georgia and the South Sandwich Islands"@en .
 
 :242 a skos:Concept ;
@@ -1107,7 +1107,7 @@
   :hasAlpha3Code "FJI" ;
   :hasAreaCode 242 ;
   skos:broader :054 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Fiji"@en .
 
 :246 a skos:Concept ;
@@ -1115,7 +1115,7 @@
   :hasAlpha3Code "FIN" ;
   :hasAreaCode 246 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Finland"@en ;
   skos:prefLabel "Finlande"@fr .
 
@@ -1124,7 +1124,7 @@
   :hasAlpha3Code "ALA" ;
   :hasAreaCode 248 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Åland Islands"@en .
 
 :250 a skos:Concept ;
@@ -1132,7 +1132,7 @@
   :hasAlpha3Code "FRA" ;
   :hasAreaCode 250 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "France"@en .
 
 :254 a skos:Concept ;
@@ -1140,7 +1140,7 @@
   :hasAlpha3Code "GUF" ;
   :hasAreaCode 254 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "French Guiana"@en ;
   skos:prefLabel "Guyane française"@fr .
 
@@ -1149,7 +1149,7 @@
   :hasAlpha3Code "PYF" ;
   :hasAreaCode 258 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "French Polynesia"@en ;
   skos:prefLabel "Polynésie française"@fr .
 
@@ -1158,7 +1158,7 @@
   :hasAlpha3Code "ATF" ;
   :hasAreaCode 260 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "French Southern Territories"@en ;
   skos:prefLabel "Territoires français du Sud"@fr .
 
@@ -1167,7 +1167,7 @@
   :hasAlpha3Code "DJI" ;
   :hasAreaCode 262 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Djibouti"@en .
 
 :266 a skos:Concept ;
@@ -1175,7 +1175,7 @@
   :hasAlpha3Code "GAB" ;
   :hasAreaCode 266 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Gabon"@en .
 
 :268 a skos:Concept ;
@@ -1183,7 +1183,7 @@
   :hasAlpha3Code "GEO" ;
   :hasAreaCode 268 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Georgia"@en ;
   skos:prefLabel "Géorgie"@fr .
 
@@ -1192,7 +1192,7 @@
   :hasAlpha3Code "GMB" ;
   :hasAreaCode 270 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Gambia"@en ;
   skos:prefLabel "Gambie"@fr .
 
@@ -1201,7 +1201,7 @@
   :hasAlpha3Code "PSE" ;
   :hasAreaCode 275 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "State of Palestine"@en ;
   skos:prefLabel "État de Palestine"@fr .
 
@@ -1210,7 +1210,7 @@
   :hasAlpha3Code "DEU" ;
   :hasAreaCode 276 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Allemagne"@fr ;
   skos:prefLabel "Germany"@en .
 
@@ -1219,7 +1219,7 @@
   :hasAlpha3Code "GHA" ;
   :hasAreaCode 288 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ghana"@en .
 
 :292 a skos:Concept ;
@@ -1227,7 +1227,7 @@
   :hasAlpha3Code "GIB" ;
   :hasAreaCode 292 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Gibraltar"@en .
 
 :296 a skos:Concept ;
@@ -1235,7 +1235,7 @@
   :hasAlpha3Code "KIR" ;
   :hasAreaCode 296 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Kiribati"@en .
 
 :300 a skos:Concept ;
@@ -1243,7 +1243,7 @@
   :hasAlpha3Code "GRC" ;
   :hasAreaCode 300 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Greece"@en ;
   skos:prefLabel "Grèce"@fr .
 
@@ -1252,7 +1252,7 @@
   :hasAlpha3Code "GRL" ;
   :hasAreaCode 304 ;
   skos:broader :021 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Greenland"@en .
 
 :308 a skos:Concept ;
@@ -1260,7 +1260,7 @@
   :hasAlpha3Code "GRD" ;
   :hasAreaCode 308 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Grenada"@en ;
   skos:prefLabel "Grenade"@fr .
 
@@ -1269,7 +1269,7 @@
   :hasAlpha3Code "GLP" ;
   :hasAreaCode 312 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guadeloupe"@en .
 
 :316 a skos:Concept ;
@@ -1277,7 +1277,7 @@
   :hasAlpha3Code "GUM" ;
   :hasAreaCode 316 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guam"@en .
 
 :320 a skos:Concept ;
@@ -1285,7 +1285,7 @@
   :hasAlpha3Code "GTM" ;
   :hasAreaCode 320 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guatemala"@en .
 
 :324 a skos:Concept ;
@@ -1293,7 +1293,7 @@
   :hasAlpha3Code "GIN" ;
   :hasAreaCode 324 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guinea"@en ;
   skos:prefLabel "Guinée"@fr .
 
@@ -1302,7 +1302,7 @@
   :hasAlpha3Code "GUY" ;
   :hasAreaCode 328 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guyana"@en ;
   skos:prefLabel "Guyane"@fr .
 
@@ -1311,7 +1311,7 @@
   :hasAlpha3Code "HTI" ;
   :hasAreaCode 332 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Haiti"@en .
 
 :334 a skos:Concept ;
@@ -1319,7 +1319,7 @@
   :hasAlpha3Code "HMD" ;
   :hasAreaCode 334 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Heard Island and McDonald Islands"@en .
 
 :336 a skos:Concept ;
@@ -1327,7 +1327,7 @@
   :hasAlpha3Code "VAT" ;
   :hasAreaCode 336 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Holy See"@en .
 
 :340 a skos:Concept ;
@@ -1335,7 +1335,7 @@
   :hasAlpha3Code "HND" ;
   :hasAreaCode 340 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Honduras"@en .
 
 :344 a skos:Concept ;
@@ -1343,7 +1343,7 @@
   :hasAlpha3Code "HKG" ;
   :hasAreaCode 344 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "China, Hong Kong Special Administrative Region"@en ;
   skos:prefLabel "Chine, Région administrative spéciale de Hong Kong"@fr .
 
@@ -1352,7 +1352,7 @@
   :hasAlpha3Code "HUN" ;
   :hasAreaCode 348 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Hongrie"@fr ;
   skos:prefLabel "Hungary"@en .
 
@@ -1361,7 +1361,7 @@
   :hasAlpha3Code "ISL" ;
   :hasAreaCode 352 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Iceland"@en ;
   skos:prefLabel "Islande"@fr .
 
@@ -1370,7 +1370,7 @@
   :hasAlpha3Code "IND" ;
   :hasAreaCode 356 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Inde"@fr ;
   skos:prefLabel "India"@en .
 
@@ -1379,7 +1379,7 @@
   :hasAlpha3Code "IDN" ;
   :hasAreaCode 360 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Indonesia"@en ;
   skos:prefLabel "Indonésie"@fr .
 
@@ -1388,7 +1388,7 @@
   :hasAlpha3Code "IRN" ;
   :hasAreaCode 364 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Iran (Islamic Republic of)"@en ;
   skos:prefLabel "Iran (République islamique d')"@fr .
 
@@ -1397,7 +1397,7 @@
   :hasAlpha3Code "IRQ" ;
   :hasAreaCode 368 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Irak"@fr ;
   skos:prefLabel "Iraq"@en .
 
@@ -1406,7 +1406,7 @@
   :hasAlpha3Code "IRL" ;
   :hasAreaCode 372 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ireland"@en ;
   skos:prefLabel "Irlande"@fr .
 
@@ -1415,7 +1415,7 @@
   :hasAlpha3Code "ISR" ;
   :hasAreaCode 376 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Israel"@en ;
   skos:prefLabel "Israël"@fr .
 
@@ -1424,7 +1424,7 @@
   :hasAlpha3Code "ITA" ;
   :hasAreaCode 380 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Italie"@fr ;
   skos:prefLabel "Italy"@en .
 
@@ -1433,7 +1433,7 @@
   :hasAlpha3Code "CIV" ;
   :hasAreaCode 384 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Côte d’Ivoire"@en .
 
 :388 a skos:Concept ;
@@ -1441,7 +1441,7 @@
   :hasAlpha3Code "JAM" ;
   :hasAreaCode 388 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Jamaica"@en ;
   skos:prefLabel "Jamaïque"@fr .
 
@@ -1450,7 +1450,7 @@
   :hasAlpha3Code "JPN" ;
   :hasAreaCode 392 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Japan"@en ;
   skos:prefLabel "Japon"@fr .
 
@@ -1459,7 +1459,7 @@
   :hasAlpha3Code "KAZ" ;
   :hasAreaCode 398 ;
   skos:broader :143 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Kazakhstan"@en .
 
 :400 a skos:Concept ;
@@ -1467,7 +1467,7 @@
   :hasAlpha3Code "JOR" ;
   :hasAreaCode 400 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Jordan"@en ;
   skos:prefLabel "Jordanie"@fr .
 
@@ -1476,7 +1476,7 @@
   :hasAlpha3Code "KEN" ;
   :hasAreaCode 404 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Kenya"@en .
 
 :408 a skos:Concept ;
@@ -1484,7 +1484,7 @@
   :hasAlpha3Code "PRK" ;
   :hasAreaCode 408 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Democratic People's Republic of Korea"@en ;
   skos:prefLabel "République populaire démocratique de Corée"@fr .
 
@@ -1493,7 +1493,7 @@
   :hasAlpha3Code "KOR" ;
   :hasAreaCode 410 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Republic of Korea"@en ;
   skos:prefLabel "République de Corée"@fr .
 
@@ -1502,7 +1502,7 @@
   :hasAlpha3Code "KWT" ;
   :hasAreaCode 414 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Koweït"@fr ;
   skos:prefLabel "Kuwait"@en .
 
@@ -1511,7 +1511,7 @@
   :hasAlpha3Code "KGZ" ;
   :hasAreaCode 417 ;
   skos:broader :143 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Kyrgyzstan"@en .
 
 :418 a skos:Concept ;
@@ -1519,14 +1519,14 @@
   :hasAlpha3Code "LAO" ;
   :hasAreaCode 418 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Lao People's Democratic Republic"@en ;
   skos:prefLabel "République démocratique populaire lao"@fr .
 
 :419 a skos:Concept ;
   :hasAreaCode 419 ;
   skos:broader :019 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :005 ;
   skos:narrower :013 ;
   skos:narrower :029 ;
@@ -1538,7 +1538,7 @@
   :hasAlpha3Code "LBN" ;
   :hasAreaCode 422 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Lebanon"@en ;
   skos:prefLabel "Liban"@fr .
 
@@ -1547,7 +1547,7 @@
   :hasAlpha3Code "LSO" ;
   :hasAreaCode 426 ;
   skos:broader :018 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Lesotho"@en .
 
 :428 a skos:Concept ;
@@ -1555,7 +1555,7 @@
   :hasAlpha3Code "LVA" ;
   :hasAreaCode 428 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Latvia"@en ;
   skos:prefLabel "Lettonie"@fr .
 
@@ -1564,7 +1564,7 @@
   :hasAlpha3Code "LBR" ;
   :hasAreaCode 430 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Liberia"@en .
 
 :434 a skos:Concept ;
@@ -1572,7 +1572,7 @@
   :hasAlpha3Code "LBY" ;
   :hasAreaCode 434 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Libya"@en ;
   skos:prefLabel "Libye"@fr .
 
@@ -1581,7 +1581,7 @@
   :hasAlpha3Code "LIE" ;
   :hasAreaCode 438 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Liechtenstein"@en .
 
 :440 a skos:Concept ;
@@ -1589,7 +1589,7 @@
   :hasAlpha3Code "LTU" ;
   :hasAreaCode 440 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Lithuania"@en ;
   skos:prefLabel "Lituanie"@fr .
 
@@ -1598,7 +1598,7 @@
   :hasAlpha3Code "LUX" ;
   :hasAreaCode 442 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Luxembourg"@en .
 
 :446 a skos:Concept ;
@@ -1606,7 +1606,7 @@
   :hasAlpha3Code "MAC" ;
   :hasAreaCode 446 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "China, Macao Special Administrative Region"@en .
 
 :450 a skos:Concept ;
@@ -1614,7 +1614,7 @@
   :hasAlpha3Code "MDG" ;
   :hasAreaCode 450 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Madagascar"@en .
 
 :454 a skos:Concept ;
@@ -1622,7 +1622,7 @@
   :hasAlpha3Code "MWI" ;
   :hasAreaCode 454 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Malawi"@en .
 
 :458 a skos:Concept ;
@@ -1630,7 +1630,7 @@
   :hasAlpha3Code "MYS" ;
   :hasAreaCode 458 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Malaisie"@fr ;
   skos:prefLabel "Malaysia"@en .
 
@@ -1639,7 +1639,7 @@
   :hasAlpha3Code "MDV" ;
   :hasAreaCode 462 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Maldives"@en .
 
 :466 a skos:Concept ;
@@ -1647,7 +1647,7 @@
   :hasAlpha3Code "MLI" ;
   :hasAreaCode 466 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mali"@en .
 
 :470 a skos:Concept ;
@@ -1655,7 +1655,7 @@
   :hasAlpha3Code "MLT" ;
   :hasAreaCode 470 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Malta"@en ;
   skos:prefLabel "Malte"@fr .
 
@@ -1664,7 +1664,7 @@
   :hasAlpha3Code "MTQ" ;
   :hasAreaCode 474 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Martinique"@en .
 
 :478 a skos:Concept ;
@@ -1672,7 +1672,7 @@
   :hasAlpha3Code "MRT" ;
   :hasAreaCode 478 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mauritania"@en ;
   skos:prefLabel "Mauritanie"@fr .
 
@@ -1681,7 +1681,7 @@
   :hasAlpha3Code "MUS" ;
   :hasAreaCode 480 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ile Maurice"@fr ;
   skos:prefLabel "Mauritius"@en .
 
@@ -1690,7 +1690,7 @@
   :hasAlpha3Code "MEX" ;
   :hasAreaCode 484 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mexico"@en ;
   skos:prefLabel "Mexique"@fr .
 
@@ -1699,7 +1699,7 @@
   :hasAlpha3Code "MCO" ;
   :hasAreaCode 492 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Monaco"@en .
 
 :496 a skos:Concept ;
@@ -1707,7 +1707,7 @@
   :hasAlpha3Code "MNG" ;
   :hasAreaCode 496 ;
   skos:broader :030 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mongolia"@en ;
   skos:prefLabel "Mongolie"@fr .
 
@@ -1716,7 +1716,7 @@
   :hasAlpha3Code "MDA" ;
   :hasAreaCode 498 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Republic of Moldova"@en ;
   skos:prefLabel "République de Moldavie"@fr .
 
@@ -1724,7 +1724,7 @@
   :hasAlpha3Code "MNE" ;
   :hasAreaCode 499 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Montenegro"@en .
 
 :500 a skos:Concept ;
@@ -1732,7 +1732,7 @@
   :hasAlpha3Code "MSR" ;
   :hasAreaCode 500 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Montserrat"@en .
 
 :504 a skos:Concept ;
@@ -1740,7 +1740,7 @@
   :hasAlpha3Code "MAR" ;
   :hasAreaCode 504 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Maroc"@fr ;
   skos:prefLabel "Morocco"@en .
 
@@ -1749,7 +1749,7 @@
   :hasAlpha3Code "MOZ" ;
   :hasAreaCode 508 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Mozambique"@en .
 
 :512 a skos:Concept ;
@@ -1757,7 +1757,7 @@
   :hasAlpha3Code "OMN" ;
   :hasAreaCode 512 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Oman"@en .
 
 :516 a skos:Concept ;
@@ -1765,7 +1765,7 @@
   :hasAlpha3Code "NAM" ;
   :hasAreaCode 516 ;
   skos:broader :018 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Namibia"@en ;
   skos:prefLabel "Namibie"@fr .
 
@@ -1774,7 +1774,7 @@
   :hasAlpha3Code "NRU" ;
   :hasAreaCode 520 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Nauru"@en .
 
 :524 a skos:Concept ;
@@ -1782,7 +1782,7 @@
   :hasAlpha3Code "NPL" ;
   :hasAreaCode 524 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Nepal"@en .
 
 :528 a skos:Concept ;
@@ -1790,7 +1790,7 @@
   :hasAlpha3Code "NLD" ;
   :hasAreaCode 528 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Netherlands"@en ;
   skos:prefLabel "Pays-Bas"@fr .
 
@@ -1798,7 +1798,7 @@
   :hasAlpha3Code "CUW" ;
   :hasAreaCode 531 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Curaçao"@en .
 
 :533 a skos:Concept ;
@@ -1806,14 +1806,14 @@
   :hasAlpha3Code "ABW" ;
   :hasAreaCode 533 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Aruba"@en .
 
 :534 a skos:Concept ;
   :hasAlpha3Code "SXM" ;
   :hasAreaCode 534 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint-Martin (partie néerlandaise)"@fr ;
   skos:prefLabel "Sint Maarten (Dutch part)"@en .
 
@@ -1821,7 +1821,7 @@
   :hasAlpha3Code "BES" ;
   :hasAreaCode 535 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Bonaire, Sint Eustatius and Saba"@en .
 
 :540 a skos:Concept ;
@@ -1829,7 +1829,7 @@
   :hasAlpha3Code "NCL" ;
   :hasAreaCode 540 ;
   skos:broader :054 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "New Caledonia"@en ;
   skos:prefLabel "Nouvelle-Calédonie"@fr .
 
@@ -1838,7 +1838,7 @@
   :hasAlpha3Code "VUT" ;
   :hasAreaCode 548 ;
   skos:broader :054 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Vanuatu"@en .
 
 :554 a skos:Concept ;
@@ -1846,7 +1846,7 @@
   :hasAlpha3Code "NZL" ;
   :hasAreaCode 554 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "New Zealand"@en ;
   skos:prefLabel "Nouvelle-Zélande"@fr .
 
@@ -1855,7 +1855,7 @@
   :hasAlpha3Code "NIC" ;
   :hasAreaCode 558 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Nicaragua"@en .
 
 :562 a skos:Concept ;
@@ -1863,7 +1863,7 @@
   :hasAlpha3Code "NER" ;
   :hasAreaCode 562 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Niger"@en .
 
 :566 a skos:Concept ;
@@ -1871,7 +1871,7 @@
   :hasAlpha3Code "NGA" ;
   :hasAreaCode 566 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Nigeria"@en .
 
 :570 a skos:Concept ;
@@ -1879,7 +1879,7 @@
   :hasAlpha3Code "NIU" ;
   :hasAreaCode 570 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Niue"@en .
 
 :574 a skos:Concept ;
@@ -1887,7 +1887,7 @@
   :hasAlpha3Code "NFK" ;
   :hasAreaCode 574 ;
   skos:broader :053 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Norfolk Island"@en .
 
 :578 a skos:Concept ;
@@ -1895,7 +1895,7 @@
   :hasAlpha3Code "NOR" ;
   :hasAreaCode 578 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Norvège"@fr ;
   skos:prefLabel "Norway"@en .
 
@@ -1904,7 +1904,7 @@
   :hasAlpha3Code "MNP" ;
   :hasAreaCode 580 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Northern Mariana Islands"@en .
 
 :581 a skos:Concept ;
@@ -1912,7 +1912,7 @@
   :hasAlpha3Code "UMI" ;
   :hasAreaCode 581 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "United States Minor Outlying Islands"@en .
 
 :583 a skos:Concept ;
@@ -1920,7 +1920,7 @@
   :hasAlpha3Code "FSM" ;
   :hasAreaCode 583 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Micronesia (Federated States of)"@en .
 
 :584 a skos:Concept ;
@@ -1928,7 +1928,7 @@
   :hasAlpha3Code "MHL" ;
   :hasAreaCode 584 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Marshall Islands"@en .
 
 :585 a skos:Concept ;
@@ -1936,7 +1936,7 @@
   :hasAlpha3Code "PLW" ;
   :hasAreaCode 585 ;
   skos:broader :057 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Palau"@en .
 
 :586 a skos:Concept ;
@@ -1944,7 +1944,7 @@
   :hasAlpha3Code "PAK" ;
   :hasAreaCode 586 ;
   skos:broader :034 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Pakistan"@en .
 
 :591 a skos:Concept ;
@@ -1952,7 +1952,7 @@
   :hasAlpha3Code "PAN" ;
   :hasAreaCode 591 ;
   skos:broader :013 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Panama"@en .
 
 :598 a skos:Concept ;
@@ -1960,7 +1960,7 @@
   :hasAlpha3Code "PNG" ;
   :hasAreaCode 598 ;
   skos:broader :054 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel " Papouasie-Nouvelle-Guinée "@fr ;
   skos:prefLabel "Papua New Guinea"@en .
 
@@ -1969,7 +1969,7 @@
   :hasAlpha3Code "PRY" ;
   :hasAreaCode 600 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Paraguay"@en .
 
 :604 a skos:Concept ;
@@ -1977,7 +1977,7 @@
   :hasAlpha3Code "PER" ;
   :hasAreaCode 604 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Peru"@en ;
   skos:prefLabel "Pérou"@fr .
 
@@ -1986,7 +1986,7 @@
   :hasAlpha3Code "PHL" ;
   :hasAreaCode 608 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Philippines"@en .
 
 :612 a skos:Concept ;
@@ -1994,7 +1994,7 @@
   :hasAlpha3Code "PCN" ;
   :hasAreaCode 612 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Pitcairn"@en .
 
 :616 a skos:Concept ;
@@ -2002,7 +2002,7 @@
   :hasAlpha3Code "POL" ;
   :hasAreaCode 616 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Poland"@en ;
   skos:prefLabel "Pologne"@fr .
 
@@ -2011,7 +2011,7 @@
   :hasAlpha3Code "PRT" ;
   :hasAreaCode 620 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Portugal"@en .
 
 :624 a skos:Concept ;
@@ -2019,7 +2019,7 @@
   :hasAlpha3Code "GNB" ;
   :hasAreaCode 624 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guinea-Bissau"@en ;
   skos:prefLabel "Guinée-Bissau"@fr .
 
@@ -2028,7 +2028,7 @@
   :hasAlpha3Code "TLS" ;
   :hasAreaCode 626 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Timor-Leste"@en .
 
 :630 a skos:Concept ;
@@ -2036,7 +2036,7 @@
   :hasAlpha3Code "PRI" ;
   :hasAreaCode 630 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Pprto Rico"@fr ;
   skos:prefLabel "Puerto Rico"@en .
 
@@ -2045,7 +2045,7 @@
   :hasAlpha3Code "QAT" ;
   :hasAreaCode 634 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Qatar"@en .
 
 :638 a skos:Concept ;
@@ -2053,7 +2053,7 @@
   :hasAlpha3Code "REU" ;
   :hasAreaCode 638 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Réunion"@en .
 
 :642 a skos:Concept ;
@@ -2061,7 +2061,7 @@
   :hasAlpha3Code "ROU" ;
   :hasAreaCode 642 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Romania"@en ;
   skos:prefLabel "Roumanie"@fr .
 
@@ -2070,7 +2070,7 @@
   :hasAlpha3Code "RUS" ;
   :hasAreaCode 643 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Fédération de Russie"@fr ;
   skos:prefLabel "Russian Federation"@en .
 
@@ -2079,14 +2079,14 @@
   :hasAlpha3Code "RWA" ;
   :hasAreaCode 646 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Rwanda"@en .
 
 :652 a skos:Concept ;
   :hasAlpha3Code "BLM" ;
   :hasAreaCode 652 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Barthélemy"@en .
 
 :654 a skos:Concept ;
@@ -2094,7 +2094,7 @@
   :hasAlpha3Code "SHN" ;
   :hasAreaCode 654 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Helena"@en .
 
 :659 a skos:Concept ;
@@ -2102,7 +2102,7 @@
   :hasAlpha3Code "KNA" ;
   :hasAreaCode 659 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Kitts and Nevis"@en .
 
 :660 a skos:Concept ;
@@ -2110,7 +2110,7 @@
   :hasAlpha3Code "AIA" ;
   :hasAreaCode 660 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Anguilla"@en .
 
 :662 a skos:Concept ;
@@ -2118,14 +2118,14 @@
   :hasAlpha3Code "LCA" ;
   :hasAreaCode 662 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Lucia"@en .
 
 :663 a skos:Concept ;
   :hasAlpha3Code "MAF" ;
   :hasAreaCode 663 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Martin (French Part)"@en ;
   skos:prefLabel "Saint Martin (Partie française)"@fr .
 
@@ -2134,7 +2134,7 @@
   :hasAlpha3Code "SPM" ;
   :hasAreaCode 666 ;
   skos:broader :021 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Pierre and Miquelon"@en ;
   skos:prefLabel "Saint Pierre et Miquelon"@fr .
 
@@ -2143,7 +2143,7 @@
   :hasAlpha3Code "VCT" ;
   :hasAreaCode 670 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Saint Vincent and the Grenadines"@en .
 
 :674 a skos:Concept ;
@@ -2151,7 +2151,7 @@
   :hasAlpha3Code "SMR" ;
   :hasAreaCode 674 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "San Marino"@en .
 
 :678 a skos:Concept ;
@@ -2159,14 +2159,14 @@
   :hasAlpha3Code "STP" ;
   :hasAreaCode 678 ;
   skos:broader :017 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Sao Tome and Principe"@en .
 
 :680 a skos:Concept ;
   :hasAlpha3Code "" ;
   :hasAreaCode 680 ;
   skos:broader :830 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Sark"@en .
 
 :682 a skos:Concept ;
@@ -2174,7 +2174,7 @@
   :hasAlpha3Code "SAU" ;
   :hasAreaCode 682 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Arabie Saoudite"@fr ;
   skos:prefLabel "Saudi Arabia"@en .
 
@@ -2183,7 +2183,7 @@
   :hasAlpha3Code "SEN" ;
   :hasAreaCode 686 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Senegal"@en ;
   skos:prefLabel "Sénégal"@fr .
 
@@ -2191,7 +2191,7 @@
   :hasAlpha3Code "SRB" ;
   :hasAreaCode 688 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Serbia"@en ;
   skos:prefLabel "Serbie"@fr .
 
@@ -2200,7 +2200,7 @@
   :hasAlpha3Code "SYC" ;
   :hasAreaCode 690 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Seychelles"@en .
 
 :694 a skos:Concept ;
@@ -2208,7 +2208,7 @@
   :hasAlpha3Code "SLE" ;
   :hasAreaCode 694 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Sierra Leone"@en .
 
 :702 a skos:Concept ;
@@ -2216,7 +2216,7 @@
   :hasAlpha3Code "SGP" ;
   :hasAreaCode 702 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Singapore"@en ;
   skos:prefLabel "Singapour"@fr .
 
@@ -2225,7 +2225,7 @@
   :hasAlpha3Code "SVK" ;
   :hasAreaCode 703 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Slovakia"@en ;
   skos:prefLabel "Slovaquie"@fr .
 
@@ -2234,7 +2234,7 @@
   :hasAlpha3Code "VNM" ;
   :hasAreaCode 704 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Viet Nam"@en ;
   skos:prefLabel "Vietnam"@fr .
 
@@ -2243,7 +2243,7 @@
   :hasAlpha3Code "SVN" ;
   :hasAreaCode 705 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Slovenia"@en ;
   skos:prefLabel "Slovenie"@fr .
 
@@ -2252,7 +2252,7 @@
   :hasAlpha3Code "SOM" ;
   :hasAreaCode 706 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Somalia"@en ;
   skos:prefLabel "Somalie"@fr .
 
@@ -2261,7 +2261,7 @@
   :hasAlpha3Code "ZAF" ;
   :hasAreaCode 710 ;
   skos:broader :018 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Afrique du Sud"@fr ;
   skos:prefLabel "South Africa"@en .
 
@@ -2270,7 +2270,7 @@
   :hasAlpha3Code "ZWE" ;
   :hasAreaCode 716 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Zimbabwe"@en .
 
 :724 a skos:Concept ;
@@ -2278,7 +2278,7 @@
   :hasAlpha3Code "ESP" ;
   :hasAreaCode 724 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Espagne"@fr ;
   skos:prefLabel "Spain"@en .
 
@@ -2286,7 +2286,7 @@
   :hasAlpha3Code "SSD" ;
   :hasAreaCode 728 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Soudan du Sud"@fr ;
   skos:prefLabel "South Sudan"@en .
 
@@ -2295,7 +2295,7 @@
   :hasAlpha3Code "SDN" ;
   :hasAreaCode 729 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Soudan"@fr ;
   skos:prefLabel "Sudan"@en .
 
@@ -2304,7 +2304,7 @@
   :hasAlpha3Code "ESH" ;
   :hasAreaCode 732 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Sahara occidental"@fr ;
   skos:prefLabel "Western Sahara"@en .
 
@@ -2313,7 +2313,7 @@
   :hasAlpha3Code "SUR" ;
   :hasAreaCode 740 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Suriname"@en .
 
 :744 a skos:Concept ;
@@ -2321,7 +2321,7 @@
   :hasAlpha3Code "SJM" ;
   :hasAreaCode 744 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Svalbard and Jan Mayen Islands"@en .
 
 :748 a skos:Concept ;
@@ -2329,7 +2329,7 @@
   :hasAlpha3Code "SWZ" ;
   :hasAreaCode 748 ;
   skos:broader :018 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Eswatini"@en .
 
 :752 a skos:Concept ;
@@ -2337,7 +2337,7 @@
   :hasAlpha3Code "SWE" ;
   :hasAreaCode 752 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Suède"@fr ;
   skos:prefLabel "Sweden"@en .
 
@@ -2346,7 +2346,7 @@
   :hasAlpha3Code "CHE" ;
   :hasAreaCode 756 ;
   skos:broader :155 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Suisse"@fr ;
   skos:prefLabel "Switzerland"@en .
 
@@ -2355,7 +2355,7 @@
   :hasAlpha3Code "SYR" ;
   :hasAreaCode 760 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "République arabe syrienne"@fr ;
   skos:prefLabel "Syrian Arab Republic"@en .
 
@@ -2364,7 +2364,7 @@
   :hasAlpha3Code "TJK" ;
   :hasAreaCode 762 ;
   skos:broader :143 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Tajikistan"@en .
 
 :764 a skos:Concept ;
@@ -2372,7 +2372,7 @@
   :hasAlpha3Code "THA" ;
   :hasAreaCode 764 ;
   skos:broader :035 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Thailand"@en ;
   skos:prefLabel "Thaïlande"@fr .
 
@@ -2381,7 +2381,7 @@
   :hasAlpha3Code "TGO" ;
   :hasAreaCode 768 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Togo"@en .
 
 :772 a skos:Concept ;
@@ -2389,7 +2389,7 @@
   :hasAlpha3Code "TKL" ;
   :hasAreaCode 772 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Tokelau"@en .
 
 :776 a skos:Concept ;
@@ -2397,7 +2397,7 @@
   :hasAlpha3Code "TON" ;
   :hasAreaCode 776 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Tonga"@en .
 
 :780 a skos:Concept ;
@@ -2405,7 +2405,7 @@
   :hasAlpha3Code "TTO" ;
   :hasAreaCode 780 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Trinidad and Tobago"@en .
 
 :784 a skos:Concept ;
@@ -2413,7 +2413,7 @@
   :hasAlpha3Code "ARE" ;
   :hasAreaCode 784 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "United Arab Emirates"@en ;
   skos:prefLabel "Émirats arabes unis"@fr .
 
@@ -2422,7 +2422,7 @@
   :hasAlpha3Code "TUN" ;
   :hasAreaCode 788 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Tunisia"@en ;
   skos:prefLabel "Tunisie"@fr .
 
@@ -2431,7 +2431,7 @@
   :hasAlpha3Code "TUR" ;
   :hasAreaCode 792 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Turquie"@fr ;
   skos:prefLabel "Türkiye"@en .
 
@@ -2440,7 +2440,7 @@
   :hasAlpha3Code "TKM" ;
   :hasAreaCode 795 ;
   skos:broader :143 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Turkmenistan"@en .
 
 :796 a skos:Concept ;
@@ -2448,7 +2448,7 @@
   :hasAlpha3Code "TCA" ;
   :hasAreaCode 796 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Turks and Caicos Islands"@en .
 
 :798 a skos:Concept ;
@@ -2456,7 +2456,7 @@
   :hasAlpha3Code "TUV" ;
   :hasAreaCode 798 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Tuvalu"@en .
 
 :800 a skos:Concept ;
@@ -2464,7 +2464,7 @@
   :hasAlpha3Code "UGA" ;
   :hasAreaCode 800 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ouganda"@fr ;
   skos:prefLabel "Uganda"@en .
 
@@ -2473,7 +2473,7 @@
   :hasAlpha3Code "UKR" ;
   :hasAreaCode 804 ;
   skos:broader :151 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Ukraine"@en .
 
 :807 a skos:Concept ;
@@ -2481,7 +2481,7 @@
   :hasAlpha3Code "MKD" ;
   :hasAreaCode 807 ;
   skos:broader :039 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Macédoine du Nord"@fr ;
   skos:prefLabel "North Macedonia"@en .
 
@@ -2490,7 +2490,7 @@
   :hasAlpha3Code "EGY" ;
   :hasAreaCode 818 ;
   skos:broader :015 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Egypt"@en ;
   skos:prefLabel "Égypte"@fr .
 
@@ -2499,14 +2499,14 @@
   :hasAlpha3Code "GBR" ;
   :hasAreaCode 826 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Royaume-Uni de Grande-Bretagne et d'Irlande du Nord"@fr ;
   skos:prefLabel "United Kingdom of Great Britain and Northern Ireland"@en .
 
 :830 a skos:Concept ;
   :hasAreaCode 830 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:narrower :680 ;
   skos:narrower :831 ;
   skos:narrower :832 ;
@@ -2516,7 +2516,7 @@
   :hasAlpha3Code "GGY" ;
   :hasAreaCode 831 ;
   skos:broader :830 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Guernesey"@fr ;
   skos:prefLabel "Guernsey"@en .
 
@@ -2524,7 +2524,7 @@
   :hasAlpha3Code "JEY" ;
   :hasAreaCode 832 ;
   skos:broader :830 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Jersey"@en .
 
 :833 a skos:Concept ;
@@ -2532,7 +2532,7 @@
   :hasAlpha3Code "IMN" ;
   :hasAreaCode 833 ;
   skos:broader :154 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Isle of Man"@en .
 
 :834 a skos:Concept ;
@@ -2540,7 +2540,7 @@
   :hasAlpha3Code "TZA" ;
   :hasAreaCode 834 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "République-Unie de Tanzanie"@fr ;
   skos:prefLabel "United Republic of Tanzania"@en .
 
@@ -2549,7 +2549,7 @@
   :hasAlpha3Code "USA" ;
   :hasAreaCode 840 ;
   skos:broader :021 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "United States of America"@en ;
   skos:prefLabel "États-Unis d'Amérique"@fr .
 
@@ -2558,7 +2558,7 @@
   :hasAlpha3Code "VIR" ;
   :hasAreaCode 850 ;
   skos:broader :029 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "United States Virgin Islands"@en .
 
 :854 a skos:Concept ;
@@ -2566,7 +2566,7 @@
   :hasAlpha3Code "BFA" ;
   :hasAreaCode 854 ;
   skos:broader :011 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Burkina Faso"@en .
 
 :858 a skos:Concept ;
@@ -2574,7 +2574,7 @@
   :hasAlpha3Code "URY" ;
   :hasAreaCode 858 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Uruguay"@en .
 
 :860 a skos:Concept ;
@@ -2582,7 +2582,7 @@
   :hasAlpha3Code "UZB" ;
   :hasAreaCode 860 ;
   skos:broader :143 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Uzbekistan"@en .
 
 :862 a skos:Concept ;
@@ -2590,7 +2590,7 @@
   :hasAlpha3Code "VEN" ;
   :hasAreaCode 862 ;
   skos:broader :005 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Venezuela (Bolivarian Republic of)"@en ;
   skos:prefLabel "Venezuela"@fr .
 
@@ -2599,7 +2599,7 @@
   :hasAlpha3Code "WLF" ;
   :hasAreaCode 876 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Wallis and Futuna Islands"@en ;
   skos:prefLabel "Îles Wallis et Futuna"@fr .
 
@@ -2608,7 +2608,7 @@
   :hasAlpha3Code "WSM" ;
   :hasAreaCode 882 ;
   skos:broader :061 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Samoa"@en .
 
 :887 a skos:Concept ;
@@ -2616,7 +2616,7 @@
   :hasAlpha3Code "YEM" ;
   :hasAreaCode 887 ;
   skos:broader :145 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Yemen"@en .
 
 :894 a skos:Concept ;
@@ -2624,11 +2624,11 @@
   :hasAlpha3Code "ZMB" ;
   :hasAreaCode 894 ;
   skos:broader :014 ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/area> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/area> ;
   skos:prefLabel "Zambia"@en ;
   skos:prefLabel "Zambie"@fr .
 
-<https://ontology.okp4.space/thesaurus/area> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/area> a skos:ConceptScheme ;
   rdfs:label "Area Code Thesaurus"@en ;
   dcterms:description "This thesaurus defines a controlled vocabulary referencing the different area codes as developed and maintained by the United Nations Statistics Division."@en ;
   dcterms:title "Area Codes for Statistical Use (Series M, No. 49) Thesaurus"@en ;

--- a/src/thesaurus/digital-service-category.ttl
+++ b/src/thesaurus/digital-service-category.ttl
@@ -1,46 +1,46 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/digital-service-category/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/digital-service-category/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 :ClassificationModel a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Classification Model"@en ;
   skos:prefLabel "Klassifizierungsmodell"@de ;
   skos:prefLabel "Modèle de classification"@fr .
 
 :ClusteringModel a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Clustering Model"@en ;
   skos:prefLabel "Clustering-Modell"@de ;
   skos:prefLabel "Modèle de clustering"@fr .
 
 :ComputerVision a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Computer Vision"@de ;
   skos:prefLabel "Computer Vision"@en ;
   skos:prefLabel "Vision par ordinateur"@fr .
 
 :DataCleaning a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Data Cleaning"@en ;
   skos:prefLabel "Datenbereinigung"@de ;
   skos:prefLabel "Nettoyage de données"@fr .
 
 :DataIntegration a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Data Integration"@en ;
   skos:prefLabel "Integration von Daten"@de ;
   skos:prefLabel "Intégration des données"@fr .
 
 :DataProcessing a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:narrower :ClassificationModel ;
   skos:narrower :ClusteringModel ;
   skos:narrower :ComputerVision ;
@@ -55,46 +55,46 @@
 
 :DataTransformation a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Data Transformation"@en ;
   skos:prefLabel "Datenumwandlung"@de ;
   skos:prefLabel "Transformation des données"@fr .
 
 :DeepLearning a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Apprentissage profond"@fr ;
   skos:prefLabel "Deep Learning"@en ;
   skos:prefLabel "mehrschichtiges Lernen"@de .
 
 :NaturalLanguageProcessing a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Natural Language Processing"@en ;
   skos:prefLabel "Traitement du langage naturel"@fr ;
   skos:prefLabel "Verarbeitung natürlicher Sprache"@de .
 
 :RegressionModel a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Modèle de régression"@fr ;
   skos:prefLabel "Regression Model"@en ;
   skos:prefLabel "Regressionsmodell"@de .
 
 :StatisticsAndAnalytics a skos:Concept ;
   skos:broader :DataProcessing ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Statistics & Analytics"@en ;
   skos:prefLabel "Statistik & Analytik"@de ;
   skos:prefLabel "Statistiques et analyses"@fr .
 
 :Storage a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-category> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-category> ;
   skos:prefLabel "Lagerung"@de ;
   skos:prefLabel "Stockage"@fr ;
   skos:prefLabel "Storage"@en .
 
-<https://ontology.okp4.space/thesaurus/digital-service-category> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/digital-service-category> a skos:ConceptScheme ;
   rdfs:label "Service Category Thesaurus"@en ;
   rdfs:label "Thesaurus der Dienstleistungskategorien"@de ;
   rdfs:label "Thésaurus des catégories de services"@fr ;

--- a/src/thesaurus/digital-service-execution-status.ttl
+++ b/src/thesaurus/digital-service-execution-status.ttl
@@ -1,22 +1,22 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/digital-service-digital-service-execution-status/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/digital-service-digital-service-execution-status/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 :Cancelled a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-execution-status> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-execution-status> ;
   skos:prefLabel "Cancelled"@en .
 
 :Delivered a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-execution-status> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-execution-status> ;
   skos:prefLabel "Delivered"@en .
 
 :Failed a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/digital-service-execution-status> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/digital-service-execution-status> ;
   skos:prefLabel "Failed"@en .
 
-<https://ontology.okp4.space/thesaurus/digital-service-execution-status> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/digital-service-execution-status> a skos:ConceptScheme ;
   rdfs:label "Digital Service Execution Status Thesaurus"@en ;
   dcterms:description """
   This thesaurus defines a controlled vocabulary for representing the status of execution of Digital Services. This allows for standardized representation and understanding of execution status in various systems.

--- a/src/thesaurus/license.ttl
+++ b/src/thesaurus/license.ttl
@@ -1,390 +1,390 @@
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/license/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/license/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 :AAL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Attribution Assurance Licenses"@en .
 
 :AFL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Academic Free License 3.0"@en .
 
 :AGPL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU Affero General Public License v3"@en .
 
 :APL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Adaptive Public License 1.0"@en .
 
 :APSL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Apple Public Source License 2.0"@en .
 
 :Against-DRM a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Against DRM"@en .
 
 :Apache-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Apache Software License 1.1"@en .
 
 :Apache-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Apache Software License 2.0"@en .
 
 :Artistic-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Artistic License 2.0"@en .
 
 :BSD-2-Clause a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "BSD 2-Clause \"Simplified\" or \"FreeBSD\" License (BSD-2-Clause)"@en .
 
 :BSD-3-Clause a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "BSD 3-Clause \"New\" or \"Revised\" License (BSD-3-Clause)"@en .
 
 :BSL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Boost Software License 1.0"@en .
 
 :BitTorrent-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "BitTorrent Open Source License 1.1"@en .
 
 :CATOSL-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Computer Associates Trusted Open Source License 1.1 (CATOSL-1.1)"@en .
 
 :CC-BY-4_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Creative Commons Attribution 4.0"@en .
 
 :CC-BY-NC-4_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Creative Commons Attribution-NonCommercial 4.0"@en .
 
 :CC-BY-SA-4_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Creative Commons Attribution Share-Alike 4.0"@en .
 
 :CC0-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "CC0 1.0"@en .
 
 :CDDL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Common Development and Distribution License 1.0"@en .
 
 :CECILL-2_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "CeCILL License 2.1"@en .
 
 :CNRI-Python a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "CNRI Python License"@en .
 
 :CPAL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Common Public Attribution License 1.0"@en .
 
 :CUA-OPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "CUA Office Public License 1.0"@en .
 
 :DSL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Design Science License"@en .
 
 :ECL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Educational Community License 2.0"@en .
 
 :EFL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Eiffel Forum License 2.0"@en .
 
 :EPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Eclipse Public License 1.0"@en .
 
 :EPL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Eclipse Public License 2.0"@en .
 
 :EUDatagrid a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "EU DataGrid Software License"@en .
 
 :EUPL-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "European Union Public License 1.1"@en .
 
 :Entessa a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Entessa Public License"@en .
 
 :FAL-1_3 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Free Art License 1.3"@en .
 
 :Fair a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Fair License"@en .
 
 :Frameworx-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Frameworx License 1.0"@en .
 
 :GFDL-1_3-no-cover-texts-no-invariant-sections a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU Free Documentation License 1.3 with no cover texts and no invariant sections"@en .
 
 :GPL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU General Public License 2.0"@en .
 
 :GPL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU General Public License 3.0"@en .
 
 :HPND a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Historical Permission Notice and Disclaimer"@en .
 
 :IPA a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "IPA Font License"@en .
 
 :IPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "IBM Public License 1.0"@en .
 
 :ISC a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "ISC License"@en .
 
 :Intel a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Intel Open Source License"@en .
 
 :LGPL-2_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU Lesser General Public License 2.1"@en .
 
 :LGPL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "GNU Lesser General Public License 3.0"@en .
 
 :LO-FR-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open License 1.0"@en .
 
 :LO-FR-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open License 2.0"@en .
 
 :LPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Lucent Public License (\"Plan9\") 1.0"@en .
 
 :LPL-1_02 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Lucent Public License 1.02"@en .
 
 :LPPL-1_3c a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "LaTeX Project Public License 1.3c"@en .
 
 :MIT a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "MIT License"@en .
 
 :MPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Mozilla Public License 1.0"@en .
 
 :MPL-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Mozilla Public License 1.1"@en .
 
 :MPL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Mozilla Public License 2.0"@en .
 
 :MS-PL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Microsoft Public License"@en .
 
 :MS-RL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Microsoft Reciprocal License"@en .
 
 :MirOS a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "MirOS Licence"@en .
 
 :Motosoto a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Motosoto License"@en .
 
 :Multics a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Multics License"@en .
 
 :NASA-1_3 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "NASA Open Source Agreement 1.3"@en .
 
 :NCSA a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "University of Illinois/NCSA Open Source License"@en .
 
 :NGPL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Nethack General Public License"@en .
 
 :NPOSL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Non-Profit Open Software License 3.0"@en .
 
 :NTP a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "NTP License"@en .
 
 :Naumen a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Naumen Public License"@en .
 
 :Nokia a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Nokia Open Source License"@en .
 
 :OCLC-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "OCLC Research Public License 2.0"@en .
 
 :ODC-BY-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Data Commons Attribution License 1.0"@en .
 
 :ODbL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Data Commons Open Database License 1.0"@en .
 
 :OFL-1_1 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Font License 1.1"@en .
 
 :OGL-Canada-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Government License 2.0 (Canada)"@en .
 
 :OGL-UK-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Government Licence 1.0 (United Kingdom)"@en .
 
 :OGL-UK-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Government Licence 2.0 (United Kingdom)"@en .
 
 :OGL-UK-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Government Licence 3.0 (United Kingdom)"@en .
 
 :OGTSL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Group Test Suite License"@en .
 
 :OSL-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Software License 3.0"@en .
 
 :PDDL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Open Data Commons Public Domain Dedication and Licence 1.0"@en .
 
 :PHP-3_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "PHP License 3.0"@en .
 
 :PostgreSQL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "PostgreSQL License"@en .
 
 :Python-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Python License 2.0"@en .
 
 :QPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Q Public License 1.0"@en .
 
 :RPL-1_5 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Reciprocal Public License 1.5"@en .
 
 :RPSL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "RealNetworks Public Source License 1.0"@en .
 
 :RSCPL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Ricoh Source Code Public License"@en .
 
 :SISSL a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Sun Industry Standards Source License 1.1"@en .
 
 :SPL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Sun Public License 1.0"@en .
 
 :SimPL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Simple Public License 2.0"@en .
 
 :Sleepycat a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Sleepycat License"@en .
 
 :Talis a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Talis Community License"@en .
 
 :Unlicense a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Unlicense"@en .
 
 :VSL-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Vovida Software License 1.0"@en .
 
 :W3C a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "W3C License"@en .
 
 :WXwindows a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "wxWindows Library License"@en .
 
 :Watcom-1_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Sybase Open Watcom Public License 1.0"@en .
 
 :Xnet a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "X.Net License"@en .
 
 :ZPL-2_0 a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Zope Public License 2.0"@en .
 
 :Zlib a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "zlib/libpng license"@en .
 
 :contentLicenses a skos:Collection ;
@@ -438,51 +438,51 @@
   skos:member :geogratis .
 
 :dli-model-use a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Statistics Canada: Data Liberation Initiative (DLI) - Model Data Use Licence"@en .
 
 :geogratis a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Geogratis"@en .
 
 :hesa-withrights a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Higher Education Statistics Agency Copyright with data.gov.uk rights"@en .
 
 :localauth-withrights a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Local Authority Copyright with data.gov.uk rights"@en .
 
 :met-office-cp a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Met Office UK Climate Projections Licence Agreement"@en .
 
 :mitre a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "MITRE Collaborative Virtual Workspace License (CVW License)"@en .
 
 :notspecified a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "License Not Specified"@en .
 
 :other-at a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Other (Attribution)"@en .
 
 :other-closed a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Other (Not Open)"@en .
 
 :other-nc a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Other (Non-Commercial)"@en .
 
 :other-open a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Other (Open)"@en .
 
 :other-pd a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "Other (Public Domain)"@en .
 
 :softwareLicenses a skos:Collection ;
@@ -574,22 +574,22 @@
   skos:member :mitre .
 
 :ukclickusepsi a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "UK Click Use PSI"@en .
 
 :ukcrown a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "UK Crown Copyright"@en .
 
 :ukcrown-withrights a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "UK Crown Copyright with data.gov.uk rights"@en .
 
 :ukpsi a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/license> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/license> ;
   skos:prefLabel "UK PSI Public Sector Information"@en .
 
-<https://ontology.okp4.space/thesaurus/license> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/license> a skos:ConceptScheme ;
   rdfs:label "Open Source Licenses Thesaurus"@en ;
   dct:description "This thesaurus defines a controlled vocabulary referencing the (major) Open Source licenses."@en ;
   dct:title "Open Source licenses Thesaurus"@en ;

--- a/src/thesaurus/mediatype.ttl
+++ b/src/thesaurus/mediatype.ttl
@@ -1,6 +1,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/media-type/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/media-type/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix schema: <http://schema.org/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
@@ -218,7 +218,7 @@
 
 :application_andrew-inset a skos:Concept ;
   :hasMediaType "application/andrew-inset" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Andrew Toolkit -osio"@fi ;
   skos:prefLabel "Andrew Toolkit innsats"@nn ;
   skos:prefLabel "Andrew Toolkit inset"@cs ;
@@ -235,7 +235,7 @@
 
 :application_illustrator a skos:Concept ;
   :hasMediaType "application/illustrator" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Adobe Illustrator -asiakirja"@fi ;
   skos:prefLabel "Adobe Illustrator document"@en ;
   skos:prefLabel "Adobe Illustrator-Dokument"@de ;
@@ -246,7 +246,7 @@
 
 :application_mac-binhex40 a skos:Concept ;
   :hasMediaType "application/mac-binhex40" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil BinHex-amgodwyd Macintosh"@cy ;
   skos:prefLabel "Macintosh BinHe-kodet arkiv"@no ;
   skos:prefLabel "Macintosh BinHex -koodattu tiedosto"@fi ;
@@ -265,7 +265,7 @@
 
 :application_octet-stream a skos:Concept ;
   :hasMediaType "application/octet-stream" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "inconnu"@fr ;
   skos:prefLabel "tuntematon"@fi ;
   skos:prefLabel "ukjent"@no ;
@@ -275,7 +275,7 @@
 
 :application_oda a skos:Concept ;
   :hasMediaType "application/oda" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen ODA"@cy ;
   skos:prefLabel "Dokument ODA"@cs ;
   skos:prefLabel "ODA document"@en ;
@@ -294,7 +294,7 @@
 
 :application_ogg a skos:Concept ;
   :hasMediaType "application/ogg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ogg Vorbis -ääni"@fi ;
   skos:prefLabel "Ogg Vorbis audio faylı"@az ;
   skos:prefLabel "Ogg Vorbis audio"@en ;
@@ -313,7 +313,7 @@
 
 :application_pdf a skos:Concept ;
   :hasMediaType "application/pdf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Document PDF"@fr ;
   skos:prefLabel "Dogfen PDF"@cy ;
   skos:prefLabel "PDF document"@en ;
@@ -327,7 +327,7 @@
 
 :application_pgp a skos:Concept ;
   :hasMediaType "application/pgp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Neges PGP"@cy ;
   skos:prefLabel "PGP bericht"@nl ;
   skos:prefLabel "PGP ismarışı"@az ;
@@ -346,7 +346,7 @@
 
 :application_pgp-encrypted a skos:Concept ;
   :hasMediaType "application/pgp-encrypted" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "En-tête de message chiffré PGP/MIME"@fr ;
   skos:prefLabel "PGP/MIME-encrypted message header"@en ;
   skos:prefLabel "PGP/MIME-kryptert meldingshode"@no ;
@@ -355,7 +355,7 @@
 
 :application_pgp-keys a skos:Concept ;
   :hasMediaType "application/pgp-keys" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Allweddi PGP"@cy ;
   skos:prefLabel "Klíče PGP"@cs ;
   skos:prefLabel "PGP açarları"@az ;
@@ -374,7 +374,7 @@
 
 :application_pgp-signature a skos:Concept ;
   :hasMediaType "application/pgp-signature" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "detached OpenPGP signature"@en ;
   skos:prefLabel "erillinen OpenPGP-allekirjoitus"@fi ;
   skos:prefLabel "frakoblet OpenPGP-signatur"@no ;
@@ -383,7 +383,7 @@
 
 :application_pkcs7-mime a skos:Concept ;
   :hasMediaType "application/pkcs7-mime" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil S/MIME"@cy ;
   skos:prefLabel "S/MIME bestand"@nl ;
   skos:prefLabel "S/MIME faylı"@az ;
@@ -402,7 +402,7 @@
 
 :application_pkcs7-signature a skos:Concept ;
   :hasMediaType "application/pkcs7-signature" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "detached S/MIME signature"@en ;
   skos:prefLabel "erillinen S/MIME-allekirjoitus"@fi ;
   skos:prefLabel "frakoblet S/MIME-signatur"@no ;
@@ -411,7 +411,7 @@
 
 :application_postscript a skos:Concept ;
   :hasMediaType "application/postscript" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Document PostScript"@fr ;
   skos:prefLabel "PostScript document"@en ;
   skos:prefLabel "PostScript-Dokument"@de ;
@@ -423,7 +423,7 @@
 :application_rtf a skos:Concept ;
   :hasMediaType "application/rtf" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Testun Gyfoethog"@cy ;
   skos:prefLabel "RTF-asiakirja"@fi ;
   skos:prefLabel "RTF-fájl"@hu ;
@@ -442,7 +442,7 @@
 :application_smil a skos:Concept ;
   :hasMediaType "application/smil" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Gesynchroniseerde multimedia integratie taal"@nl ;
   skos:prefLabel "Iaith Integreiddio Aml-Gyfrwng wedi ei Chydweddu"@cy ;
   skos:prefLabel "SMIL-Dokument"@de ;
@@ -459,7 +459,7 @@
 
 :application_vndcorel-draw a skos:Concept ;
   :hasMediaType "application/vnd.corel-draw" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Corel Draw -piirros"@fi ;
   skos:prefLabel "Corel Draw drawing"@en ;
   skos:prefLabel "Corel Draw tekening"@nl ;
@@ -478,7 +478,7 @@
 
 :application_vndhp-hpgl a skos:Concept ;
   :hasMediaType "application/vnd.hp-hpgl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "HP Graphics Language (piirturi)"@fi ;
   skos:prefLabel "HP Graphics Language (plotter)"@en ;
   skos:prefLabel "HP-Grafiksprache (Plotter)"@de ;
@@ -486,7 +486,7 @@
 
 :application_vndhp-pcl a skos:Concept ;
   :hasMediaType "application/vnd.hp-pcl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fichier du langage de contrôle de l'imprimante HP"@fr ;
   skos:prefLabel "HP Printer Control Language -tiedosto"@fi ;
   skos:prefLabel "HP Printer Control Language file"@en ;
@@ -494,7 +494,7 @@
 
 :application_vndlotus-1-2-3 a skos:Concept ;
   :hasMediaType "application/vnd.lotus-1-2-3" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Lotus 1-2-3 -taulukko"@fi ;
   skos:prefLabel "Lotus 1-2-3 hesab cədvəli"@az ;
   skos:prefLabel "Lotus 1-2-3 regneark"@no ;
@@ -514,7 +514,7 @@
 :application_vndms-excel a skos:Concept ;
   :hasMediaType "application/vnd.ms-excel" ;
   skos:exactMatch :application_msexcel ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Feuille de calcul Microsoft Excel"@fr ;
   skos:prefLabel "Microsoft Excel -taulukko"@fi ;
   skos:prefLabel "Microsoft Excel hesab cədvəli"@az ;
@@ -533,7 +533,7 @@
 
 :application_vndms-powerpoint a skos:Concept ;
   :hasMediaType "application/vnd.ms-powerpoint" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft PowerPoint -esitys"@fi ;
   skos:prefLabel "Microsoft PowerPoint presentation"@en ;
   skos:prefLabel "Microsoft PowerPoint-Präsentation"@de ;
@@ -544,7 +544,7 @@
 :application_vndms-word a skos:Concept ;
   :hasMediaType "application/vnd.ms-word" ;
   skos:exactMatch :application_msword ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Document Microsoft Word"@fr ;
   skos:prefLabel "Dogfen Miscrosoft Word"@cy ;
   skos:prefLabel "Dokument Microsoft Word"@cs ;
@@ -563,14 +563,14 @@
 
 :application_vndpalm a skos:Concept ;
   :hasMediaType "application/vnd.palm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Palmpilot database/document"@en ;
   skos:prefLabel "Palmpilot-Datenbank/-Dokument"@de ;
   skos:prefLabel "Palmpilot-tietokanta tai -asiakirja"@fi .
 
 :application_vndrn-realmedia a skos:Concept ;
   :hasMediaType "application/vnd.rn-realmedia" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Document RealAudio/Video"@fr ;
   skos:prefLabel "Dogfen RealAudio neu RealVideo"@cy ;
   skos:prefLabel "Dokument RealAudio/Video"@cs ;
@@ -589,7 +589,7 @@
 
 :application_vndshp a skos:Concept ;
   :hasMediaType "application/vndshp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Shapefile"@de ;
   skos:prefLabel "Shapefile"@en ;
   skos:prefLabel "Shapefile"@es ;
@@ -602,7 +602,7 @@
 
 :application_vndstardivisioncalc a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.calc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Feuille de calcul StarCalc"@fr ;
   skos:prefLabel "StarCalc hesab cədvəli"@az ;
   skos:prefLabel "StarCalc spreadsheet"@en ;
@@ -621,7 +621,7 @@
 
 :application_vndstardivisionchart a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.chart" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Graf StarChart"@cs ;
   skos:prefLabel "Siart StarChart"@cy ;
   skos:prefLabel "StarCalc 표"@ko ;
@@ -640,7 +640,7 @@
 
 :application_vndstardivisiondraw a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.draw" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Darlun StarDraw"@cy ;
   skos:prefLabel "Kresba StarDraw"@cs ;
   skos:prefLabel "StarCalc 드로잉"@ko ;
@@ -659,7 +659,7 @@
 
 :application_vndstardivisionimpress a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.impress" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Cyflwyniad StarImpress"@cy ;
   skos:prefLabel "Prezentace StarImpress"@cs ;
   skos:prefLabel "StarImpress presentatie"@nl ;
@@ -678,7 +678,7 @@
 
 :application_vndstardivisionmail a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.mail" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "StarMail email"@en ;
   skos:prefLabel "StarMail-E-Mail"@de ;
   skos:prefLabel "StarMail-melding"@no ;
@@ -686,7 +686,7 @@
 
 :application_vndstardivisionmath a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.math" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "StarMath formula"@en ;
   skos:prefLabel "StarMath-Formel"@de ;
   skos:prefLabel "StarMath-asiakirja"@fi ;
@@ -694,7 +694,7 @@
 
 :application_vndstardivisionwriter a skos:Concept ;
   :hasMediaType "application/vnd.stardivision.writer" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen StarWriter"@cy ;
   skos:prefLabel "Dokument StarWriter"@cs ;
   skos:prefLabel "StarWriter document"@en ;
@@ -713,7 +713,7 @@
 
 :application_vndsunxmlcalc a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.calc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Feuille de calcul OpenOffice.org Calc"@fr ;
   skos:prefLabel "OpenOffice.org Calc -taulukko"@fi ;
   skos:prefLabel "OpenOffice.org Calc spreadsheet"@en ;
@@ -723,7 +723,7 @@
 
 :application_vndsunxmlcalctemplate a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.calc.template" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Modèle de feuille de calcul OpenOffice.org Calc"@fr ;
   skos:prefLabel "OpenOffice.org Calc -taulukkomalli"@fi ;
   skos:prefLabel "OpenOffice.org Calc spreadsheet template"@en ;
@@ -733,7 +733,7 @@
 
 :application_vndsunxmldraw a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.draw" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Draw dessin"@fr ;
   skos:prefLabel "OpenOffice.org Draw drawing"@en ;
   skos:prefLabel "OpenOffice.org Draw-Zeichnung"@de ;
@@ -742,7 +742,7 @@
 
 :application_vndsunxmldrawtemplate a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.draw.template" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Draw -piirrosmalli"@fi ;
   skos:prefLabel "OpenOffice.org Draw drawing template"@en ;
   skos:prefLabel "OpenOffice.org Draw modèle de dessin"@fr ;
@@ -751,7 +751,7 @@
 
 :application_vndsunxmlimpress a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.impress" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Impress -esitys"@fi ;
   skos:prefLabel "OpenOffice.org Impress presentation"@en ;
   skos:prefLabel "OpenOffice.org Impress-presentasjon"@no ;
@@ -762,7 +762,7 @@
 
 :application_vndsunxmlimpresstemplate a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.impress.template" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Modèle de présentation d'OpenOffice.org Impress"@fr ;
   skos:prefLabel "OpenOffice.org Impress -esitysmalli"@fi ;
   skos:prefLabel "OpenOffice.org Impress presentation template"@en ;
@@ -773,7 +773,7 @@
 
 :application_vndsunxmlmath a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.math" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "OpenOffice.org Formule mathématique"@fr ;
   skos:prefLabel "OpenOffice.org Math formula"@en ;
   skos:prefLabel "OpenOffice.org Math-asiakirja"@fi ;
@@ -782,7 +782,7 @@
 
 :application_vndsunxmlwriter a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.writer" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Document OpenOffice.org Writer"@fr ;
   skos:prefLabel "OpenOffice.org Writer -asiakirja"@fi ;
   skos:prefLabel "OpenOffice.org Writer document"@en ;
@@ -793,7 +793,7 @@
 
 :application_vndsunxmlwriterglobal a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.writer.global" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Globalt OpenOffice.org Writer-dokument"@no ;
   skos:prefLabel "OpenOffice.org Writer global document"@en ;
   skos:prefLabel "OpenOffice.org Writer-globaldokument"@sv ;
@@ -802,7 +802,7 @@
 
 :application_vndsunxmlwritertemplate a skos:Concept ;
   :hasMediaType "application/vnd.sun.xml.writer.template" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Modèle de Document OpenOffice.org Writer"@fr ;
   skos:prefLabel "OpenOffice.org Writer -asiakirjamalli"@fi ;
   skos:prefLabel "OpenOffice.org Writer document template"@en ;
@@ -814,7 +814,7 @@
   :hasMediaType "application/vnd.wordperfect" ;
   skos:exactMatch :application_wordperfect ;
   skos:exactMatch :application_x-wordperfect ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen WordPerfect"@cy ;
   skos:prefLabel "Dokument WordPerfect"@cs ;
   skos:prefLabel "WordPerfect document"@en ;
@@ -833,7 +833,7 @@
 
 :application_x-abiword a skos:Concept ;
   :hasMediaType "application/x-abiword" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AbiWord document"@en ;
   skos:prefLabel "AbiWord-Dokument"@de ;
   skos:prefLabel "AbiWord-asiakirja"@fi ;
@@ -843,7 +843,7 @@
 
 :application_x-amipro a skos:Concept ;
   :hasMediaType "application/x-amipro" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Lotus AmiPro"@cy ;
   skos:prefLabel "Dokument Lotus AmiPro"@cs ;
   skos:prefLabel "Lotus AmiPro -asiakirja"@fi ;
@@ -862,7 +862,7 @@
 
 :application_x-applix-spreadsheet a skos:Concept ;
   :hasMediaType "application/x-applix-spreadsheet" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Applix Spreadsheets -taulukko"@fi ;
   skos:prefLabel "Applix Spreadsheets spreadsheet"@en ;
   skos:prefLabel "Applix Spreadsheets-Tabellendokument"@de ;
@@ -871,7 +871,7 @@
 
 :application_x-applix-word a skos:Concept ;
   :hasMediaType "application/x-applix-word" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Applix Word 문서"@ko ;
   skos:prefLabel "Applix Words -asiakirja"@fi ;
   skos:prefLabel "Applix Words document"@en ;
@@ -890,11 +890,11 @@
 
 :application_x-arc a skos:Concept ;
   :hasMediaType "application/x-arc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-archive a skos:Concept ;
   :hasMediaType "application/x-archive" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AR archive"@en ;
   skos:prefLabel "AR-Archiv"@de ;
   skos:prefLabel "AR-arkisto"@fi ;
@@ -902,7 +902,7 @@
 
 :application_x-arj a skos:Concept ;
   :hasMediaType "application/x-arj" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "ARJ archief"@nl ;
   skos:prefLabel "ARJ archive"@en ;
   skos:prefLabel "ARJ arxivi"@az ;
@@ -921,7 +921,7 @@
 :application_x-asp a skos:Concept ;
   :hasMediaType "application/x-asp" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "ASP (active server page)"@hu ;
   skos:prefLabel "Active server page"@cs ;
   skos:prefLabel "Active-Server-Page-Seite"@de ;
@@ -940,7 +940,7 @@
 :application_x-awk a skos:Concept ;
   :hasMediaType "application/x-awk" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AWK script"@en ;
   skos:prefLabel "AWK script"@nl ;
   skos:prefLabel "AWK skripti"@az ;
@@ -958,7 +958,7 @@
 
 :application_x-bcpio a skos:Concept ;
   :hasMediaType "application/x-bcpio" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "BCPIO document"@en ;
   skos:prefLabel "BCPIO document"@nl ;
   skos:prefLabel "BCPIO sənədi"@az ;
@@ -977,7 +977,7 @@
 
 :application_x-bittorrent a skos:Concept ;
   :hasMediaType "application/x-bittorrent" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "BitTorrent seed faylı"@az ;
   skos:prefLabel "BitTorrent seed file"@en ;
   skos:prefLabel "BitTorrent zaad-bestand"@nl ;
@@ -996,7 +996,7 @@
 
 :application_x-blender a skos:Concept ;
   :hasMediaType "application/x-blender" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Blender scene"@en ;
   skos:prefLabel "Blender-Szene"@de ;
   skos:prefLabel "Blender-scene"@no ;
@@ -1004,7 +1004,7 @@
 
 :application_x-bzip a skos:Concept ;
   :hasMediaType "application/x-bzip" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "bzip archive"@en ;
   skos:prefLabel "bzip-Archiv"@de ;
   skos:prefLabel "bzip-arkisto"@fi ;
@@ -1012,7 +1012,7 @@
 
 :application_x-bzip-compressed-tar a skos:Concept ;
   :hasMediaType "application/x-bzip-compressed-tar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "tar archive (bzip-compressed)"@en ;
   skos:prefLabel "tar-Archiv (bzip-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (bzip-pakattu)"@fi ;
@@ -1020,7 +1020,7 @@
 
 :application_x-cd-image a skos:Concept ;
   :hasMediaType "application/x-cd-image" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CD-Roh-Image"@de ;
   skos:prefLabel "raaka CD-vedos"@fi ;
   skos:prefLabel "raw CD image"@en ;
@@ -1029,7 +1029,7 @@
 :application_x-cgi a skos:Concept ;
   :hasMediaType "application/x-cgi" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CGI script"@en ;
   skos:prefLabel "CGI-Skript"@de ;
   skos:prefLabel "CGI-skript"@no ;
@@ -1037,7 +1037,7 @@
 
 :application_x-chess-pgn a skos:Concept ;
   :hasMediaType "application/x-chess-pgn" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Gêm wyddbwyll PGN"@cy ;
   skos:prefLabel "PGN chess game"@en ;
   skos:prefLabel "PGN schaakspel"@nl ;
@@ -1056,7 +1056,7 @@
 
 :application_x-class-file a skos:Concept ;
   :hasMediaType "application/x-class-file" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Côd beit Java"@cy ;
   skos:prefLabel "Java bajtový kód"@cs ;
   skos:prefLabel "Java bayt kodu"@az ;
@@ -1075,7 +1075,7 @@
 
 :application_x-compress a skos:Concept ;
   :hasMediaType "application/x-compress" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "UNIX-compressed file"@en ;
   skos:prefLabel "UNIX-komprimert fil"@no ;
   skos:prefLabel "UNIX-komprimierte Datei"@de ;
@@ -1083,7 +1083,7 @@
 
 :application_x-compressed-tar a skos:Concept ;
   :hasMediaType "application/x-compressed-tar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "tar archive (gzip-compressed)"@en ;
   skos:prefLabel "tar-Archiv (gzip-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (gzip-pakattu)"@fi ;
@@ -1091,14 +1091,14 @@
 
 :application_x-core a skos:Concept ;
   :hasMediaType "application/x-core" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Daten zu Programmabsturz"@de ;
   skos:prefLabel "ohjelman kaatumistiedot"@fi ;
   skos:prefLabel "program crash data"@en .
 
 :application_x-cpio a skos:Concept ;
   :hasMediaType "application/x-cpio" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO"@cy ;
   skos:prefLabel "Archiv CPIO"@cs ;
   skos:prefLabel "CPIO archief"@nl ;
@@ -1116,7 +1116,7 @@
 
 :application_x-cpio-compressed a skos:Concept ;
   :hasMediaType "application/x-cpio-compressed" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO (gywasgwyd drwy gzip)"@cy ;
   skos:prefLabel "Archiv CPIO (komprimovaný gzip)"@cs ;
   skos:prefLabel "CPIO archief (gzip-ingepakt)"@nl ;
@@ -1135,7 +1135,7 @@
 :application_x-csh a skos:Concept ;
   :hasMediaType "application/x-csh" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "C qabıq skripti"@az ;
   skos:prefLabel "C shell script"@en ;
   skos:prefLabel "C shell script"@nl ;
@@ -1154,7 +1154,7 @@
 
 :application_x-dbase a skos:Concept ;
   :hasMediaType "application/x-dbase" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen dBASE"@cy ;
   skos:prefLabel "Dokument dBASE"@cs ;
   skos:prefLabel "dBASE document"@en ;
@@ -1173,11 +1173,11 @@
 
 :application_x-dbm a skos:Concept ;
   :hasMediaType "application/x-dbm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-dc-rom a skos:Concept ;
   :hasMediaType "application/x-dc-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dreamcast ROM"@el ;
   skos:prefLabel "Dreamcast ROM"@en ;
   skos:prefLabel "Dreamcast-ROM"@de ;
@@ -1186,7 +1186,7 @@
 
 :application_x-deb a skos:Concept ;
   :hasMediaType "application/x-deb" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Balíček Debianu"@cs ;
   skos:prefLabel "Debian package"@en ;
   skos:prefLabel "Debian paketi"@az ;
@@ -1205,7 +1205,7 @@
 
 :application_x-designer a skos:Concept ;
   :hasMediaType "application/x-designer" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "QT Designer-Datei"@de ;
   skos:prefLabel "Qt Designer -tiedosto"@fi ;
   skos:prefLabel "Qt Designer file"@en ;
@@ -1217,7 +1217,7 @@
   :hasMediaType "application/x-desktop" ;
   skos:broader :text_plain ;
   skos:exactMatch :application_x-gnome-app-info ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Desktop-Konfigurationsdatei"@de ;
   skos:prefLabel "desktop configuration file"@en ;
   skos:prefLabel "konfigurasjonsfil for skrivebordet"@no ;
@@ -1225,7 +1225,7 @@
 
 :application_x-dia-diagram a skos:Concept ;
   :hasMediaType "application/x-dia-diagram" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dia diagram"@en ;
   skos:prefLabel "Dia diagram"@nl ;
   skos:prefLabel "Dia diagram"@nn ;
@@ -1244,7 +1244,7 @@
 
 :application_x-dvi a skos:Concept ;
   :hasMediaType "application/x-dvi" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "TeX DVI -asiakirja"@fi ;
   skos:prefLabel "TeX DVI document"@en ;
   skos:prefLabel "TeX DVI-dokument"@no ;
@@ -1253,7 +1253,7 @@
 
 :application_x-e-theme a skos:Concept ;
   :hasMediaType "application/x-e-theme" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Enlightenment tema"@no ;
   skos:prefLabel "Enlightenment thema"@nl ;
   skos:prefLabel "Enlightenment theme"@en ;
@@ -1272,7 +1272,7 @@
 
 :application_x-egon a skos:Concept ;
   :hasMediaType "application/x-egon" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Egon Animator -animaatio"@fi ;
   skos:prefLabel "Egon Animator animation"@en ;
   skos:prefLabel "Egon Animator-Animation"@de ;
@@ -1280,7 +1280,7 @@
 
 :application_x-executable a skos:Concept ;
   :hasMediaType "application/x-executable" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Programm"@de ;
   skos:prefLabel "executable"@en ;
   skos:prefLabel "kjørbar"@no ;
@@ -1290,7 +1290,7 @@
 
 :application_x-font-afm a skos:Concept ;
   :hasMediaType "application/x-font-afm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Adobe font metrics"@en ;
   skos:prefLabel "Adobe lettertype-metrieken"@nl ;
   skos:prefLabel "Adobe skrifttypefil"@no ;
@@ -1308,7 +1308,7 @@
 
 :application_x-font-bdf a skos:Concept ;
   :hasMediaType "application/x-font-bdf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "BDF font"@en ;
   skos:prefLabel "BDF lettertype"@nl ;
   skos:prefLabel "BDF yazı növü"@az ;
@@ -1327,7 +1327,7 @@
 
 :application_x-font-dos a skos:Concept ;
   :hasMediaType "application/x-font-dos" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DOS font"@en ;
   skos:prefLabel "DOS lettertype"@nl ;
   skos:prefLabel "DOS yazı növü"@az ;
@@ -1346,7 +1346,7 @@
 
 :application_x-font-framemaker a skos:Concept ;
   :hasMediaType "application/x-font-framemaker" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Adobe FrameMaker -kirjasin"@fi ;
   skos:prefLabel "Adobe FrameMaker font"@en ;
   skos:prefLabel "Adobe FrameMaker lettertype"@nl ;
@@ -1365,7 +1365,7 @@
 
 :application_x-font-libgrx a skos:Concept ;
   :hasMediaType "application/x-font-libgrx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont LIBGRX"@cy ;
   skos:prefLabel "LIBGRX font"@en ;
   skos:prefLabel "LIBGRX lettertype"@nl ;
@@ -1384,7 +1384,7 @@
 
 :application_x-font-linux-psf a skos:Concept ;
   :hasMediaType "application/x-font-linux-psf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont Linux PSF"@cy ;
   skos:prefLabel "Linux PSF -konsolikirjasin"@fi ;
   skos:prefLabel "Linux PSF console font"@en ;
@@ -1403,7 +1403,7 @@
 
 :application_x-font-otf a skos:Concept ;
   :hasMediaType "application/x-font-otf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont OpenType"@cy ;
   skos:prefLabel "OpenType font"@en ;
   skos:prefLabel "OpenType lettertype"@nl ;
@@ -1422,7 +1422,7 @@
 
 :application_x-font-pcf a skos:Concept ;
   :hasMediaType "application/x-font-pcf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont PCF"@cy ;
   skos:prefLabel "PCF font"@en ;
   skos:prefLabel "PCF lettertype"@nl ;
@@ -1441,7 +1441,7 @@
 
 :application_x-font-speedo a skos:Concept ;
   :hasMediaType "application/x-font-speedo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont Speedo"@cy ;
   skos:prefLabel "Písmo Speedo"@cs ;
   skos:prefLabel "Speedo font"@en ;
@@ -1460,7 +1460,7 @@
 
 :application_x-font-sunos-news a skos:Concept ;
   :hasMediaType "application/x-font-sunos-news" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont SunOS News"@cy ;
   skos:prefLabel "Písmo SunOS News"@cs ;
   skos:prefLabel "SunOS NEWS-skrifttype"@nn ;
@@ -1479,7 +1479,7 @@
 
 :application_x-font-tex a skos:Concept ;
   :hasMediaType "application/x-font-tex" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont TeX"@cy ;
   skos:prefLabel "Písmo TeX"@cs ;
   skos:prefLabel "TeX font"@en ;
@@ -1498,7 +1498,7 @@
 
 :application_x-font-tex-tfm a skos:Concept ;
   :hasMediaType "application/x-font-tex-tfm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Metrigau Ffont TeX"@cy ;
   skos:prefLabel "Metrika písma TeX"@cs ;
   skos:prefLabel "TeX font metrics"@en ;
@@ -1516,7 +1516,7 @@
 
 :application_x-font-ttf a skos:Concept ;
   :hasMediaType "application/x-font-ttf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "TrueType font"@en ;
   skos:prefLabel "TrueType-Schrift"@de ;
   skos:prefLabel "TrueType-skrift"@no ;
@@ -1525,7 +1525,7 @@
 
 :application_x-font-type1 a skos:Concept ;
   :hasMediaType "application/x-font-type1" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Schrift"@de ;
   skos:prefLabel "font"@en ;
   skos:prefLabel "kirjasin"@fi ;
@@ -1535,7 +1535,7 @@
 
 :application_x-font-vfont a skos:Concept ;
   :hasMediaType "application/x-font-vfont" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffont V"@cy ;
   skos:prefLabel "Písmo V"@cs ;
   skos:prefLabel "V font"@en ;
@@ -1554,11 +1554,11 @@
 
 :application_x-frame a skos:Concept ;
   :hasMediaType "application/x-frame" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-gameboy-rom a skos:Concept ;
   :hasMediaType "application/x-gameboy-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Game Boy -ROM"@fi ;
   skos:prefLabel "Game Boy ROM"@el ;
   skos:prefLabel "Game Boy ROM"@en ;
@@ -1567,11 +1567,11 @@
 
 :application_x-gdbm a skos:Concept ;
   :hasMediaType "application/x-gdbm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-genesis-rom a skos:Concept ;
   :hasMediaType "application/x-genesis-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Genesis ROM"@el ;
   skos:prefLabel "Genesis ROM"@en ;
   skos:prefLabel "Genesis-ROM"@de ;
@@ -1580,7 +1580,7 @@
 
 :application_x-gettext-translation a skos:Concept ;
   :hasMediaType "application/x-gettext-translation" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "käännetyt viestit (koneluettava)"@fi ;
   skos:prefLabel "oversatte meldinger (maskinlesbar)"@no ;
   skos:prefLabel "translated messages (machine-readable)"@en ;
@@ -1589,7 +1589,7 @@
 :application_x-glade a skos:Concept ;
   :hasMediaType "application/x-glade" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Glade layihəsi"@az ;
   skos:prefLabel "Glade project"@en ;
   skos:prefLabel "Glade project"@nl ;
@@ -1607,7 +1607,7 @@
 
 :application_x-gmc-link a skos:Concept ;
   :hasMediaType "application/x-gmc-link" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Cyswllt GMC"@cy ;
   skos:prefLabel "GMC koppeling"@nl ;
   skos:prefLabel "GMC körpüsü"@az ;
@@ -1626,7 +1626,7 @@
 
 :application_x-gnucash a skos:Concept ;
   :hasMediaType "application/x-gnucash" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "GnuCash spreadsheet"@en ;
   skos:prefLabel "GnuCash-Tabellendokument"@de ;
   skos:prefLabel "GnuCash-regneark"@no ;
@@ -1635,7 +1635,7 @@
 
 :application_x-gnumeric a skos:Concept ;
   :hasMediaType "application/x-gnumeric" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Gnumeric spreadsheet"@en ;
   skos:prefLabel "Gnumeric-Tabellendokument"@de ;
   skos:prefLabel "Gnumeric-kalkylblad"@sv ;
@@ -1645,14 +1645,14 @@
 
 :application_x-graphite a skos:Concept ;
   :hasMediaType "application/x-graphite" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Graphite scientific graph"@en ;
   skos:prefLabel "Graphite-graafi"@fi ;
   skos:prefLabel "wissenschaftlicher Graphite-Graph"@de .
 
 :application_x-gtar a skos:Concept ;
   :hasMediaType "application/x-gtar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archiv gtar"@cs ;
   skos:prefLabel "archif gtar"@cy ;
   skos:prefLabel "archive gtar"@fr ;
@@ -1670,7 +1670,7 @@
 
 :application_x-gtktalog a skos:Concept ;
   :hasMediaType "application/x-gtktalog" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "GTKtalog catalog"@en ;
   skos:prefLabel "GTKtalog-Katalog"@de ;
   skos:prefLabel "GTKtalog-katalog"@no ;
@@ -1678,7 +1678,7 @@
 
 :application_x-gzip a skos:Concept ;
   :hasMediaType "application/x-gzip" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "gzip archive"@en ;
   skos:prefLabel "gzip-Archiv"@de ;
   skos:prefLabel "gzip-arkisto"@fi ;
@@ -1687,7 +1687,7 @@
 
 :application_x-gzpostscript a skos:Concept ;
   :hasMediaType "application/x-gzpostscript" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "PostScript document (gzip-compressed)"@en ;
   skos:prefLabel "PostScript-Dokument (gzip-komprimiert)"@de ;
   skos:prefLabel "PostScript-asiakirja (gzip-pakattu)"@fi ;
@@ -1696,7 +1696,7 @@
 
 :application_x-hdf a skos:Concept ;
   :hasMediaType "application/x-hdf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen HDF"@cy ;
   skos:prefLabel "Dokument HDF"@cs ;
   skos:prefLabel "HDF document"@en ;
@@ -1715,7 +1715,7 @@
 
 :application_x-ipod-firmware a skos:Concept ;
   :hasMediaType "application/x-ipod-firmware" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "iPod firmware"@en ;
   skos:prefLabel "iPod-Firmware"@de ;
   skos:prefLabel "iPod-firmware"@no ;
@@ -1723,7 +1723,7 @@
 
 :application_x-jar a skos:Concept ;
   :hasMediaType "application/x-jar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Java archive"@en ;
   skos:prefLabel "Java-Archiv"@de ;
   skos:prefLabel "Java-arkisto"@fi ;
@@ -1732,7 +1732,7 @@
 
 :application_x-java a skos:Concept ;
   :hasMediaType "application/x-java" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Java class"@en ;
   skos:prefLabel "Java-Klasse"@de ;
   skos:prefLabel "Java-klass"@sv ;
@@ -1742,14 +1742,14 @@
 :application_x-javascript a skos:Concept ;
   :hasMediaType "application/x-javascript" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Javascript program"@en ;
   skos:prefLabel "Javascript-Programm"@de ;
   skos:prefLabel "Πρόγραμμα Javascript"@el .
 
 :application_x-jbuilder-project a skos:Concept ;
   :hasMediaType "application/x-jbuilder-project" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "JBuilder project"@en ;
   skos:prefLabel "JBuilder-Projekt"@de ;
   skos:prefLabel "JBuilder-projekti"@fi ;
@@ -1757,7 +1757,7 @@
 
 :application_x-karbon a skos:Concept ;
   :hasMediaType "application/x-karbon" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Karbon14 drawing"@en ;
   skos:prefLabel "Karbon14-Zeichnung"@de ;
   skos:prefLabel "Karbon14-piirros"@fi ;
@@ -1765,7 +1765,7 @@
 
 :application_x-kchart a skos:Concept ;
   :hasMediaType "application/x-kchart" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KChart chart"@en ;
   skos:prefLabel "KChart-Diagramm"@de ;
   skos:prefLabel "KChart-graf"@no ;
@@ -1773,7 +1773,7 @@
 
 :application_x-kformula a skos:Concept ;
   :hasMediaType "application/x-kformula" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KFormula formula"@en ;
   skos:prefLabel "KFormula-Formel"@de ;
   skos:prefLabel "KFormula-formel"@no ;
@@ -1781,7 +1781,7 @@
 
 :application_x-killustrator a skos:Concept ;
   :hasMediaType "application/x-killustrator" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KIllustrator drawing"@en ;
   skos:prefLabel "KIllustrator-Zeichnung"@de ;
   skos:prefLabel "KIllustrator-piirros"@fi ;
@@ -1790,7 +1790,7 @@
 
 :application_x-kivio a skos:Concept ;
   :hasMediaType "application/x-kivio" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Kivio flowchart"@en ;
   skos:prefLabel "Kivio-Flussdiagramm"@de ;
   skos:prefLabel "Kivio-flytdiagram"@no ;
@@ -1798,7 +1798,7 @@
 
 :application_x-kontour a skos:Concept ;
   :hasMediaType "application/x-kontour" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Kontour drawing"@en ;
   skos:prefLabel "Kontour-Zeichnung"@de ;
   skos:prefLabel "Kontour-piirros"@fi ;
@@ -1806,14 +1806,14 @@
 
 :application_x-kpovmodeler a skos:Concept ;
   :hasMediaType "application/x-kpovmodeler" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KPovModeler scene"@en ;
   skos:prefLabel "KPovModeler-Szene"@de ;
   skos:prefLabel "KPovModeler-tiedosto"@fi .
 
 :application_x-kpresenter a skos:Concept ;
   :hasMediaType "application/x-kpresenter" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KPresenter presentation"@en ;
   skos:prefLabel "KPresenter-Präsentation"@de ;
   skos:prefLabel "KPresenter-esitys"@fi ;
@@ -1823,7 +1823,7 @@
 
 :application_x-krita a skos:Concept ;
   :hasMediaType "application/x-krita" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Krita document"@en ;
   skos:prefLabel "Krita-Dokument"@de ;
   skos:prefLabel "Krita-asiakirja"@fi ;
@@ -1832,7 +1832,7 @@
 
 :application_x-kspread a skos:Concept ;
   :hasMediaType "application/x-kspread" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KSpread spreadsheet"@en ;
   skos:prefLabel "KSpread-Tabellendokument"@de ;
   skos:prefLabel "KSpread-regneark"@no ;
@@ -1841,7 +1841,7 @@
 
 :application_x-kspread-crypt a skos:Concept ;
   :hasMediaType "application/x-kspread-crypt" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KSpread spreadsheet (encrypted)"@en ;
   skos:prefLabel "KSpread-Tabellendokument (verschlüsselt)"@de ;
   skos:prefLabel "KSpread-regneark (kryptert)"@no ;
@@ -1849,11 +1849,11 @@
 
 :application_x-ksysv-package a skos:Concept ;
   :hasMediaType "application/x-ksysv-package" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-kugar a skos:Concept ;
   :hasMediaType "application/x-kugar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Kugar document"@en ;
   skos:prefLabel "Kugar-Dokument"@de ;
   skos:prefLabel "Kugar-asiakirja"@fi ;
@@ -1862,7 +1862,7 @@
 
 :application_x-kword a skos:Concept ;
   :hasMediaType "application/x-kword" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen KWord"@cy ;
   skos:prefLabel "KWord document"@en ;
   skos:prefLabel "KWord документ"@sr ;
@@ -1874,7 +1874,7 @@
 
 :application_x-kword-crypt a skos:Concept ;
   :hasMediaType "application/x-kword-crypt" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "KWord document (encrypted)"@en ;
   skos:prefLabel "KWord-Dokument (verschlüsselt)"@de ;
   skos:prefLabel "KWord-asiakirja (salattu)"@fi ;
@@ -1882,7 +1882,7 @@
 
 :application_x-lha a skos:Concept ;
   :hasMediaType "application/x-lha" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif LHA"@cy ;
   skos:prefLabel "Archiv LHA"@cs ;
   skos:prefLabel "LHA archief"@nl ;
@@ -1900,7 +1900,7 @@
 
 :application_x-lhz a skos:Concept ;
   :hasMediaType "application/x-lhz" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "LHZ archive"@en ;
   skos:prefLabel "LHZ-Archiv"@de ;
   skos:prefLabel "LHZ-arkisto"@fi ;
@@ -1908,7 +1908,7 @@
 
 :application_x-linguist a skos:Concept ;
   :hasMediaType "application/x-linguist" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Nachrichtenkatalog"@de ;
   skos:prefLabel "meldingskatalog"@no ;
   skos:prefLabel "message catalog"@en ;
@@ -1916,7 +1916,7 @@
 
 :application_x-lyx a skos:Concept ;
   :hasMediaType "application/x-lyx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "LyX document"@en ;
   skos:prefLabel "LyX-Dokument"@de ;
   skos:prefLabel "LyX-asiakirja"@fi ;
@@ -1926,7 +1926,7 @@
 
 :application_x-lzop a skos:Concept ;
   :hasMediaType "application/x-lzop" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "LZO archive"@en ;
   skos:prefLabel "LZO-Archiv"@de ;
   skos:prefLabel "LZO-arkisto"@fi ;
@@ -1934,7 +1934,7 @@
 
 :application_x-macbinary a skos:Concept ;
   :hasMediaType "application/x-macbinary" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MacBinary-tiedosto"@fi ;
   skos:prefLabel "Macintosh MacBinary file"@en ;
   skos:prefLabel "Macintosh MacBinary-fil"@no ;
@@ -1943,7 +1943,7 @@
 :application_x-magicpoint a skos:Concept ;
   :hasMediaType "application/x-magicpoint" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Cyflwyniad MagicPoint"@cy ;
   skos:prefLabel "MagicPoint presentation"@en ;
   skos:prefLabel "MagicPoint презентација"@sr ;
@@ -1956,7 +1956,7 @@
 
 :application_x-matroska a skos:Concept ;
   :hasMediaType "application/x-matroska" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Matroska video"@en ;
   skos:prefLabel "Matroska-Video"@de ;
   skos:prefLabel "Matroska-film"@no ;
@@ -1965,7 +1965,7 @@
 
 :application_x-mif a skos:Concept ;
   :hasMediaType "application/x-mif" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "FrameMaker MIF document"@en ;
   skos:prefLabel "FrameMaker MIF-dokument"@no ;
   skos:prefLabel "FrameMaker-MIF-Dokument"@de ;
@@ -1974,7 +1974,7 @@
 
 :application_x-mozilla-bookmarks a skos:Concept ;
   :hasMediaType "application/x-mozilla-bookmarks" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Mozilla bookmarks"@en ;
   skos:prefLabel "Mozilla-Lesezeichen"@de ;
   skos:prefLabel "Mozilla-bokmerker"@no ;
@@ -1983,7 +1983,7 @@
 
 :application_x-ms-dos-executable a skos:Concept ;
   :hasMediaType "application/x-ms-dos-executable" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DOS/Windows executable"@en ;
   skos:prefLabel "DOS/Windows suoritettava ohjema"@fi ;
   skos:prefLabel "DOS/Windows-Programm"@de ;
@@ -1992,11 +1992,11 @@
 
 :application_x-mswinurl a skos:Concept ;
   :hasMediaType "application/x-mswinurl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-mswrite a skos:Concept ;
   :hasMediaType "application/x-mswrite" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Microsoft Write"@cy ;
   skos:prefLabel "Dokument Microsoft Write"@cs ;
   skos:prefLabel "Microsoft Write -asiakirja"@fi ;
@@ -2015,7 +2015,7 @@
 
 :application_x-msx-rom a skos:Concept ;
   :hasMediaType "application/x-msx-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MSX ROM"@el ;
   skos:prefLabel "MSX ROM"@en ;
   skos:prefLabel "MSX ром"@sr ;
@@ -2028,7 +2028,7 @@
 
 :application_x-n64-rom a skos:Concept ;
   :hasMediaType "application/x-n64-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Nintendo64 ROM"@el ;
   skos:prefLabel "Nintendo64 ROM"@en ;
   skos:prefLabel "Nintendo64-ROM"@de ;
@@ -2038,7 +2038,7 @@
 :application_x-nautilus-link a skos:Concept ;
   :hasMediaType "application/x-nautilus-link" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Cyswllt Nautilus"@cy ;
   skos:prefLabel "Nautilus koppeling"@nl ;
   skos:prefLabel "Nautilus körpüsü"@az ;
@@ -2057,7 +2057,7 @@
 
 :application_x-nes-rom a skos:Concept ;
   :hasMediaType "application/x-nes-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "NES ROM"@el ;
   skos:prefLabel "NES ROM"@en ;
   skos:prefLabel "NES ROM"@no ;
@@ -2070,7 +2070,7 @@
 
 :application_x-netcdf a skos:Concept ;
   :hasMediaType "application/x-netcdf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Unidata NetCDF document"@en ;
   skos:prefLabel "Unidata NetCDF-dokument"@no ;
   skos:prefLabel "Unidata netCDF -asiakirja"@fi ;
@@ -2079,7 +2079,7 @@
 :application_x-netscape-bookmarks a skos:Concept ;
   :hasMediaType "application/x-netscape-bookmarks" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Netscape bookmarks"@en ;
   skos:prefLabel "Netscape-Lesezeichen"@de ;
   skos:prefLabel "Netscape-bokmerker"@no ;
@@ -2088,7 +2088,7 @@
 
 :application_x-object a skos:Concept ;
   :hasMediaType "application/x-object" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Objekt-Code"@de ;
   skos:prefLabel "object code"@en ;
   skos:prefLabel "objektikoodi"@fi ;
@@ -2096,14 +2096,14 @@
 
 :application_x-ole-storage a skos:Concept ;
   :hasMediaType "application/x-ole-storage" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "OLE2 compound document storage"@en ;
   skos:prefLabel "OLE2-Verbunddokumentenspeicher"@de ;
   skos:prefLabel "OLE2-yhdisteasiakirja"@fi .
 
 :application_x-oleo a skos:Concept ;
   :hasMediaType "application/x-oleo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "GNU Oleo -taulukko"@fi ;
   skos:prefLabel "GNU Oleo regneark"@no ;
   skos:prefLabel "GNU Oleo spreadsheet"@en ;
@@ -2112,7 +2112,7 @@
 
 :application_x-palm-database a skos:Concept ;
   :hasMediaType "application/x-palm-database" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Cronfa Ddata Palm OS"@cy ;
   skos:prefLabel "Databáze Palm OS"@cs ;
   skos:prefLabel "Palm OS -tietokanta"@fi ;
@@ -2131,7 +2131,7 @@
 
 :application_x-pef-executable a skos:Concept ;
   :hasMediaType "application/x-pef-executable" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "PEF executable"@en ;
   skos:prefLabel "PEF suoritettava ohjelma"@fi ;
   skos:prefLabel "PEF-Programm"@de ;
@@ -2141,7 +2141,7 @@
 :application_x-perl a skos:Concept ;
   :hasMediaType "application/x-perl" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Perl script"@en ;
   skos:prefLabel "Perl skript"@nn ;
   skos:prefLabel "Perl skript"@no ;
@@ -2155,7 +2155,7 @@
 :application_x-php a skos:Concept ;
   :hasMediaType "application/x-php" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "PHP script"@en ;
   skos:prefLabel "PHP script"@nl ;
   skos:prefLabel "PHP skripti"@az ;
@@ -2174,7 +2174,7 @@
 
 :application_x-pkcs12 a skos:Concept ;
   :hasMediaType "application/x-pkcs12" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "PKCS#12 certificate bundle"@en ;
   skos:prefLabel "PKCS#12 sertifikathaug"@no ;
   skos:prefLabel "PKCS#12-Zertifikatspaket"@de ;
@@ -2183,7 +2183,7 @@
 :application_x-profile a skos:Concept ;
   :hasMediaType "application/x-profile" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Profiler-Ergebnisse"@de ;
   skos:prefLabel "Výsledky profileru"@cs ;
   skos:prefLabel "canlyniadau proffeilio"@cy ;
@@ -2201,7 +2201,7 @@
 
 :application_x-pw a skos:Concept ;
   :hasMediaType "application/x-pw" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Pathetic Writer -asiakirja"@fi ;
   skos:prefLabel "Pathetic Writer document"@en ;
   skos:prefLabel "Pathetic Writer-Dokument"@de ;
@@ -2210,7 +2210,7 @@
 :application_x-python a skos:Concept ;
   :hasMediaType "application/x-python" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Python script"@en ;
   skos:prefLabel "Python-Skript"@de ;
   skos:prefLabel "Python-skript"@no ;
@@ -2220,7 +2220,7 @@
 
 :application_x-python-bytecode a skos:Concept ;
   :hasMediaType "application/x-python-bytecode" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bajtový kód Python"@cs ;
   skos:prefLabel "Côd beit Python"@cy ;
   skos:prefLabel "Python bayt kodu"@az ;
@@ -2238,7 +2238,7 @@
 
 :application_x-quattropro a skos:Concept ;
   :hasMediaType "application/x-quattropro" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Quattro Pro -taulukko"@fi ;
   skos:prefLabel "Quattro Pro spreadsheet"@en ;
   skos:prefLabel "Quattro Pro-Tabellendokument"@de ;
@@ -2247,7 +2247,7 @@
 
 :application_x-qw a skos:Concept ;
   :hasMediaType "application/x-qw" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Quicken"@cy ;
   skos:prefLabel "Dokument Quicken"@cs ;
   skos:prefLabel "Quicken document"@en ;
@@ -2266,7 +2266,7 @@
 
 :application_x-rar a skos:Concept ;
   :hasMediaType "application/x-rar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif RAR"@cy ;
   skos:prefLabel "RAR archive"@en ;
   skos:prefLabel "RAR-Archiv"@de ;
@@ -2280,7 +2280,7 @@
 :application_x-reject a skos:Concept ;
   :hasMediaType "application/x-reject" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "abgelehnter Patch"@de ;
   skos:prefLabel "avvist patchfil"@no ;
   skos:prefLabel "hylättyjen muutosten tiedosto"@fi ;
@@ -2288,7 +2288,7 @@
 
 :application_x-rpm a skos:Concept ;
   :hasMediaType "application/x-rpm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "RPM package"@en ;
   skos:prefLabel "RPM-Paket"@de ;
   skos:prefLabel "RPM-paket"@sv ;
@@ -2299,7 +2299,7 @@
 :application_x-ruby a skos:Concept ;
   :hasMediaType "application/x-ruby" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ruby script"@en ;
   skos:prefLabel "Ruby-Skript"@de ;
   skos:prefLabel "Ruby-skript"@no ;
@@ -2308,12 +2308,12 @@
 
 :application_x-sc a skos:Concept ;
   :hasMediaType "application/x-sc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :application_x-shar a skos:Concept ;
   :hasMediaType "application/x-shar" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archiv shellu"@cs ;
   skos:prefLabel "Shell-Archiv"@de ;
   skos:prefLabel "archif plisgyn"@cy ;
@@ -2331,7 +2331,7 @@
 
 :application_x-shared-library-la a skos:Concept ;
   :hasMediaType "application/x-shared-library-la" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "delt bibliotek (la)"@no ;
   skos:prefLabel "gemeinsame Bibliothek (la)"@de ;
   skos:prefLabel "jaettu kirjasto (la)"@fi ;
@@ -2339,7 +2339,7 @@
 
 :application_x-sharedlib a skos:Concept ;
   :hasMediaType "application/x-sharedlib" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sdílená knihovna"@cs ;
   skos:prefLabel "bölüşülmüş kitabxana"@az ;
   skos:prefLabel "delat bibliotek"@sv ;
@@ -2358,7 +2358,7 @@
 :application_x-shellscript a skos:Concept ;
   :hasMediaType "application/x-shellscript" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Shell-Skript"@de ;
   skos:prefLabel "Skript shellu"@cs ;
   skos:prefLabel "komentojono"@fi ;
@@ -2376,7 +2376,7 @@
 
 :application_x-shockwave-flash a skos:Concept ;
   :hasMediaType "application/x-shockwave-flash" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Shockwave Flash -media"@fi ;
   skos:prefLabel "Shockwave Flash file"@en ;
   skos:prefLabel "Shockwave Flash-Datei"@de ;
@@ -2385,7 +2385,7 @@
 
 :application_x-siag a skos:Concept ;
   :hasMediaType "application/x-siag" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Siag spreadsheet"@en ;
   skos:prefLabel "Siag-kalkylblad"@sv ;
   skos:prefLabel "Siag-regneark"@no ;
@@ -2395,7 +2395,7 @@
 
 :application_x-slp a skos:Concept ;
   :hasMediaType "application/x-slp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Balíček Stampede"@cs ;
   skos:prefLabel "Pecyn Stampede"@cy ;
   skos:prefLabel "Stampede package"@en ;
@@ -2414,7 +2414,7 @@
 
 :application_x-sms-rom a skos:Concept ;
   :hasMediaType "application/x-sms-rom" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "SMS- tai Game Gear -ROM"@fi ;
   skos:prefLabel "SMS/Game Gear ROM"@en ;
   skos:prefLabel "SMS/Game Gear-ROM"@de ;
@@ -2422,7 +2422,7 @@
 
 :application_x-stuffit a skos:Concept ;
   :hasMediaType "application/x-stuffit" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif Macintosh StuffIt"@cy ;
   skos:prefLabel "Archiv Macintosh StuffIt"@cs ;
   skos:prefLabel "Macintosh StuffIt -arkisto"@fi ;
@@ -2440,7 +2440,7 @@
 
 :application_x-sv4cpio a skos:Concept ;
   :hasMediaType "application/x-sv4cpio" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archif CPIO SV4"@cy ;
   skos:prefLabel "Archiv SV4 CPIO"@cs ;
   skos:prefLabel "SV4 CPIO -arkisto"@fi ;
@@ -2458,7 +2458,7 @@
 
 :application_x-sv4crc a skos:Concept ;
   :hasMediaType "application/x-sv4crc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "(CRC를 가지는) SV4 CPIP 아카이브"@ko ;
   skos:prefLabel "Archif CPIP SV4 (efo CRC)"@cy ;
   skos:prefLabel "Archiv SV4 CPIP (s CRC)"@cs ;
@@ -2476,7 +2476,7 @@
 
 :application_x-tar a skos:Concept ;
   :hasMediaType "application/x-tar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "tar archive"@en ;
   skos:prefLabel "tar-Archiv"@de ;
   skos:prefLabel "tar-arkisto"@fi ;
@@ -2484,7 +2484,7 @@
 
 :application_x-tarz a skos:Concept ;
   :hasMediaType "application/x-tarz" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "tar archive (compressed)"@en ;
   skos:prefLabel "tar-Archiv (komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (pakattu)"@fi ;
@@ -2492,7 +2492,7 @@
 
 :application_x-tex-gf a skos:Concept ;
   :hasMediaType "application/x-tex-gf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "generic font file"@en ;
   skos:prefLabel "generische Schriftdatei"@de ;
   skos:prefLabel "vanlig skriftfil"@no ;
@@ -2500,7 +2500,7 @@
 
 :application_x-tex-pk a skos:Concept ;
   :hasMediaType "application/x-tex-pk" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "gepackte Schriftdatei"@de ;
   skos:prefLabel "packed font file"@en ;
   skos:prefLabel "pakattu kirjasintiedosto"@fi ;
@@ -2508,7 +2508,7 @@
 
 :application_x-tgif a skos:Concept ;
   :hasMediaType "application/x-tgif" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "TGIF document"@en ;
   skos:prefLabel "TGIF-Dokument"@de ;
   skos:prefLabel "TGIF-asiakirja"@fi ;
@@ -2519,7 +2519,7 @@
 :application_x-theme a skos:Concept ;
   :hasMediaType "application/x-theme" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Thema"@de ;
   skos:prefLabel "Téma"@cs ;
   skos:prefLabel "drakt"@nn ;
@@ -2538,7 +2538,7 @@
 
 :application_x-toutdoux a skos:Concept ;
   :hasMediaType "application/x-toutdoux" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen ToutDoux"@cy ;
   skos:prefLabel "Dokument ToutDoux"@cs ;
   skos:prefLabel "ToutDoux document"@en ;
@@ -2557,7 +2557,7 @@
 
 :application_x-trash a skos:Concept ;
   :hasMediaType "application/x-trash" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sicherungsdatei"@de ;
   skos:prefLabel "backup file"@en ;
   skos:prefLabel "sikkerhetskopi"@no ;
@@ -2566,7 +2566,7 @@
 :application_x-troff a skos:Concept ;
   :hasMediaType "application/x-troff" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen troff"@cy ;
   skos:prefLabel "Dokument troff"@cs ;
   skos:prefLabel "Troff document"@en ;
@@ -2586,14 +2586,14 @@
 :application_x-troff-man a skos:Concept ;
   :hasMediaType "application/x-troff-man" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Troff document (with manpage macros)"@en ;
   skos:prefLabel "Troff-Dokument (mit man-Seitenmakros)"@de ;
   skos:prefLabel "Troff-asiakirja man-sivu-makroilla"@fi .
 
 :application_x-troff-man-compressed a skos:Concept ;
   :hasMediaType "application/x-troff-man-compressed" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "(압축된) 설명서 페이지"@ko ;
   skos:prefLabel "Handbuchseite (komprimiert)"@de ;
   skos:prefLabel "Manuálová stránka (komprimovaná)"@cs ;
@@ -2611,7 +2611,7 @@
 
 :application_x-tzo a skos:Concept ;
   :hasMediaType "application/x-tzo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "tar archive (LZO-compressed)"@en ;
   skos:prefLabel "tar-Archiv (LZO-komprimiert)"@de ;
   skos:prefLabel "tar-arkisto (LZO-pakattu)"@fi ;
@@ -2619,7 +2619,7 @@
 
 :application_x-ustar a skos:Concept ;
   :hasMediaType "application/x-ustar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Archiv ustar"@cs ;
   skos:prefLabel "Ustar 아카이브"@ko ;
   skos:prefLabel "archif ustar"@cy ;
@@ -2637,7 +2637,7 @@
 
 :application_x-wais-source a skos:Concept ;
   :hasMediaType "application/x-wais-source" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Rhaglen WAIS"@cy ;
   skos:prefLabel "WAIS broncode"@nl ;
   skos:prefLabel "WAIS mənbə faylı"@az ;
@@ -2656,7 +2656,7 @@
 
 :application_x-wpg a skos:Concept ;
   :hasMediaType "application/x-wpg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "WordPerfect- tai DrawPerfect -kuva"@fi ;
   skos:prefLabel "WordPerfect/DrawPerfect-Bild"@de ;
   skos:prefLabel "WordPerfect/Drawperfect image"@en ;
@@ -2664,7 +2664,7 @@
 
 :application_x-x509-ca-cert a skos:Concept ;
   :hasMediaType "application/x-x509-ca-cert" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DER-, PEM- tai Netscape-koodattu X.509-varmenne"@fi ;
   skos:prefLabel "DER/PEM/Netscape-encoded X.509 certificate"@en ;
   skos:prefLabel "DER/PEM/Netscape-kodet X.509-sertifikat"@no ;
@@ -2673,7 +2673,7 @@
 :application_x-xbel a skos:Concept ;
   :hasMediaType "application/x-xbel" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "XBEL bookmarks"@en ;
   skos:prefLabel "XBEL-Lesezeichen"@de ;
   skos:prefLabel "XBEL-bokmerker"@no ;
@@ -2682,7 +2682,7 @@
 
 :application_x-zerosize a skos:Concept ;
   :hasMediaType "application/x-zerosize" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "empty document"@en ;
   skos:prefLabel "leeres Dokument"@de ;
   skos:prefLabel "tomt dokument"@no ;
@@ -2691,7 +2691,7 @@
 
 :application_x-zoo a skos:Concept ;
   :hasMediaType "application/x-zoo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "zoo archive"@en ;
   skos:prefLabel "zoo-Archiv"@de ;
   skos:prefLabel "zoo-arkisto"@fi ;
@@ -2700,7 +2700,7 @@
 :application_xhtmlxml a skos:Concept ;
   :hasMediaType "application/xhtml+xml" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "XHTML page"@en ;
   skos:prefLabel "XHTML-Seite"@de ;
   skos:prefLabel "XHTML-sida"@sv ;
@@ -2710,7 +2710,7 @@
 
 :application_zip a skos:Concept ;
   :hasMediaType "application/zip" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "ZIP archive"@en ;
   skos:prefLabel "ZIP-Archiv"@de ;
   skos:prefLabel "ZIP-arkisto"@fi ;
@@ -2748,7 +2748,7 @@
 
 :audio_ac3 a skos:Concept ;
   :hasMediaType "audio/ac3" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dolby Digital -ääni"@fi ;
   skos:prefLabel "Dolby Digital audio"@az ;
   skos:prefLabel "Dolby Digital audio"@en ;
@@ -2767,7 +2767,7 @@
 
 :audio_basic a skos:Concept ;
   :hasMediaType "audio/basic" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sain ULAW (Sun)"@cy ;
   skos:prefLabel "ULAW (Sun) -ääni"@fi ;
   skos:prefLabel "ULAW (Sun) audio faylı"@az ;
@@ -2786,7 +2786,7 @@
 :audio_midi a skos:Concept ;
   :hasMediaType "audio/midi" ;
   skos:exactMatch :audio_x-midi ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MIDI audio faylı"@az ;
   skos:prefLabel "MIDI audio"@en ;
   skos:prefLabel "MIDI geluidsbestand"@nl ;
@@ -2805,7 +2805,7 @@
 
 :audio_prssid a skos:Concept ;
   :hasMediaType "audio/prs.sid" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Commodore 64 -ääni"@fi ;
   skos:prefLabel "Commodore 64 audio"@en ;
   skos:prefLabel "Commodore 64-Audio"@de ;
@@ -2815,7 +2815,7 @@
 
 :audio_x-adpcm a skos:Concept ;
   :hasMediaType "audio/x-adpcm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "PCM audio faylı"@az ;
   skos:prefLabel "PCM audio"@en ;
   skos:prefLabel "PCM geluidsbestand"@nl ;
@@ -2834,7 +2834,7 @@
 
 :audio_x-aifc a skos:Concept ;
   :hasMediaType "audio/x-aifc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AIFC audio faylı"@az ;
   skos:prefLabel "AIFC audio"@en ;
   skos:prefLabel "AIFC geluidsbestand"@nl ;
@@ -2853,7 +2853,7 @@
 
 :audio_x-aiff a skos:Concept ;
   :hasMediaType "audio/x-aiff" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AIFF/Amiga/Mac audio faylı"@az ;
   skos:prefLabel "AIFF/Amiga/Mac audio"@en ;
   skos:prefLabel "AIFF/Amiga/Mac geluidsbestand"@nl ;
@@ -2871,7 +2871,7 @@
 
 :audio_x-aiffc a skos:Concept ;
   :hasMediaType "audio/x-aiffc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AIFF audio faylı"@az ;
   skos:prefLabel "AIFF audio"@en ;
   skos:prefLabel "AIFF geluidsbestand"@nl ;
@@ -2890,7 +2890,7 @@
 
 :audio_x-flac a skos:Concept ;
   :hasMediaType "audio/x-flac" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "FLAC audio"@en ;
   skos:prefLabel "FLAC-Audio"@de ;
   skos:prefLabel "FLAC-lyd"@no ;
@@ -2899,7 +2899,7 @@
 
 :audio_x-it a skos:Concept ;
   :hasMediaType "audio/x-it" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Impulse Tracker -ääni"@fi ;
   skos:prefLabel "Impulse Tracker audio faylı"@az ;
   skos:prefLabel "Impulse Tracker audio"@en ;
@@ -2918,7 +2918,7 @@
 
 :audio_x-mod a skos:Concept ;
   :hasMediaType "audio/x-mod" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Amiga SoundTracker -ääni"@fi ;
   skos:prefLabel "Amiga SoundTracker audio"@en ;
   skos:prefLabel "Amiga SoundTracker-Audio"@de ;
@@ -2926,7 +2926,7 @@
 
 :audio_x-mp3 a skos:Concept ;
   :hasMediaType "audio/x-mp3" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio faylı"@az ;
   skos:prefLabel "MP3 audio"@en ;
   skos:prefLabel "MP3 geluidsbestand"@nl ;
@@ -2945,7 +2945,7 @@
 
 :audio_x-mp3-playlist a skos:Concept ;
   :hasMediaType "audio/x-mp3-playlist" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MP3 playlist"@en ;
   skos:prefLabel "MP3-Wiedergabeliste"@de ;
   skos:prefLabel "MP3-soittolista"@fi ;
@@ -2953,7 +2953,7 @@
 
 :audio_x-mpeg a skos:Concept ;
   :hasMediaType "audio/x-mpeg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio faylı"@az ;
   skos:prefLabel "MP3 audio"@en ;
   skos:prefLabel "MP3 geluidsbestand"@nl ;
@@ -2972,7 +2972,7 @@
 
 :audio_x-mpegurl a skos:Concept ;
   :hasMediaType "audio/x-mpegurl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MP3 audio (streamed)"@en ;
   skos:prefLabel "MP3-Audio (Stream)"@de ;
   skos:prefLabel "MP3-lyd (streaming)"@no ;
@@ -2980,7 +2980,7 @@
 
 :audio_x-ms-asx a skos:Concept ;
   :hasMediaType "audio/x-ms-asx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Afspeellijst"@nl ;
   skos:prefLabel "Lejátszható felvételek listája"@hu ;
   skos:prefLabel "Playlist"@en ;
@@ -3000,7 +3000,7 @@
 :audio_x-pn-realaudio a skos:Concept ;
   :hasMediaType "audio/x-pn-realaudio" ;
   skos:exactMatch :audio_vndrn-realaudio ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Darllediad RealAudio"@cy ;
   skos:prefLabel "RealAudio broadcast"@en ;
   skos:prefLabel "RealAudio uitzending"@nl ;
@@ -3018,7 +3018,7 @@
 
 :audio_x-riff a skos:Concept ;
   :hasMediaType "audio/x-riff" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "RIFF audio faylı"@az ;
   skos:prefLabel "RIFF audio"@en ;
   skos:prefLabel "RIFF geluidsbestand"@nl ;
@@ -3037,7 +3037,7 @@
 
 :audio_x-s3m a skos:Concept ;
   :hasMediaType "audio/x-s3m" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sain Scream Tracker 3"@cy ;
   skos:prefLabel "Scream Tracker 3 -ääni"@fi ;
   skos:prefLabel "Scream Tracker 3 audio faylı"@az ;
@@ -3056,7 +3056,7 @@
 
 :audio_x-scpls a skos:Concept ;
   :hasMediaType "audio/x-scpls" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MP3 ShoutCast -soittolista"@fi ;
   skos:prefLabel "MP3 ShoutCast playlist"@en ;
   skos:prefLabel "MP3 ShoutCast-spilleliste"@no ;
@@ -3064,7 +3064,7 @@
 
 :audio_x-stm a skos:Concept ;
   :hasMediaType "audio/x-stm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sain Scream Tracker"@cy ;
   skos:prefLabel "Scream Tracker -ääni"@fi ;
   skos:prefLabel "Scream Tracker audio faylı"@az ;
@@ -3083,7 +3083,7 @@
 
 :audio_x-voc a skos:Concept ;
   :hasMediaType "audio/x-voc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sain VOC"@cy ;
   skos:prefLabel "VOC audio faylı"@az ;
   skos:prefLabel "VOC audio"@en ;
@@ -3102,7 +3102,7 @@
 
 :audio_x-wav a skos:Concept ;
   :hasMediaType "audio/x-wav" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Sain WAV"@cy ;
   skos:prefLabel "WAV audio faylı"@az ;
   skos:prefLabel "WAV audio"@en ;
@@ -3121,7 +3121,7 @@
 
 :audio_x-xi a skos:Concept ;
   :hasMediaType "audio/x-xi" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Nástroj pro Scream Tracker"@cs ;
   skos:prefLabel "Offeryn Scream Tracker"@cy ;
   skos:prefLabel "Scream Tracker -soitin"@fi ;
@@ -3140,7 +3140,7 @@
 
 :audio_x-xm a skos:Concept ;
   :hasMediaType "audio/x-xm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "FastTracker II -ääni"@fi ;
   skos:prefLabel "FastTracker II audio faylı"@az ;
   skos:prefLabel "FastTracker II audio"@en ;
@@ -3169,7 +3169,7 @@
 
 :geopackagesqlite3 a skos:Concept ;
   :hasMediaType "application/geopackage+sqlite3" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Base de Dados GeoPackage SQLite3"@pt ;
   skos:prefLabel "Base de datos GeoPackage SQLite3"@es ;
   skos:prefLabel "Base de données GeoPackage SQLite3"@fr ;
@@ -3240,7 +3240,7 @@
 
 :image_bmp a skos:Concept ;
   :hasMediaType "image/bmp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd BMP Windows"@cy ;
   skos:prefLabel "Obrázek Windows BMP"@cs ;
   skos:prefLabel "Windows BMP -kuva"@fi ;
@@ -3259,7 +3259,7 @@
 
 :image_cgm a skos:Concept ;
   :hasMediaType "image/cgm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CGM-Datei"@de ;
   skos:prefLabel "Computer Graphics -metatiedosto"@fi ;
   skos:prefLabel "Computer Graphics Metabestand"@nl ;
@@ -3277,7 +3277,7 @@
 
 :image_dpx a skos:Concept ;
   :hasMediaType "image/dpx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DPX-Bild"@de ;
   skos:prefLabel "DPX-bild (Digital Moving Picture Exchange)"@sv ;
   skos:prefLabel "Delwedd Digital Moving Picture Exchange"@cy ;
@@ -3295,7 +3295,7 @@
 
 :image_fax-g3 a skos:Concept ;
   :hasMediaType "image/fax-g3" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CCITT G3 fax"@en ;
   skos:prefLabel "CCITT G3-faks"@no ;
   skos:prefLabel "CCITT g3 -faksi"@fi ;
@@ -3304,7 +3304,7 @@
 
 :image_g3fax a skos:Concept ;
   :hasMediaType "image/g3fax" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Ffacs G3"@cy ;
   skos:prefLabel "G3 faks rəsmi"@az ;
   skos:prefLabel "G3 faksbilete"@nn ;
@@ -3323,7 +3323,7 @@
 
 :image_gif a skos:Concept ;
   :hasMediaType "image/gif" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd GIF"@cy ;
   skos:prefLabel "GIF afbeelding"@nl ;
   skos:prefLabel "GIF image"@en ;
@@ -3342,7 +3342,7 @@
 
 :image_ief a skos:Concept ;
   :hasMediaType "image/ief" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd IEF"@cy ;
   skos:prefLabel "IEF afbeelding"@nl ;
   skos:prefLabel "IEF image"@en ;
@@ -3361,7 +3361,7 @@
 
 :image_jpeg a skos:Concept ;
   :hasMediaType "image/jpeg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd JPEG"@cy ;
   skos:prefLabel "JPEG afbeelding"@nl ;
   skos:prefLabel "JPEG image"@en ;
@@ -3380,7 +3380,7 @@
 
 :image_jpeg2000 a skos:Concept ;
   :hasMediaType "image/jpeg2000" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "JPEG-2000 -kuva"@fi ;
   skos:prefLabel "JPEG-2000 image"@en ;
   skos:prefLabel "JPEG-2000-Bild"@de ;
@@ -3388,7 +3388,7 @@
 
 :image_png a skos:Concept ;
   :hasMediaType "image/png" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PNG"@cy ;
   skos:prefLabel "Obrázek PNG"@cs ;
   skos:prefLabel "PNG afbeelding"@nl ;
@@ -3407,13 +3407,13 @@
 
 :image_rle a skos:Concept ;
   :hasMediaType "image/rle" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "RLE-Bitmap"@de ;
   skos:prefLabel "Run Length Encoded bitmap"@en .
 
 :image_svgxml a skos:Concept ;
   :hasMediaType "image/svg+xml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "SVG-kuva"@fi ;
   skos:prefLabel "scalable SVG image"@en ;
   skos:prefLabel "skalerbart SVG-bilde"@no ;
@@ -3421,7 +3421,7 @@
 
 :image_tiff a skos:Concept ;
   :hasMediaType "image/tiff" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "TIFF image"@en ;
   skos:prefLabel "TIFF-Bild"@de ;
   skos:prefLabel "TIFF-bild"@sv ;
@@ -3432,7 +3432,7 @@
 :image_vnddjvu a skos:Concept ;
   :hasMediaType "image/vnd.djvu" ;
   skos:exactMatch :image_x-djvu ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DjVu -kuva"@fi ;
   skos:prefLabel "DjVu image"@en ;
   skos:prefLabel "DjVu 이미지"@ko ;
@@ -3443,7 +3443,7 @@
 
 :image_vnddwg a skos:Concept ;
   :hasMediaType "image/vnd.dwg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AutoCAD afbeelding"@nl ;
   skos:prefLabel "AutoCAD image"@en ;
   skos:prefLabel "AutoCAD rəsmi"@az ;
@@ -3462,7 +3462,7 @@
 
 :image_vnddxf a skos:Concept ;
   :hasMediaType "image/vnd.dxf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DXF vector image"@en ;
   skos:prefLabel "DXF-Vektorbild"@de ;
   skos:prefLabel "DXF-vektorgrafikk"@no ;
@@ -3470,7 +3470,7 @@
 
 :image_x-3ds a skos:Concept ;
   :hasMediaType "image/x-3ds" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "3D Studio -kuva"@fi ;
   skos:prefLabel "3D Studio afbeelding"@nl ;
   skos:prefLabel "3D Studio image"@en ;
@@ -3489,7 +3489,7 @@
 
 :image_x-applix-graphics a skos:Concept ;
   :hasMediaType "image/x-applix-graphics" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Applix Graphics -kuva"@fi ;
   skos:prefLabel "Applix Graphics image"@en ;
   skos:prefLabel "Applix Graphics-Bild"@de ;
@@ -3498,7 +3498,7 @@
 
 :image_x-cmu-raster a skos:Concept ;
   :hasMediaType "image/x-cmu-raster" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CMU raster afbeelding"@nl ;
   skos:prefLabel "CMU raster image"@en ;
   skos:prefLabel "CMU raster rəsmi"@az ;
@@ -3516,7 +3516,7 @@
 
 :image_x-compressed-xcf a skos:Concept ;
   :hasMediaType "image/x-compressed-xcf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "GIMP image (compressed)"@en ;
   skos:prefLabel "GIMP-Bild (komprimiert)"@de ;
   skos:prefLabel "GIMP-bilde (komprimert)"@no ;
@@ -3525,7 +3525,7 @@
 
 :image_x-dcm a skos:Concept ;
   :hasMediaType "image/x-dcm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bildformat för digital bildbehandling och medicinsk kommunikation"@sv ;
   skos:prefLabel "DICOM-Bild"@de ;
   skos:prefLabel "Delwedd DCIM (Digital Imaging and Communications in Medicine)"@cy ;
@@ -3542,7 +3542,7 @@
 
 :image_x-dib a skos:Concept ;
   :hasMediaType "image/x-dib" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Apparaat onafhankelijke bitmap"@nl ;
   skos:prefLabel "Avadanlıqdan Müstəqil Bitmap"@az ;
   skos:prefLabel "Bitmapa nezávislá na zařízení"@cs ;
@@ -3560,7 +3560,7 @@
 
 :image_x-eps a skos:Concept ;
   :hasMediaType "image/x-eps" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PostScript wedi ei chrisialu"@cy ;
   skos:prefLabel "EPS-Bild"@de ;
   skos:prefLabel "Encapsulated PostScript image"@en ;
@@ -3578,7 +3578,7 @@
 
 :image_x-fits a skos:Concept ;
   :hasMediaType "image/x-fits" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "FITS-Dokument"@de ;
   skos:prefLabel "Fleksibelt bildetransportsystem"@no ;
   skos:prefLabel "Flexibel afbeeldingstransportsysteem"@nl ;
@@ -3596,7 +3596,7 @@
 
 :image_x-fpx a skos:Concept ;
   :hasMediaType "image/x-fpx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "FlashPix image"@en ;
   skos:prefLabel "FlashPix-Bild"@de ;
   skos:prefLabel "FlashPix-bilde"@no ;
@@ -3605,7 +3605,7 @@
 
 :image_x-icb a skos:Concept ;
   :hasMediaType "image/x-icb" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Targa Truevision"@cy ;
   skos:prefLabel "Obrázek Truevision Targa"@cs ;
   skos:prefLabel "Truevision Targa -kuva"@fi ;
@@ -3624,7 +3624,7 @@
 
 :image_x-ico a skos:Concept ;
   :hasMediaType "image/x-ico" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft Windows -kuvake"@fi ;
   skos:prefLabel "Microsoft Windows icon"@en ;
   skos:prefLabel "Microsoft Windows-Symbol"@de ;
@@ -3633,7 +3633,7 @@
 
 :image_x-iff a skos:Concept ;
   :hasMediaType "image/x-iff" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd IFF"@cy ;
   skos:prefLabel "IFF afbeelding"@nl ;
   skos:prefLabel "IFF image"@en ;
@@ -3652,7 +3652,7 @@
 
 :image_x-ilbm a skos:Concept ;
   :hasMediaType "image/x-ilbm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd ILBM"@cy ;
   skos:prefLabel "ILBM afbeelding"@nl ;
   skos:prefLabel "ILBM image"@en ;
@@ -3671,7 +3671,7 @@
 
 :image_x-jng a skos:Concept ;
   :hasMediaType "image/x-jng" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd JNG"@cy ;
   skos:prefLabel "JNG afbeelding"@nl ;
   skos:prefLabel "JNG image"@en ;
@@ -3690,7 +3690,7 @@
 
 :image_x-lwo a skos:Concept ;
   :hasMediaType "image/x-lwo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Gwrthrych LightWave"@cy ;
   skos:prefLabel "LightWave cismi"@az ;
   skos:prefLabel "LightWave object"@en ;
@@ -3709,7 +3709,7 @@
 
 :image_x-lws a skos:Concept ;
   :hasMediaType "image/x-lws" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Golygfa LightWave"@cy ;
   skos:prefLabel "LightWave scene"@en ;
   skos:prefLabel "LightWave scêne"@nl ;
@@ -3728,7 +3728,7 @@
 
 :image_x-msod a skos:Concept ;
   :hasMediaType "image/x-msod" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft Office -piirros"@fi ;
   skos:prefLabel "Microsoft Office drawing"@en ;
   skos:prefLabel "Microsoft Office-Zeichnung"@de ;
@@ -3736,15 +3736,15 @@
 
 :image_x-niff a skos:Concept ;
   :hasMediaType "image/x-niff" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :image_x-pcx a skos:Concept ;
   :hasMediaType "image/x-pcx" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :image_x-photo-cd a skos:Concept ;
   :hasMediaType "image/x-photo-cd" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PhotoCD"@cy ;
   skos:prefLabel "Obrázek PhotoCD"@cs ;
   skos:prefLabel "Photo CD-bilete"@nn ;
@@ -3763,14 +3763,14 @@
 
 :image_x-pict a skos:Concept ;
   :hasMediaType "image/x-pict" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Macintosh Quickdraw/PICT -piirros"@fi ;
   skos:prefLabel "Macintosh Quickdraw/PICT drawing"@en ;
   skos:prefLabel "Macintosh Quickdraw/PICT-Zeichnung"@de .
 
 :image_x-portable-anymap a skos:Concept ;
   :hasMediaType "image/x-portable-anymap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd PNM"@cy ;
   skos:prefLabel "Obrázek PNM"@cs ;
   skos:prefLabel "PNM afbeelding"@nl ;
@@ -3789,7 +3789,7 @@
 
 :image_x-portable-bitmap a skos:Concept ;
   :hasMediaType "image/x-portable-bitmap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeiliau Fformat Pixfap Cludadwy"@cy ;
   skos:prefLabel "Formát souborů Portable Bitmap"@cs ;
   skos:prefLabel "Portabelt bitmapp-filformat"@sv ;
@@ -3805,7 +3805,7 @@
 
 :image_x-portable-graymap a skos:Concept ;
   :hasMediaType "image/x-portable-graymap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeiliau Fformat Llwydfap Cludadwy"@cy ;
   skos:prefLabel "Formát souborů Portable Graymap"@cs ;
   skos:prefLabel "Portabelt gråskale-filformat"@sv ;
@@ -3821,7 +3821,7 @@
 
 :image_x-portable-pixmap a skos:Concept ;
   :hasMediaType "image/x-portable-pixmap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd Pixmap Cludadwy"@cy ;
   skos:prefLabel "Formát souboru Portable Pixmap"@cs ;
   skos:prefLabel "Portabelt Pixmap-filformat"@no ;
@@ -3838,7 +3838,7 @@
 
 :image_x-psd a skos:Concept ;
   :hasMediaType "image/x-psd" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Photoshop image"@en ;
   skos:prefLabel "Photoshop-Bild"@de ;
   skos:prefLabel "Photoshop-bilde"@no ;
@@ -3847,7 +3847,7 @@
 
 :image_x-rgb a skos:Concept ;
   :hasMediaType "image/x-rgb" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd RGB"@cy ;
   skos:prefLabel "Obrázek RGB"@cs ;
   skos:prefLabel "RGB afbeelding"@nl ;
@@ -3866,14 +3866,14 @@
 
 :image_x-sgi a skos:Concept ;
   :hasMediaType "image/x-sgi" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Silicon Graphics IRIS -kuva"@fi ;
   skos:prefLabel "Silicon Graphics IRIS image"@en ;
   skos:prefLabel "Silicon Graphics-IRIS-Bild"@de .
 
 :image_x-sun-raster a skos:Concept ;
   :hasMediaType "image/x-sun-raster" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "SUN Rasterfile image"@en ;
   skos:prefLabel "SUN rasterfil-bilde"@no ;
   skos:prefLabel "SUN-Rasterfile-Bild"@de ;
@@ -3881,7 +3881,7 @@
 
 :image_x-tga a skos:Concept ;
   :hasMediaType "image/x-tga" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd TarGA"@cy ;
   skos:prefLabel "Obrázek TarGA"@cs ;
   skos:prefLabel "TarGA afbeelding"@nl ;
@@ -3900,14 +3900,14 @@
 
 :image_x-win-bitmap a skos:Concept ;
   :hasMediaType "image/x-win-bitmap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Windows cursor"@en ;
   skos:prefLabel "Windows-Cursor"@de ;
   skos:prefLabel "Windows-kursori"@fi .
 
 :image_x-wmf a skos:Concept ;
   :hasMediaType "image/x-wmf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft WMF -tiedosto"@fi ;
   skos:prefLabel "Microsoft WMF file"@en ;
   skos:prefLabel "Microsoft WMF-fil"@no ;
@@ -3916,7 +3916,7 @@
 
 :image_x-xbitmap a skos:Concept ;
   :hasMediaType "image/x-xbitmap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bilete i X Bitmap-format"@nn ;
   skos:prefLabel "Delwedd didfap X"@cy ;
   skos:prefLabel "Obrázek X BitMap"@cs ;
@@ -3934,7 +3934,7 @@
 
 :image_x-xcf a skos:Concept ;
   :hasMediaType "image/x-xcf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "GIF-kuva"@fi ;
   skos:prefLabel "GIMP image"@en ;
   skos:prefLabel "GIMP-Bild"@de ;
@@ -3944,7 +3944,7 @@
 
 :image_x-xfig a skos:Concept ;
   :hasMediaType "image/x-xfig" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "XFig image"@en ;
   skos:prefLabel "XFig-Bild"@de ;
   skos:prefLabel "XFig-bilde"@no ;
@@ -3953,7 +3953,7 @@
 
 :image_x-xpixmap a skos:Concept ;
   :hasMediaType "image/x-xpixmap" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bilete i X Bitmap-format"@nn ;
   skos:prefLabel "Delwedd picsfap X"@cy ;
   skos:prefLabel "Obrázek X PixMap"@cs ;
@@ -3971,7 +3971,7 @@
 
 :image_x-xwindowdump a skos:Concept ;
   :hasMediaType "image/x-xwindowdump" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Delwedd ffenest X"@cy ;
   skos:prefLabel "Obrázek X window"@cs ;
   skos:prefLabel "X Window afbeelding"@nl ;
@@ -3997,7 +3997,7 @@
 
 :inode_blockdevice a skos:Concept ;
   :hasMediaType "inode/blockdevice" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Blockgerät"@de ;
   skos:prefLabel "block device"@en ;
   skos:prefLabel "blokkenhet"@no ;
@@ -4005,7 +4005,7 @@
 
 :inode_chardevice a skos:Concept ;
   :hasMediaType "inode/chardevice" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Character-Device"@de ;
   skos:prefLabel "character device"@en ;
   skos:prefLabel "merkkilaite"@fi ;
@@ -4013,7 +4013,7 @@
 
 :inode_directory a skos:Concept ;
   :hasMediaType "inode/directory" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:narrower :inode_mount-point ;
   skos:prefLabel "Ordner"@de ;
   skos:prefLabel "folder"@en ;
@@ -4024,7 +4024,7 @@
 
 :inode_fifo a skos:Concept ;
   :hasMediaType "inode/fifo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Pipe"@de ;
   skos:prefLabel "pipe"@en ;
   skos:prefLabel "putki"@fi ;
@@ -4034,7 +4034,7 @@
 :inode_mount-point a skos:Concept ;
   :hasMediaType "inode/mount-point" ;
   skos:broader :inode_directory ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Einbindepunkt"@de ;
   skos:prefLabel "liitospiste"@fi ;
   skos:prefLabel "monteringspunkt"@no ;
@@ -4043,7 +4043,7 @@
 
 :inode_socket a skos:Concept ;
   :hasMediaType "inode/socket" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Socket"@de ;
   skos:prefLabel "pistoke"@fi ;
   skos:prefLabel "plugg"@no ;
@@ -4051,7 +4051,7 @@
 
 :inode_symlink a skos:Concept ;
   :hasMediaType "inode/symlink" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Symbolický odkaz"@cs ;
   skos:prefLabel "Symbolischer Link"@de ;
   skos:prefLabel "cyswllt symbolaidd"@cy ;
@@ -4083,7 +4083,7 @@
 :message_delivery-status a skos:Concept ;
   :hasMediaType "message/delivery-status" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Adroddiad trosgludo post"@cy ;
   skos:prefLabel "E-Mail-Zustellungsbericht"@de ;
   skos:prefLabel "Zpráva o doručení pošty"@cs ;
@@ -4101,7 +4101,7 @@
 
 :message_disposition-notification a skos:Concept ;
   :hasMediaType "message/disposition-notification" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Übertragungsbericht"@de ;
   skos:prefLabel "Zpráva o předání pošty"@cs ;
   skos:prefLabel "adroddiad ffurf post"@cy ;
@@ -4119,7 +4119,7 @@
 
 :message_external-body a skos:Concept ;
   :hasMediaType "message/external-body" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Odkaz na vzdálený soubor"@cs ;
   skos:prefLabel "Verweis auf entfernte Datei"@de ;
   skos:prefLabel "cyfeiriad at ffeil bell"@cy ;
@@ -4138,7 +4138,7 @@
 :message_news a skos:Concept ;
   :hasMediaType "message/news" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Neges newyddion Usenet"@cy ;
   skos:prefLabel "Příspěvek do diskusních skupin Usenet"@cs ;
   skos:prefLabel "USENET diskusjonsmelding"@nn ;
@@ -4157,7 +4157,7 @@
 :message_partial a skos:Concept ;
   :hasMediaType "message/partial" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Nachrichtenfragment"@de ;
   skos:prefLabel "darn o neges e-bost"@cy ;
   skos:prefLabel "del av e-post-melding"@nn ;
@@ -4176,7 +4176,7 @@
 :message_rfc822 a skos:Concept ;
   :hasMediaType "message/rfc822" ;
   skos:broader :text_plain ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Nachricht"@de ;
   skos:prefLabel "e-postmeddelande"@sv ;
   skos:prefLabel "e-postmelding"@no ;
@@ -4186,7 +4186,7 @@
 
 :message_x-gnu-rmail a skos:Concept ;
   :hasMediaType "message/x-gnu-rmail" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-mailová zpráva GNU"@cs ;
   skos:prefLabel "GNU e-mail bericht"@nl ;
   skos:prefLabel "GNU e-postmelding"@nn ;
@@ -4211,7 +4211,7 @@
 
 :model_vrml a skos:Concept ;
   :hasMediaType "model/vrml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen VRML"@cy ;
   skos:prefLabel "Dokument VRML"@cs ;
   skos:prefLabel "VRML document"@en ;
@@ -4244,7 +4244,7 @@
 
 :multipart_alternative a skos:Concept ;
   :hasMediaType "multipart/alternative" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Nachricht in mehreren Formaten"@de ;
   skos:prefLabel "Zpráva v několika formátech"@cs ;
   skos:prefLabel "bericht in verschillende formaten"@nl ;
@@ -4262,7 +4262,7 @@
 
 :multipart_appledouble a skos:Concept ;
   :hasMediaType "multipart/appledouble" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil AppleDouble-amgodedig Macintosh"@cy ;
   skos:prefLabel "Macintosh AppleDouble -koodattu tiedosto"@fi ;
   skos:prefLabel "Macintosh AppleDouble kódolású fájl"@hu ;
@@ -4281,7 +4281,7 @@
 
 :multipart_digest a skos:Concept ;
   :hasMediaType "multipart/digest" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Digest zpráv"@cs ;
   skos:prefLabel "Nachrichtensammlung"@de ;
   skos:prefLabel "berichtsamenvatting"@nl ;
@@ -4299,7 +4299,7 @@
 
 :multipart_encrypted a skos:Concept ;
   :hasMediaType "multipart/encrypted" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Neges wedi ei hamgryptio"@cy ;
   skos:prefLabel "Zašifrovaná zpráva"@cs ;
   skos:prefLabel "encrypted message"@en ;
@@ -4318,7 +4318,7 @@
 
 :multipart_mixed a skos:Concept ;
   :hasMediaType "multipart/mixed" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Verbunddokumente"@de ;
   skos:prefLabel "compound documents"@en ;
   skos:prefLabel "sammensatte dokumenter"@no ;
@@ -4326,7 +4326,7 @@
 
 :multipart_related a skos:Concept ;
   :hasMediaType "multipart/related" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Složený dokument"@cs ;
   skos:prefLabel "Verbunddokument"@de ;
   skos:prefLabel "birləşik sənəd"@az ;
@@ -4344,7 +4344,7 @@
 
 :multipart_report a skos:Concept ;
   :hasMediaType "multipart/report" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Systembericht"@de ;
   skos:prefLabel "Zpráva poštovního systému"@cs ;
   skos:prefLabel "adroddiad system bost"@cy ;
@@ -4362,7 +4362,7 @@
 
 :multipart_signed a skos:Concept ;
   :hasMediaType "multipart/signed" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Podepsaná zpráva"@cs ;
   skos:prefLabel "allekirjoitettu viesti"@fi ;
   skos:prefLabel "aláírt üzenet"@hu ;
@@ -4380,7 +4380,7 @@
 
 :multipart_x-mixed-replace a skos:Concept ;
   :hasMediaType "multipart/x-mixed-replace" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Datenstrom (Server-Push)"@de ;
   skos:prefLabel "datastrøm (server push)"@no ;
   skos:prefLabel "stream of data (server push)"@en ;
@@ -4460,7 +4460,7 @@
 
 :text_calendar a skos:Concept ;
   :hasMediaType "text/calendar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil iCalendar"@cy ;
   skos:prefLabel "Soubor iCalendar"@cs ;
   skos:prefLabel "fichier iCalendar"@fr ;
@@ -4479,7 +4479,7 @@
 
 :text_css a skos:Concept ;
   :hasMediaType "text/css" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CSS-Stylesheet"@de ;
   skos:prefLabel "CSS-stíluslap"@hu ;
   skos:prefLabel "CSS-tyylisäännöstö"@fi ;
@@ -4500,14 +4500,14 @@
   rdfs:seeAlso <https://www.rfc-editor.org/rfc/rfc7111> ;
   skos:altLabel "CSV"@en ;
   skos:exactMatch :text_x-comma-separated-values ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "CSV (valeurs séparées par des virgules)"@fr ;
   skos:prefLabel "Comma Separated Values"@en ;
   skos:prefLabel "Werte durch Komma getrennt"@de .
 
 :text_directory a skos:Concept ;
   :hasMediaType "text/directory" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gwybodaeth cyfeiriadur"@cy ;
   skos:prefLabel "Soubor informací o adresáři"@cs ;
   skos:prefLabel "Verzeichnisinformationsdatei"@de ;
@@ -4525,7 +4525,7 @@
 
 :text_enriched a skos:Concept ;
   :hasMediaType "text/enriched" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen testun wedi ei gyfoethogi"@cy ;
   skos:prefLabel "Rozšířený textový dokument"@cs ;
   skos:prefLabel "angereichertes Textdokument"@de ;
@@ -4543,7 +4543,7 @@
 
 :text_html a skos:Concept ;
   :hasMediaType "text/html" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "HTML page"@en ;
   skos:prefLabel "HTML-Seite"@de ;
   skos:prefLabel "HTML-sida"@sv ;
@@ -4553,7 +4553,7 @@
 
 :text_htmlh a skos:Concept ;
   :hasMediaType "text/htmlh" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Hilfeseite"@de ;
   skos:prefLabel "Stránka nápovědy"@cs ;
   skos:prefLabel "help page"@en ;
@@ -4572,7 +4572,7 @@
 
 :text_mathml a skos:Concept ;
   :hasMediaType "text/mathml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen MathML"@cy ;
   skos:prefLabel "Dokument MathML"@cs ;
   skos:prefLabel "MathML document"@en ;
@@ -4591,7 +4591,7 @@
 
 :text_plain a skos:Concept ;
   :hasMediaType "text/plain" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:narrower :application_rtf ;
   skos:narrower :application_smil ;
   skos:narrower :application_x-asp ;
@@ -4629,7 +4629,7 @@
 
 :text_rdf a skos:Concept ;
   :hasMediaType "text/rdf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil RDF (Resource Description Framework)"@cy ;
   skos:prefLabel "Mənbə İzahat Çərçivəsi (RDF) faylı"@az ;
   skos:prefLabel "RDF (erőforrásleíró) -fájl"@hu ;
@@ -4646,7 +4646,7 @@
 
 :text_rfc822-headers a skos:Concept ;
   :hasMediaType "text/rfc822-headers" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "E-Mail-Kopfzeilen"@de ;
   skos:prefLabel "Hlavičky E-mailu"@cs ;
   skos:prefLabel "e-mail koppen"@nl ;
@@ -4664,7 +4664,7 @@
 
 :text_richtext a skos:Concept ;
   :hasMediaType "text/richtext" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bohatý textový dokument"@cs ;
   skos:prefLabel "RTF-Textdokument"@de ;
   skos:prefLabel "RTF-asiakirja"@fi ;
@@ -4682,7 +4682,7 @@
 
 :text_rss a skos:Concept ;
   :hasMediaType "text/rss" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Crynodeb Safle RDF"@cy ;
   skos:prefLabel "RDF Sayt İcmalı"@az ;
   skos:prefLabel "RDF Site Summary"@en ;
@@ -4700,7 +4700,7 @@
 
 :text_sgml a skos:Concept ;
   :hasMediaType "text/sgml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen SGML"@cy ;
   skos:prefLabel "SGML document"@en ;
   skos:prefLabel "SGML документ"@sr ;
@@ -4713,7 +4713,7 @@
 
 :text_spreadsheet a skos:Concept ;
   :hasMediaType "text/spreadsheet" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dokument for regnearkutveksling"@no ;
   skos:prefLabel "Spreadsheet interchange document"@en ;
   skos:prefLabel "Tabellenkalkulations-Austauschdokument"@de ;
@@ -4721,7 +4721,7 @@
 
 :text_tab-separated-values a skos:Concept ;
   :hasMediaType "text/tab-separated-values" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Textdokument·(Werte·durch·Tabulatorzeichen·unterteilt)"@de ;
   skos:prefLabel "sarkaimella eroteltuja arvoja tekstitiedostossa"@fi ;
   skos:prefLabel "tekstdokument (med tabulatorseparerte verdier)"@no ;
@@ -4729,7 +4729,7 @@
 
 :text_vndwapwml a skos:Concept ;
   :hasMediaType "text/vnd.wap.wml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen WML"@cy ;
   skos:prefLabel "Dokument WML"@cs ;
   skos:prefLabel "WML document"@en ;
@@ -4748,7 +4748,7 @@
 
 :text_x-adasrc a skos:Concept ;
   :hasMediaType "text/x-adasrc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ada source code"@en ;
   skos:prefLabel "Ada-Quelltext"@de ;
   skos:prefLabel "Ada-kildekode"@no ;
@@ -4757,7 +4757,7 @@
 
 :text_x-authors a skos:Concept ;
   :hasMediaType "text/x-authors" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Autorenliste"@de ;
   skos:prefLabel "author list"@en ;
   skos:prefLabel "forfatterliste"@no ;
@@ -4765,7 +4765,7 @@
 
 :text_x-bibtex a skos:Concept ;
   :hasMediaType "text/x-bibtex" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Bibtex bibliografiske data"@no ;
   skos:prefLabel "Bibtex bibliographic data"@en ;
   skos:prefLabel "bibliographische Bibitex-Daten"@de ;
@@ -4774,7 +4774,7 @@
 :text_x-chdr a skos:Concept ;
   :hasMediaType "text/x-c++hdr" ;
   :hasMediaType "text/x-chdr" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "C source code header"@en ;
   skos:prefLabel "C заглавља изворног кôда"@sr ;
   skos:prefLabel "C++ source code header"@en ;
@@ -4788,7 +4788,7 @@
 
 :text_x-comma-separated-values a skos:Concept ;
   :hasMediaType "text/x-comma-separated-values" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Textdokument (Werte durch Kommata unterteilt)"@de ;
   skos:prefLabel "pilkulla eroteltuja arvoja tekstitiedostossa"@fi ;
   skos:prefLabel "tekstdokument (med kommaseparerte verdier)"@no ;
@@ -4796,7 +4796,7 @@
 
 :text_x-copying a skos:Concept ;
   :hasMediaType "text/x-copying" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Podmínky licence na software"@cs ;
   skos:prefLabel "Software-Lizenzbedingungen"@de ;
   skos:prefLabel "lisensbestemmelser for programvare"@no ;
@@ -4814,7 +4814,7 @@
 
 :text_x-credits a skos:Concept ;
   :hasMediaType "text/x-credits" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Informace o autorovi software"@cs ;
   skos:prefLabel "Software-Impressum"@de ;
   skos:prefLabel "clodau awduron meddalwedd"@cy ;
@@ -4832,7 +4832,7 @@
 
 :text_x-csharp a skos:Concept ;
   :hasMediaType "text/x-csharp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "C# source code"@en ;
   skos:prefLabel "C#-Quelltext"@de ;
   skos:prefLabel "C#-lähdekoodi"@fi ;
@@ -4841,7 +4841,7 @@
 :text_x-csrc a skos:Concept ;
   :hasMediaType "text/x-c++src" ;
   :hasMediaType "text/x-csrc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "C source code"@en ;
   skos:prefLabel "C++ source code"@en ;
   skos:prefLabel "C++-Quelltext"@de ;
@@ -4855,7 +4855,7 @@
 
 :text_x-dcl a skos:Concept ;
   :hasMediaType "text/x-dcl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DCL script"@en ;
   skos:prefLabel "DCL script"@nl ;
   skos:prefLabel "DCL skripti"@az ;
@@ -4874,7 +4874,7 @@
 
 :text_x-dsl a skos:Concept ;
   :hasMediaType "text/x-dsl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "DSSSL document"@en ;
   skos:prefLabel "DSSSL document"@nl ;
   skos:prefLabel "DSSSL sənədi"@az ;
@@ -4893,7 +4893,7 @@
 
 :text_x-dtd a skos:Concept ;
   :hasMediaType "text/x-dtd" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Definice typu dokumentu"@cs ;
   skos:prefLabel "Diffiniad math dogfen"@cy ;
   skos:prefLabel "Dokumenttypenbeschreibung (DTD)"@de ;
@@ -4911,7 +4911,7 @@
 
 :text_x-emacs-lisp a skos:Concept ;
   :hasMediaType "text/x-emacs-lisp" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Emacs Lisp -lähdekoodi"@fi ;
   skos:prefLabel "Emacs Lisp broncode"@nl ;
   skos:prefLabel "Emacs Lisp kjeldekode"@nn ;
@@ -4930,7 +4930,7 @@
 
 :text_x-fortran a skos:Concept ;
   :hasMediaType "text/x-fortran" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell rhaglen FORTRAN"@cy ;
   skos:prefLabel "Fortran broncode"@nl ;
   skos:prefLabel "Fortran mənbə kodu"@az ;
@@ -4949,7 +4949,7 @@
 
 :text_x-gettext-translation a skos:Concept ;
   :hasMediaType "text/x-gettext-translation" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "käännettyjä viestejä"@fi ;
   skos:prefLabel "oversatte meldinger"@no ;
   skos:prefLabel "translated messages"@en ;
@@ -4958,13 +4958,13 @@
 
 :text_x-gettext-translation-template a skos:Concept ;
   :hasMediaType "text/x-gettext-translation-template" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Vorlage zur Nachrichtenübersetzung"@de ;
   skos:prefLabel "message translation template"@en .
 
 :text_x-gtkrc a skos:Concept ;
   :hasMediaType "text/x-gtkrc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffurfosodiad GTK"@cy ;
   skos:prefLabel "GTK configuratie"@nl ;
   skos:prefLabel "GTK configuration"@en ;
@@ -4983,7 +4983,7 @@
 
 :text_x-haskell a skos:Concept ;
   :hasMediaType "text/x-haskell" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell rhaglen Haskell"@cy ;
   skos:prefLabel "Haskell broncode"@nl ;
   skos:prefLabel "Haskell mənbə kodu"@az ;
@@ -5002,7 +5002,7 @@
 
 :text_x-idl a skos:Concept ;
   :hasMediaType "text/x-idl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen IDL"@cy ;
   skos:prefLabel "Dokument IDL"@cs ;
   skos:prefLabel "IDL document"@en ;
@@ -5021,7 +5021,7 @@
 
 :text_x-install a skos:Concept ;
   :hasMediaType "text/x-install" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Návod k instalaci software"@cs ;
   skos:prefLabel "Software-Installationsanleitung"@de ;
   skos:prefLabel "cyfarwyddiadau gosod meddalwedd"@cy ;
@@ -5039,7 +5039,7 @@
 
 :text_x-java a skos:Concept ;
   :hasMediaType "text/x-java" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Java source code"@en ;
   skos:prefLabel "Java-Quelltext"@de ;
   skos:prefLabel "Java-kildekode"@no ;
@@ -5048,7 +5048,7 @@
 
 :text_x-ksh a skos:Concept ;
   :hasMediaType "text/x-ksh" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Korn qabıq skripti"@az ;
   skos:prefLabel "Korn shell script"@en ;
   skos:prefLabel "Korn shell script"@nl ;
@@ -5067,11 +5067,11 @@
 
 :text_x-ksysv-log a skos:Concept ;
   :hasMediaType "text/x-ksysv-log" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :text_x-literate-haskell a skos:Concept ;
   :hasMediaType "text/x-literate-haskell" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Haskell llenyddol"@cy ;
   skos:prefLabel "Literate Haskell-Quelltext"@de ;
   skos:prefLabel "Literate Haskell-källkod"@sv ;
@@ -5089,7 +5089,7 @@
 
 :text_x-log a skos:Concept ;
   :hasMediaType "text/x-log" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Anwendungsprotokoll"@de ;
   skos:prefLabel "application log"@en ;
   skos:prefLabel "applikasjonslogg"@no ;
@@ -5097,7 +5097,7 @@
 
 :text_x-makefile a skos:Concept ;
   :hasMediaType "text/x-makefile" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil 'make'"@cy ;
   skos:prefLabel "Makefil"@sv ;
   skos:prefLabel "Makefile"@cs ;
@@ -5116,7 +5116,7 @@
 
 :text_x-moc a skos:Concept ;
   :hasMediaType "text/x-moc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "QT-Meta-Objektdatei"@de ;
   skos:prefLabel "Qt Meta Object -tiedosto"@fi ;
   skos:prefLabel "Qt Meta Object file"@en ;
@@ -5124,7 +5124,7 @@
 
 :text_x-objcsrc a skos:Concept ;
   :hasMediaType "text/x-objcsrc" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Objective-C -lähdekoodi"@fi ;
   skos:prefLabel "Objective-C source code"@en ;
   skos:prefLabel "Objective-C-Quelltext"@de ;
@@ -5133,7 +5133,7 @@
 
 :text_x-pascal a skos:Concept ;
   :hasMediaType "text/x-pascal" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Pascal source code"@en ;
   skos:prefLabel "Pascal-Quelltext"@de ;
   skos:prefLabel "Pascal-kildekode"@no ;
@@ -5142,7 +5142,7 @@
 
 :text_x-patch a skos:Concept ;
   :hasMediaType "text/x-patch" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Unterschied zwischen Dateien"@de ;
   skos:prefLabel "differences between files"@en ;
   skos:prefLabel "forskjeller mellom filer"@no ;
@@ -5150,7 +5150,7 @@
 
 :text_x-readme a skos:Concept ;
   :hasMediaType "text/x-readme" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen README"@cy ;
   skos:prefLabel "Dokument README"@cs ;
   skos:prefLabel "LEESMIJ document"@nl ;
@@ -5169,7 +5169,7 @@
 
 :text_x-scheme a skos:Concept ;
   :hasMediaType "text/x-scheme" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffynhonnell Rhaglen Scheme"@cy ;
   skos:prefLabel "Scheme broncode"@nl ;
   skos:prefLabel "Scheme kjeldekode"@nn ;
@@ -5188,7 +5188,7 @@
 
 :text_x-setext a skos:Concept ;
   :hasMediaType "text/x-setext" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen Setext"@cy ;
   skos:prefLabel "Dokument Setext"@cs ;
   skos:prefLabel "Setext document"@en ;
@@ -5207,7 +5207,7 @@
 
 :text_x-speech a skos:Concept ;
   :hasMediaType "text/x-speech" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Danışıq sənədi"@az ;
   skos:prefLabel "Dogfen leferydd"@cy ;
   skos:prefLabel "Dokument Speech"@cs ;
@@ -5226,7 +5226,7 @@
 
 :text_x-sql a skos:Concept ;
   :hasMediaType "text/x-sql" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Côd SQL"@cy ;
   skos:prefLabel "Kód SQL"@cs ;
   skos:prefLabel "SQL code"@en ;
@@ -5245,7 +5245,7 @@
 
 :text_x-tcl a skos:Concept ;
   :hasMediaType "text/x-tcl" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Tcl script"@en ;
   skos:prefLabel "Tcl-Skript"@de ;
   skos:prefLabel "Tcl-skript"@no ;
@@ -5255,7 +5255,7 @@
 
 :text_x-tex a skos:Concept ;
   :hasMediaType "text/x-tex" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen TeX "@cy ;
   skos:prefLabel "TeX document"@en ;
   skos:prefLabel "TeX документ"@sr ;
@@ -5268,7 +5268,7 @@
 
 :text_x-texinfo a skos:Concept ;
   :hasMediaType "text/x-texinfo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen TeXInfo"@cy ;
   skos:prefLabel "Dokument TeXInfo"@cs ;
   skos:prefLabel "TeXInfo document"@en ;
@@ -5287,7 +5287,7 @@
 
 :text_x-troff-me a skos:Concept ;
   :hasMediaType "text/x-troff-me" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Troff ME -syöteasiakirja"@fi ;
   skos:prefLabel "Troff ME input document"@en ;
   skos:prefLabel "Troff ME-inndatadokument"@no ;
@@ -5295,7 +5295,7 @@
 
 :text_x-troff-mm a skos:Concept ;
   :hasMediaType "text/x-troff-mm" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Troff MM -syöteasiakirja"@fi ;
   skos:prefLabel "Troff MM input document"@en ;
   skos:prefLabel "Troff MM-inndatadokument"@no ;
@@ -5303,7 +5303,7 @@
 
 :text_x-troff-ms a skos:Concept ;
   :hasMediaType "text/x-troff-ms" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Troff MS -syöteasiakirja"@fi ;
   skos:prefLabel "Troff MS input document"@en ;
   skos:prefLabel "Troff MS-inndatadokument"@no ;
@@ -5311,21 +5311,21 @@
 
 :text_x-uil a skos:Concept ;
   :hasMediaType "text/x-uil" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "X-Motif UIL -taulukko"@fi ;
   skos:prefLabel "X-Motif UIL table"@en ;
   skos:prefLabel "X-Motif-UIL-Tabelle"@de .
 
 :text_x-uri a skos:Concept ;
   :hasMediaType "text/x-uri" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ressourcenort"@de ;
   skos:prefLabel "resource location"@en ;
   skos:prefLabel "ressurslokasjon"@no .
 
 :text_x-vcalendar a skos:Concept ;
   :hasMediaType "text/x-vcalendar" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gyfnewid vCalendar"@cy ;
   skos:prefLabel "Soubor výměny vCalendar"@cs ;
   skos:prefLabel "fichier « vCalendar interchange »"@fr ;
@@ -5342,7 +5342,7 @@
 
 :text_x-vcard a skos:Concept ;
   :hasMediaType "text/x-vcard" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "electronic business card"@en ;
   skos:prefLabel "elektronische Visitenkarte"@de ;
   skos:prefLabel "elektronisk visittkort"@no ;
@@ -5351,13 +5351,13 @@
 
 :text_x-xmi a skos:Concept ;
   :hasMediaType "text/x-xmi" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "XML Metadata Interchange file"@en ;
   skos:prefLabel "XML-Metadaten-Austauschdatei"@de .
 
 :text_x-xslfo a skos:Concept ;
   :hasMediaType "text/x-xslfo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Ffeil gwrthrych ffurfwedd XSL"@cy ;
   skos:prefLabel "Soubor objektu formátování XSL"@cs ;
   skos:prefLabel "XSF:FO-fájl"@hu ;
@@ -5374,7 +5374,7 @@
 
 :text_x-xslt a skos:Concept ;
   :hasMediaType "text/x-xslt" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "XSLT stylesheet"@en ;
   skos:prefLabel "XSLT-Stylesheet"@de ;
   skos:prefLabel "XSLT-stilark"@no ;
@@ -5382,11 +5382,11 @@
 
 :text_xmcd a skos:Concept ;
   :hasMediaType "text/xmcd" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> .
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> .
 
 :text_xml a skos:Concept ;
   :hasMediaType "text/xml" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Dogfen XML (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language) (eXtensible Markup Language)"@cy ;
   skos:prefLabel "Dokument eXtensible Markup Language"@cs ;
   skos:prefLabel "Uitbreidbare opmaaktaal document (XML)"@nl ;
@@ -5423,7 +5423,7 @@
 
 :video_isivideo a skos:Concept ;
   :hasMediaType "video/isivideo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fideo ISI"@cy ;
   skos:prefLabel "ISI video faylı"@az ;
   skos:prefLabel "ISI video"@en ;
@@ -5442,7 +5442,7 @@
 
 :video_mpeg a skos:Concept ;
   :hasMediaType "video/mpeg" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MPEG video"@en ;
   skos:prefLabel "MPEG-Video"@de ;
   skos:prefLabel "MPEG-film"@no ;
@@ -5452,7 +5452,7 @@
 
 :video_quicktime a skos:Concept ;
   :hasMediaType "video/quicktime" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "QuickTime video"@en ;
   skos:prefLabel "QuickTime-Video"@de ;
   skos:prefLabel "QuickTime-video"@fi ;
@@ -5461,7 +5461,7 @@
 
 :video_vivo a skos:Concept ;
   :hasMediaType "video/vivo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fideo Vivo"@cy ;
   skos:prefLabel "Video Vivo"@cs ;
   skos:prefLabel "Vivo video faylı"@az ;
@@ -5480,7 +5480,7 @@
 
 :video_wavelet a skos:Concept ;
   :hasMediaType "video/wavelet" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fideo Wavelet"@cy ;
   skos:prefLabel "Video Wavelet"@cs ;
   skos:prefLabel "Wavelet video faylı"@az ;
@@ -5499,7 +5499,7 @@
 
 :video_x-anim a skos:Concept ;
   :hasMediaType "video/x-anim" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "ANIM animasiyası"@az ;
   skos:prefLabel "ANIM animatie"@nl ;
   skos:prefLabel "ANIM animation"@en ;
@@ -5518,7 +5518,7 @@
 
 :video_x-avi a skos:Concept ;
   :hasMediaType "video/x-avi" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AVI video faylı"@az ;
   skos:prefLabel "AVI video"@en ;
   skos:prefLabel "AVI video"@nl ;
@@ -5537,7 +5537,7 @@
 
 :video_x-flic a skos:Concept ;
   :hasMediaType "video/x-flic" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "AutoDesk FLIC -animaatio"@fi ;
   skos:prefLabel "AutoDesk FLIC animation"@en ;
   skos:prefLabel "AutoDesk FLIC-animasjon"@no ;
@@ -5545,7 +5545,7 @@
 
 :video_x-mng a skos:Concept ;
   :hasMediaType "video/x-mng" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "MNG animation"@en ;
   skos:prefLabel "MNG-Animation"@de ;
   skos:prefLabel "MNG-animaatio"@fi ;
@@ -5553,7 +5553,7 @@
 
 :video_x-ms-asf a skos:Concept ;
   :hasMediaType "video/x-ms-asf" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft ASF -video"@fi ;
   skos:prefLabel "Microsoft ASF video"@en ;
   skos:prefLabel "Microsoft ASF-film"@no ;
@@ -5562,7 +5562,7 @@
 
 :video_x-ms-wmv a skos:Concept ;
   :hasMediaType "video/x-ms-wmv" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft WMV -video"@fi ;
   skos:prefLabel "Microsoft WMV video faylı"@az ;
   skos:prefLabel "Microsoft WMV video"@en ;
@@ -5581,7 +5581,7 @@
 
 :video_x-msvideo a skos:Concept ;
   :hasMediaType "video/x-msvideo" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Microsoft AVI -video"@fi ;
   skos:prefLabel "Microsoft AVI video"@en ;
   skos:prefLabel "Microsoft AVI-film"@no ;
@@ -5591,7 +5591,7 @@
 
 :video_x-nsv a skos:Concept ;
   :hasMediaType "video/x-nsv" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fideo Nullsoft"@cy ;
   skos:prefLabel "Nullsoft video faylı"@az ;
   skos:prefLabel "Nullsoft video"@en ;
@@ -5610,7 +5610,7 @@
 
 :video_x-real-video a skos:Concept ;
   :hasMediaType "video/x-real-video" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "Fideo RealVideo"@cy ;
   skos:prefLabel "RealVideo film"@no ;
   skos:prefLabel "RealVideo video faylı"@az ;
@@ -5629,7 +5629,7 @@
 
 :video_x-sgi-movie a skos:Concept ;
   :hasMediaType "video/x-sgi-movie" ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/media-type> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/media-type> ;
   skos:prefLabel "SGI video faylı"@az ;
   skos:prefLabel "SGI video"@en ;
   skos:prefLabel "SGI video"@nl ;
@@ -5646,7 +5646,7 @@
   skos:prefLabel "vidéo SGI"@fr ;
   skos:prefLabel "Βίντεο SGI"@el .
 
-<https://ontology.okp4.space/thesaurus/media-type> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/media-type> a skos:ConceptScheme ;
   rdfs:label "Media types Thesaurus"@en ;
   dct:description """
     The Media Types Thesaurus is a comprehensive list of Internet media types (originally called MIME types) that are commonly used and widely recognized.

--- a/src/thesaurus/topic.ttl
+++ b/src/thesaurus/topic.ttl
@@ -1,70 +1,70 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix : <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix : <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 :AgricultureFoodEnvironmentAndForestry a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Agriculture, alimentation, environnement et forêt"@fr ;
   skos:prefLabel "Agriculture, food, environment and forestry"@en ;
   skos:prefLabel "Landwirtschaft, Ernährung, Umwelt und Forstwirtschaft"@de .
 
 :BiologyGeologyAndChemistry a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Biologie, Geologie und Chemie"@de ;
   skos:prefLabel "Biologie, géologie et chimie"@fr ;
   skos:prefLabel "Biology, geology and chemistry"@en .
 
 :BusinessAndPurchase a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Business and purchase"@en ;
   skos:prefLabel "Commerce et achat"@fr ;
   skos:prefLabel "Geschäft und Einkauf"@de .
 
 :DeFiAndCrypto a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "DeFi and Crypto"@en ;
   skos:prefLabel "DeFi et Crypto"@fr ;
   skos:prefLabel "DeFi und Krypto"@de .
 
 :Energy a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Energie"@de ;
   skos:prefLabel "Energie"@fr ;
   skos:prefLabel "Energy"@en .
 
 :Healthcare a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Gesundheit"@de ;
   skos:prefLabel "Health"@en ;
   skos:prefLabel "Santé"@fr .
 
 :IndustryMobilityAndEngineering a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Industrie, Mobilität und Technik"@de ;
   skos:prefLabel "Industrie, mobilité et ingénierie"@fr ;
   skos:prefLabel "Industry, mobility and engineering"@en .
 
 :LogisticsRetailSupplyChainECommerce a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Logistics, retail, supply chain and eCommerce"@en ;
   skos:prefLabel "Logistik, Einzelhandel, Lieferkette und eCommerce"@de ;
   skos:prefLabel "Logistique, commerce, chaîne d'approvisionnement et eCommerce"@fr .
 
 :MarketingAndCustomerBehavior a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Marketing and Customer Behavior"@en ;
   skos:prefLabel "Marketing et comportement des consommateurs"@fr ;
   skos:prefLabel "Marketing und Kundenverhalten"@de .
 
 :Other a skos:Concept ;
-  skos:inScheme <https://ontology.okp4.space/thesaurus/topic> ;
+  skos:inScheme <https://w3id.org/okp4/ontology/thesaurus/topic> ;
   skos:prefLabel "Andere"@de ;
   skos:prefLabel "Autres"@fr ;
   skos:prefLabel "Other"@en .
 
-<https://ontology.okp4.space/thesaurus/topic> a skos:ConceptScheme ;
+<https://w3id.org/okp4/ontology/thesaurus/topic> a skos:ConceptScheme ;
   rdfs:label "Thema Thesaurus"@de ;
   rdfs:label "Thésaurus des thèmes"@fr ;
   rdfs:label "Topic Thesaurus"@en ;

--- a/test/dataset.ttl
+++ b/test/dataset.ttl
@@ -3,10 +3,10 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix tst: <https://ontology.okp4.space/test/> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix meta: <https://ontology.okp4.space/metadata/dataset/> .
-@prefix topic: <https://ontology.okp4.space/thesaurus/topic/> .
+@prefix tst: <https://w3id.org/okp4/ontology/test/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/dataset/> .
+@prefix topic: <https://w3id.org/okp4/ontology/thesaurus/topic/> .
 
 tst:AssertGeneralMetadatas a sh:NodeShape ;
   sh:targetClass meta:GeneralMetadata ;
@@ -24,5 +24,5 @@ tst:AssertGeneralMetadatas a sh:NodeShape ;
             topic:LogisticsRetailSupplyChainECommerce
             topic:MarketingAndCustomerBehavior
             topic:Other ) ; 
-    sh:message "meta:GeneralMetadata requires one core:hasTopic instance part of the <https://ontology.okp4.space/thesaurus/topic> thesaurus."@en ;
+    sh:message "meta:GeneralMetadata requires one core:hasTopic instance part of the <https://w3id.org/okp4/ontology/thesaurus/topic> thesaurus."@en ;
   ] .

--- a/test/governance.ttl
+++ b/test/governance.ttl
@@ -3,9 +3,9 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
-@prefix core: <https://ontology.okp4.space/core/> .
-@prefix meta: <https://ontology.okp4.space/metadata/governance/> .
-@prefix tst: <https://ontology.okp4.space/test/> .
+@prefix core: <https://w3id.org/okp4/ontology/core/> .
+@prefix meta: <https://w3id.org/okp4/ontology/metadata/governance/> .
+@prefix tst: <https://w3id.org/okp4/ontology/test/> .
 
 tst:AssertArticles a sh:NodeShape ;
   sh:targetClass meta:Article ;

--- a/test/vocab.ttl
+++ b/test/vocab.ttl
@@ -3,7 +3,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
-@prefix tst: <https://ontology.okp4.space/test/> .
+@prefix tst: <https://w3id.org/okp4/ontology/test/> .
 
 tst:AssertConceptSchemes a sh:NodeShape ;
   sh:property [


### PR DESCRIPTION
# Refactor/update uri scheme

- [x] I've read the last version of [CODE_OF_CONDUCT.md](https://github.com/okp4/.github/blob/main/CODE-OF-CONDUCT.md) and [CONTRIBUTING.md](https://github.com/okp4/.github/blob/main/CONTRIBUTING.md)

## Description

This PR aims at updating all references from ontology.okp4.space to w3id.org/okp4/ontology within the ontology. 
It is related to the first task of #215 

This change is aimed at:

- ensure persistent and stable URIs for our ontology.
- enhance the reliability and accessibility of our ontology.
- align with best practices in the semantic web community.

