### PR TITLE
fix: typo

### DIFF
--- a/docs/schemas/credential-governance-text.md
+++ b/docs/schemas/credential-governance-text.md
@@ -27,7 +27,7 @@ Here are the namespaces used in this schema:
 
 ### Description
 
-Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a human-readable format.
+Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a "human-readable format".
 
 The Governance Text Credential applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
 
@@ -147,7 +147,7 @@ The title of a Governance Text.
 
 #### Description
 
-Governance Text provides descriptive information about a Governance text in a human-readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
+Governance Text provides descriptive information about a Governance text in a "human-readable format". It gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
 
 Governance Text is mostly valuable in decentralized applications and web3 interfaces where governance texts are utilized to describe and represent the rules that applies to resources, like Zone or Digital Resources. This enables users to more readily engage with the governance text, allowing them to gain a better understanding of how the text operates and the rules governing the relationship between all resources in a Zone within the Dataverse.
 

--- a/docs/schemas/credential-governance-text.md
+++ b/docs/schemas/credential-governance-text.md
@@ -29,7 +29,7 @@ Here are the namespaces used in this schema:
 
 Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a human-readable format.
 
-The Governance Text Credentaials applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
+The Governance Text Credential applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
 
 - Zone Rules: Rules establish the boundaries of a specific area in the Dataverse, termed a Zone, within which governance is enforced. Each Zone is governed by its unique set of Rules tailored to its particular function or purpose.
 - Resource Consent: Consents are agreements associated with the use of Resources within Zones. By resources, we mean Digital Resources (e.g. datasets) or Digital Services. It goes beyond simple approval and encompasses the permissions and restrictions on resource owners' access, usage, sharing, management and handling of their resources. It allows parties to define boundaries and establish terms for others to interact with their digital resources. It's a crucial aspect of governance, ensuring resources are used appropriately per the relevant parties' expressed will and intentions.
@@ -147,7 +147,7 @@ The title of a Governance Text.
 
 #### Description
 
-Governance Text provides descriptive information about a Governance text in a human readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
+Governance Text provides descriptive information about a Governance text in a human-readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
 
 Governance Text is mostly valuable in decentralized applications and web3 interfaces where governance texts are utilized to describe and represent the rules that applies to resources, like Zone or Digital Resources. This enables users to more readily engage with the governance text, allowing them to gain a better understanding of how the text operates and the rules governing the relationship between all resources in a Zone within the Dataverse.
 

--- a/docs/schemas/credential-zone-description.md
+++ b/docs/schemas/credential-zone-description.md
@@ -30,7 +30,7 @@ Here are the namespaces used in this schema:
 
 Zone Description credentials deliver an extensive overview of the essential information about a zone. This typically comprises details like the zone's title, description, and tags.
 
-The primary objective of this credentials is to provide a broad overview of the zone, facilitating users' comprehension of its purpose and potential use cases.
+The primary objective of these credentials is to provide a broad overview of the zone, facilitating users' comprehension of its purpose and potential use cases.
 
 ### Examples
 

--- a/src/schema/governance/credential-governance-text.ttl
+++ b/src/schema/governance/credential-governance-text.ttl
@@ -19,7 +19,7 @@
 :GovernanceText a rdfs:Class ;
   rdfs:label "Governance Text"@en ;
   rdfs:comment """
-  Governance Text provides descriptive information about a Governance text in a human-readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
+  Governance Text provides descriptive information about a Governance text in a "human-readable format". It gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
   
   Governance Text is mostly valuable in decentralized applications and web3 interfaces where governance texts are utilized to describe and represent the rules that applies to resources, like Zone or Digital Resources. This enables users to more readily engage with the governance text, allowing them to gain a better understanding of how the text operates and the rules governing the relationship between all resources in a Zone within the Dataverse.
 
@@ -29,7 +29,7 @@
 :GovernanceTextCredential a rdfs:Class ;
   rdfs:label "Governance Description Credential"@en ;
   rdfs:comment """
-  Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a human-readable format.
+  Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a "human-readable format".
 
   The Governance Text Credential applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
 

--- a/src/schema/governance/credential-governance-text.ttl
+++ b/src/schema/governance/credential-governance-text.ttl
@@ -19,7 +19,7 @@
 :GovernanceText a rdfs:Class ;
   rdfs:label "Governance Text"@en ;
   rdfs:comment """
-  Governance Text provides descriptive information about a Governance text in a human readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
+  Governance Text provides descriptive information about a Governance text in a human-readable format. It  gives a description in a hierarchical manner, organized into chapters, sections, and articles. This hierarchy helps to structure the governance text and makes it easier to navigate and comprehend.
   
   Governance Text is mostly valuable in decentralized applications and web3 interfaces where governance texts are utilized to describe and represent the rules that applies to resources, like Zone or Digital Resources. This enables users to more readily engage with the governance text, allowing them to gain a better understanding of how the text operates and the rules governing the relationship between all resources in a Zone within the Dataverse.
 
@@ -31,7 +31,7 @@
   rdfs:comment """
   Governance Text Credential is a type of Credential that attests to descriptive information about a governance text in a human-readable format.
 
-  The Governance Text Credentaials applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
+  The Governance Text Credential applies to all resources in the Dataverse for which rules must be followed. Such Governances are categorized into three main types as recognized by the [OKP4 protocol](https://okp4.network):
 
   - Zone Rules: Rules establish the boundaries of a specific area in the Dataverse, termed a Zone, within which governance is enforced. Each Zone is governed by its unique set of Rules tailored to its particular function or purpose.
   - Resource Consent: Consents are agreements associated with the use of Resources within Zones. By resources, we mean Digital Resources (e.g. datasets) or Digital Services. It goes beyond simple approval and encompasses the permissions and restrictions on resource owners' access, usage, sharing, management and handling of their resources. It allows parties to define boundaries and establish terms for others to interact with their digital resources. It's a crucial aspect of governance, ensuring resources are used appropriately per the relevant parties' expressed will and intentions.

--- a/src/schema/zone/credential-zone-description.ttl
+++ b/src/schema/zone/credential-zone-description.ttl
@@ -10,7 +10,7 @@
   rdfs:comment """
   Zone Description credentials deliver an extensive overview of the essential information about a zone. This typically comprises details like the zone's title, description, and tags.
   
-  The primary objective of this credentials is to provide a broad overview of the zone, facilitating users' comprehension of its purpose and potential use cases.
+  The primary objective of these credentials is to provide a broad overview of the zone, facilitating users' comprehension of its purpose and potential use cases.
   """@en .
 
 :hasDescription a rdf:Property ;


### PR DESCRIPTION
Everything in the title

Following #252 and #253


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Corrected typos and improved clarity in the descriptions of governance and zone credentials within the schema documentation.
- **Bug Fixes**
	- Fixed a typo in the "Governance Text Credential" description.
	- Corrected the pluralization of "credential" in the zone description to ensure consistency and clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->