### PR TITLE
feat: add service webpage property

### DIFF
--- a/src/schema/digital-service/credential-digital-service-description.ttl
+++ b/src/schema/digital-service/credential-digital-service-description.ttl
@@ -37,6 +37,14 @@
   schema:domainIncludes :DigitalServiceDescriptionCredential ;
   schema:rangeIncludes xsd:anyURI .
 
+:hasWebpage a rdf:Property ;
+  rdfs:label "has webpage"@en ;
+  rdfs:comment """
+  A public web page detailing the service, its pricing and any other information useful for the user of the service.
+  """@en ;
+  schema:domainIncludes :DigitalServiceDescriptionCredential ;
+  schema:rangeIncludes xsd:anyURI .
+
 :hasPublisher a rdf:Property ;
   rdfs:label "has publisher"@en ;
   rdfs:comment """

--- a/src/schema/digital-service/credential-digital-service-description.ttl
+++ b/src/schema/digital-service/credential-digital-service-description.ttl
@@ -37,14 +37,6 @@
   schema:domainIncludes :DigitalServiceDescriptionCredential ;
   schema:rangeIncludes xsd:anyURI .
 
-:hasWebpage a rdf:Property ;
-  rdfs:label "has webpage"@en ;
-  rdfs:comment """
-  A public web page detailing the service, its pricing and any other information useful for the user of the service.
-  """@en ;
-  schema:domainIncludes :DigitalServiceDescriptionCredential ;
-  schema:rangeIncludes xsd:anyURI .
-
 :hasPublisher a rdf:Property ;
   rdfs:label "has publisher"@en ;
   rdfs:comment """
@@ -69,5 +61,13 @@
   """@en ;
   schema:domainIncludes :DigitalServiceDescriptionCredential ;
   schema:rangeIncludes xsd:string .
+
+:hasWebpage a rdf:Property ;
+  rdfs:label "has webpage"@en ;
+  rdfs:comment """
+  A public web page detailing the service, its pricing and any other information useful for the user of the service.
+  """@en ;
+  schema:domainIncludes :DigitalServiceDescriptionCredential ;
+  schema:rangeIncludes xsd:anyURI .
 
 


### PR DESCRIPTION
# My pull request title

- [x] I've read the last version of [CODE_OF_CONDUCT.md](https://github.com/okp4/.github/blob/main/CODE-OF-CONDUCT.md) and [CONTRIBUTING.md](https://github.com/okp4/.github/blob/main/CONTRIBUTING.md)

## Description

This PR adds the property `hasWebpage` to the `credential digital service description`. 
It is linked to the issue #113 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new property `hasWebpage` to the digital service descriptions, enabling users to associate web pages with digital service credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->