### PR TITLE
Add `digital-resource-publication` credential

### DIFF
--- a/docs/schemas/credential-digital-resource-publication.md
+++ b/docs/schemas/credential-digital-resource-publication.md
@@ -1,0 +1,54 @@
+---
+sidebar_position: 2
+---
+[//]: # (This file is auto-generated. Please do not modify it yourself.)
+
+# Digital resource publication credential
+
+> **Name**: `credential-digital-resource-publication`
+>
+> **Namespace**: [https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/](https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/)
+
+## Namespaces
+
+Here are the namespaces used in this schema:
+
+- `rdf`: [http://www.w3.org/1999/02/22-rdf-syntax-ns#](http://www.w3.org/1999/02/22-rdf-syntax-ns#)
+- `rdfs`: [http://www.w3.org/2000/01/rdf-schema#](http://www.w3.org/2000/01/rdf-schema#)
+- `skos`: [http://www.w3.org/2004/02/skos/core#](http://www.w3.org/2004/02/skos/core#)
+- `dcterms`: [http://purl.org/dc/terms/](http://purl.org/dc/terms/)
+- `schema`: [http://schema.org/](http://schema.org/)
+- `xsd`: [http://www.w3.org/2001/XMLSchema#](http://www.w3.org/2001/XMLSchema#)
+- `credential-digital-resource-publication`: [https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/](https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/)
+
+## Verifiable Credential
+
+> **IRI**: [credential-digital-resource-publication:DigitalResourcePublicationCredential](https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/DigitalResourcePublicationCredential)
+
+### Description
+
+Digital Resource Publication Credentials confirm the publication and availability of a digital asset through a digital service.
+
+### Properties
+
+#### Has identifier
+>
+> **IRI**: [credential-digital-resource-publication:hasIdentifier](https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/hasIdentifier)
+>
+> **Range**:&nbsp;[xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+The URI that identifies the digital asset within the scope of a digital service that provides access to it.
+
+#### Served by
+>
+> **IRI**: [credential-digital-resource-publication:servedBy](https://w3id.org/okp4/ontology/v3/schema/credential/digital-resource/publication/servedBy)
+>
+> **Range**:&nbsp;[xsd:anyURI](http://www.w3.org/2001/XMLSchema#anyURI)
+
+The digital service that makes the resource accessible.
+
+This information is vital for enabling interactions with the resource. In this context, digital services act as conduits for distributing
+and exchanging digital resources across various networks. These services manifest in multiple forms, including network communication
+protocols such as RESTful APIs and gRPC services. They play a crucial role in connecting resources to orchestrator services, which
+leverage these resources for a range of applications. For instance, a digital resource might be a dataset accessible via a RESTful API,
+utilized by an orchestrator service to train a machine learning model.

--- a/docs/schemas/credential-digital-resource-rights.md
+++ b/docs/schemas/credential-digital-resource-rights.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 3
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/schemas/credential-digital-service-description.md
+++ b/docs/schemas/credential-digital-service-description.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 4
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/schemas/credential-digital-service-execution-order.md
+++ b/docs/schemas/credential-digital-service-execution-order.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 5
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/schemas/credential-digital-service-execution-result.md
+++ b/docs/schemas/credential-digital-service-execution-result.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 6
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/schemas/credential-governance-text.md
+++ b/docs/schemas/credential-governance-text.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/docs/schemas/credential-zone-description.md
+++ b/docs/schemas/credential-zone-description.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 8
 ---
 [//]: # (This file is auto-generated. Please do not modify it yourself.)
 

--- a/src/schema/digital-resource/credential-digital-resource-publication.ttl
+++ b/src/schema/digital-resource/credential-digital-resource-publication.ttl
@@ -1,0 +1,35 @@
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix : <https://w3id.org/okp4/ontology/v$major/schema/credential/digital-resource/publication/> .
+@prefix schema: <http://schema.org/> .
+
+:DigitalResourcePublicationCredential a rdfs:Class ;
+  rdfs:label "Digital Resource Publication Credential"@en ;
+  rdfs:comment """
+  Digital Resource Publication Credentials confirm the publication and availability of a digital asset through a digital service.
+  """@en .
+
+:hasIdentifier a rdf:Property ;
+  rdfs:label "has identifier"@en ;
+  rdfs:comment """
+  The URI that identifies the digital asset within the scope of a digital service that provides access to it.
+  """@en ;
+  schema:domainIncludes :DigitalResourcePublicationCredential ;
+  schema:rangeIncludes xsd:anyURI .
+
+:servedBy a rdf:Property ;
+  rdfs:label "served by"@en ;
+  rdfs:comment """
+  The digital service that makes the resource accessible.
+
+  This information is vital for enabling interactions with the resource. In this context, digital services act as conduits for distributing 
+  and exchanging digital resources across various networks. These services manifest in multiple forms, including network communication 
+  protocols such as RESTful APIs and gRPC services. They play a crucial role in connecting resources to orchestrator services, which 
+  leverage these resources for a range of applications. For instance, a digital resource might be a dataset accessible via a RESTful API,
+  utilized by an orchestrator service to train a machine learning model.
+  """@en ;
+  schema:domainIncludes :DigitalResourcePublicationCredential ;
+  schema:rangeIncludes xsd:anyURI .
+
+


### PR DESCRIPTION
Add the `digital-resource-publication` credential to create a connection between a digital asset and the digital service that provides access to it.

Notes:
- This is a revival of the `hasIdentifier` and `servedBy` properties, which were previously improperly assigned to `credential-digital-resource-declaration` and were removed in #234. They are reintroduced here for their true purpose: to define the publication of a digital resource through a digital service. This is the simplest way to express a one-to-one link, but more sophisticated mechanisms may be introduced in the future.
- The description of the properties is imperfect but captures their primary function. As we continue our experiments, refinements will be made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Introduced a schema for Digital Resource Publication Credentials, outlining the verification process for the publication and availability of digital assets.
	- Updated the sidebar position for various credential documentation to improve navigation and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->