### PR TITLE
refactor(schema)!: remove SubSection hierarchy

### DIFF
--- a/docs/schemas/credential-governance-text.md
+++ b/docs/schemas/credential-governance-text.md
@@ -47,7 +47,7 @@ The Governance Text that governs a Resource in the Dataverse.
 
 ## Classes
 
-This schema defines 6 classes.
+This schema defines 5 classes.
 
 ### Article
 >
@@ -203,53 +203,7 @@ The title of a Governance Text.
 
 #### Description
 
-A section of a governance text, which groups related subsections together.
-
-#### Properties
-
-##### Has content
->
-> **IRI**: [credential-governance-text:hasContent](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/hasContent)
->
-> **Range**:&nbsp;[xsd:string](http://www.w3.org/2001/XMLSchema#string)
-
-The content of a Governance Text.
-
-##### Has ordinal number
->
-> **IRI**: [credential-governance-text:hasOrdinalNumber](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/hasOrdinalNumber)
->
-> **Range**:&nbsp;[xsd:integer](http://www.w3.org/2001/XMLSchema#integer)
-
-This property associates a governance component with its sequential number.
-
-It assigns an ordinal number as a value, starting from 1, ensuring sequential continuity within a specific domain instance.
-
-The format for this numbering may vary based on the domain, for instance, employing Roman numerals for section numbering.
-
-##### Has subsection
->
-> **IRI**: [credential-governance-text:hasSubSection](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/hasSubSection)
->
-> **Range**:&nbsp;[credential-governance-text:SubSection](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/SubSection)
-
-The subsection of a Governance Text.
-
-##### Has title
->
-> **IRI**: [credential-governance-text:hasTitle](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/hasTitle)
->
-> **Range**:&nbsp;[xsd:string](http://www.w3.org/2001/XMLSchema#string)
-
-The title of a Governance Text.
-
-### Subsection
->
-> **IRI**: [credential-governance-text:SubSection](https://w3id.org/okp4/ontology/v3/schema/credential/governance/text/SubSection)
-
-#### Description
-
-A subsection of a governance text, which groups related articles together within a section.
+A section of a governance text, which groups related articles together.
 
 #### Properties
 

--- a/src/schema/governance/credential-governance-text.ttl
+++ b/src/schema/governance/credential-governance-text.ttl
@@ -47,13 +47,7 @@
 :Section a rdfs:Class ;
   rdfs:label "Section"@en ;
   rdfs:comment """
-  A section of a governance text, which groups related subsections together.
-  """@en .
-
-:SubSection a rdfs:Class ;
-  rdfs:label "Subsection"@en ;
-  rdfs:comment """
-  A subsection of a governance text, which groups related articles together within a section.
+  A section of a governance text, which groups related articles together.
   """@en .
 
 :fromGovernance a rdf:Property ;
@@ -69,7 +63,7 @@
   rdfs:comment """
   The article of a Governance Text.
   """@en ;
-  schema:domainIncludes :SubSection ;
+  schema:domainIncludes :Section ;
   schema:rangeIncludes :Article .
 
 :hasChapter a rdf:Property ;
@@ -89,7 +83,6 @@
   schema:domainIncludes :Chapter ;
   schema:domainIncludes :Paragraph ;
   schema:domainIncludes :Section ;
-  schema:domainIncludes :SubSection ;
   schema:rangeIncludes xsd:string .
 
 :hasOrdinalNumber a rdf:Property ;
@@ -104,7 +97,6 @@
   schema:domainIncludes :Article ;
   schema:domainIncludes :Chapter ;
   schema:domainIncludes :Section ;
-  schema:domainIncludes :SubSection ;
   schema:rangeIncludes xsd:integer .
 
 :hasParagraph a rdf:Property ;
@@ -123,14 +115,6 @@
   schema:domainIncludes :Chapter ;
   schema:rangeIncludes :Section .
 
-:hasSubSection a rdf:Property ;
-  rdfs:label "has subsection"@en ;
-  rdfs:comment """
-  The subsection of a Governance Text.
-  """@en ;
-  schema:domainIncludes :Section ;
-  schema:rangeIncludes :SubSection .
-
 :hasTitle a rdf:Property ;
   rdfs:label "has title"@en ;
   rdfs:comment """
@@ -140,7 +124,6 @@
   schema:domainIncludes :Chapter ;
   schema:domainIncludes :Paragraph ;
   schema:domainIncludes :Section ;
-  schema:domainIncludes :SubSection ;
   schema:rangeIncludes xsd:string .
 
 :isGovernedBy a rdf:Property ;


### PR DESCRIPTION
## Purpose

This PR removes the intermediate hierarchical level, `SubSection`, between the `Section` and the `Article`. Initially, the design intended for governance descriptions to have only one `Chapter` at the top hierarchical level, necessitating an additional level to describe the various governance hierarchies. This is no longer the case. Descriptions now anticipate as many top-level `Chapters` as necessary to categorize the major governance themes, rendering the intermediate `SubSection` level unnecessary.

## UI relation

The following picture describes the relation of the different elements of the governance description VC with the elements presented in the UI (a little dated, but it gives a good idea).

<img width="1186" alt="image" src="https://github.com/okp4/ontology/assets/9574336/e49350f0-c9c7-4e26-91e5-c99bc506d368">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated governance text structure, simplifying the classification by removing `SubSection` and enhancing the `Section` to group articles directly. Adjustments made to properties for better alignment with the new structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->