### PR TITLE
Adopt a flatten representation for generated JSON-LD  schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ $(OBJ_ONTS_RDFXML): $(DST_ONT)/%.rdf.xml: $(DST_ONT)/%.ttl
 $(OBJ_SCHEMAS_JSONLD): $(DST_SCHEMA)/%.jsonld: $(DST_SCHEMA)/%.ttl
 	@echo "${COLOR_CYAN}🔨 building${COLOR_RESET} schema ${COLOR_GREEN}$@${COLOR_RESET}"
 	@mkdir -p -m $(PERMISSION_MODE) $(@D)
-	@${call CLI,jsonld,convert,$<,-o,$@,--indent,$(JSONLD_INDENT)}
+	@${call CLI,jsonld,convert,$<,-o,$@,--flatten,--indent,$(JSONLD_INDENT)}
 
 $(OBJ_THESAURI_JSONLD): $(DST_THESAURUS)/%.jsonld: $(DST_THESAURUS)/%.ttl
 	@echo "${COLOR_CYAN}🔨 building${COLOR_RESET} thesaurus ${COLOR_GREEN}$@${COLOR_RESET}"
@@ -227,7 +227,7 @@ $(BIN_OKP4_RDFXML): $(BIN_OKP4_NT)
 $(BIN_OKP4_JSONLD): $(BIN_OKP4_NT)
 	@echo "${COLOR_CYAN}📦 making${COLOR_RESET} ontology ${COLOR_GREEN}$@${COLOR_RESET}"
 	@touch $@
-	@${call CLI,jsonld,convert,$<,-o,$@,--indent,$(JSONLD_INDENT)}
+	@${call CLI,jsonld,convert,$<,-o,$@,--flatten,--indent,$(JSONLD_INDENT)}
 
 $(BIN_DOC_SCHEMAS): $(OBJ_ONTS_TTL) $(OBJ_EXAMPLES) $(shell find $(SRC_SCRIPT) -name "*.*") Makefile
 	@echo "${COLOR_CYAN}📝 generating ${COLOR_GREEN}schemas ${COLOR_RESET}documentation"

--- a/script/cli/cli.py
+++ b/script/cli/cli.py
@@ -82,14 +82,20 @@ def generate(input_path: os.PathLike[str], output_path: os.PathLike[str],
     default=None,
     help="The number of spaces to use for indentation.",
 )
-def convert(input_file: t.TextIO, output_file: t.TextIO, indent: t.Optional[int], format: t.Optional[str]) -> None:
+@click.option(
+    "--flatten",
+    "flatten",
+    is_flag=True,
+    help="Produces a flattened JSON-LD representation.",
+)
+def convert(input_file: t.TextIO, output_file: t.TextIO, flatten: bool, indent: t.Optional[int], format: t.Optional[str]) -> None:
     """Converts a schema to JSON-LD.
 
     If the output file is not specified, the JSON-LD will be printed to the console.
     You can specify the format of the input file, if it cannot be inferred from the file extension.
     """
     try:
-        convert_jsonld(input_file, output_file, indent, format)
+        convert_jsonld(input_file, output_file, flatten, indent, format)
     except Exception as e:
         raise click.UsageError(f"{e}")
 

--- a/script/cli/jsonld.py
+++ b/script/cli/jsonld.py
@@ -8,7 +8,7 @@ from rdflib.term import Node
 SCHEMA = Namespace("http://schema.org/")
 
 
-def convert_jsonld(input_file: t.TextIO, output_file: t.TextIO, indent: t.Optional[int] = None,
+def convert_jsonld(input_file: t.TextIO, output_file: t.TextIO, flatten: bool, indent: t.Optional[int] = None,
                    format: t.Optional[str] = None):
     """Converts a schema to JSON-LD."""
     context = empty_context()
@@ -30,7 +30,7 @@ def convert_jsonld(input_file: t.TextIO, output_file: t.TextIO, indent: t.Option
         is_a_type = (isinstance(range, term.Identifier)) and ((range == XSD.anyURI) or not range.startswith(str(XSD)))
 
         domains: list[Node | None] = list(g.objects(s, SCHEMA.domainIncludes))
-        if not domains:
+        if not domains or flatten:
             domains = [None]
 
         for domain in domains:


### PR DESCRIPTION
This PR enhances the build process by adding the flag `--flatten` to the CLI for generating a flattened `JSON-LD` representation, which is better suited for the [cognitarium smart contract](https://github.com/okp4/contracts/tree/main/contracts/okp4-cognitarium).

By default, this flag is enabled, ensuring that classes and properties are organized at the same hierarchical level. Previously, properties were nested under the class context to which they were associated (i.e., their *domain*).

**before**:
```json
{
  "@context": {
    "@protected": true,
    "id": "@id",
    "type": "@type",
    "DigitalResourceRightsCredential": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/DigitalResourceRightsCredential",
      "@context": {
        "@protected": true,
        "id": "@id",
        "type": "@type",
        "hasAuthor": {
          "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasAuthor",
          "@type": "@id"
        },
        "hasCreator": {
          "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasCreator",
          "@type": "@id"
        },
        "hasLicense": {
          "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasLicense",
          "@type": "@id"
        },
        "hasPublisher": {
          "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasPublisher",
          "@type": "@id"
        }
      }
    }
  }
}
```

**now**:
```json
{
  "@context": {
    "@protected": true,
    "id": "@id",
    "type": "@type",
    "DigitalResourceRightsCredential": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/DigitalResourceRightsCredential"
    },
    "hasAuthor": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasAuthor",
      "@type": "@id"
    },
    "hasCreator": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasCreator",
      "@type": "@id"
    },
    "hasLicense": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasLicense",
      "@type": "@id"
    },
    "hasPublisher": {
      "@id": "https://w3id.org/okp4/ontology/v2/schema/credential/digital-resource/rights/hasPublisher",
      "@type": "@id"
    }
  }
}
```

While this representation is simpler and seems to be more commonly used, it leads to a reduction in type strictness because the connection between a property and its associated class is no longer explicitly stated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added an option to produce flattened JSON-LD in the conversion commands, enhancing data handling and integration capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->