### PR TITLE
ci(workflow): add workflow to update ontology docs

### DIFF
--- a/.github/workflows/notify-release.yml
+++ b/.github/workflows/notify-release.yml
@@ -12,11 +12,30 @@ jobs:
         uses: fjogeleit/http-request-action@v1
         with:
           url: ${{ secrets.OKP4_DISCORD_WEBHOOK }}
-          method: 'POST'
+          method: "POST"
           customHeaders: '{"Content-Type": "application/json"}'
           data: |-
             {
               "avatar_url": "https://avatars.githubusercontent.com/u/98603954?v=4",
               "username": "Bot Anik",
               "content": "🚨 A new version of @${{github.repository}} ${{ github.event.release.tag_name }} has been released! 🎉\n\n👉 Changelog: https://github.com/${{ github.repository }}/releases/tag/${{ github.event.release.tag_name }}\n👉 Official repo: https://github.com/${{ github.repository }}\n👉 Documentation: https://w3id.org/okp4/ontology"
+            }
+  update-docs:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Update ontology docs repository
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'https://api.github.com/repos/okp4/docs/actions/workflows/39152549/dispatches'
+          method: 'POST'
+          customHeaders: '{"Accept": "application/vnd.github+json", "Authorization": "Bearer ${{ secrets.OKP4_TOKEN }}"}'
+          data: |-
+            {
+              "ref": "main",
+              "inputs": {
+                "version": "${{ github.event.release.tag_name }}",
+                "repository": "${{github.repository}}",
+                "section": "ontology",
+                "docs_directory": "docs/*"
+              }
             }


### PR DESCRIPTION
Self explanatory.

Following #229, let's introduce a workflow for updating the generated documentation on the [docusaurus website](https://github.com/okp4/docs).

_NB_: this is the same recipe used in the [okp4d](https://github.com/okp4/okp4d) and [contracts](https://github.com/okp4/contracts) repositories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Implemented an automated step to update ontology documentation with release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->